### PR TITLE
feat(kpgs): encode orchestration state math as governed heuristics

### DIFF
--- a/governance/orchestration-state-math/README.md
+++ b/governance/orchestration-state-math/README.md
@@ -1,0 +1,141 @@
+# KPGS Orchestration State Math
+
+Status: **POC / executable governance heuristic**
+
+This package converts recurring equations from KPGS design conversations into a small, testable runtime surface. The equations are intentionally treated as **governance heuristics**, not scientific measurements of a person and not claims about inaccessible model internals.
+
+## Why this belongs in Introduction-to-MCP
+
+`Introduction-to-MCP` already contains the CCP, PKA, POC-vs-FOC, APU vector, stateless-renter consistency, and governance primitives. The orchestration equations govern how those components decide whether to infer, execute, clarify, confirm, or hold. Duplicating the math into every downstream repo would create governance drift.
+
+Canonical implementation:
+
+- `kopano-core/kopano/orchestration_state_math.py`
+- `tests/test_orchestration_state_math.py`
+
+Downstream repositories should consume or port from this source with a pinned receipt rather than silently inventing divergent weights or thresholds.
+
+## Equations encoded
+
+### 1. Response pressure
+
+Conversation shorthand:
+
+`response ∝ learned_patterns + context + instruction_hierarchy + alignment + prompt_salience`
+
+Runtime implementation: `ResponsePressure.score()`.
+
+All values are caller-provided proxies in `[0,1]`. The runtime does not inspect hidden transformer activations.
+
+### 2. Orchestration is larger than prompting
+
+`orchestration = identity + state + history + permissions + feedback + tools + uncertainty_control + initiative`
+
+Runtime implementation: `OrchestrationState.capacity()`.
+
+This is a state-vector heuristic for sustained behavior over time, not a single-prompt score.
+
+### 3. Meaning is contextual
+
+`meaning_received = f(words, tone, timing, status, audience, history, delivery)`
+
+Runtime implementation: `MeaningSignal.received()`.
+
+A tone-sensitive preset is provided because identical words can produce materially different interpersonal effects through tone and delivery. The preset is explicit and replaceable; callers must not treat its weights as universal psychological truth.
+
+### 4. Knowing is not understanding
+
+`K(x) = stored / available representation of x`
+
+`U(x,c) = contextual interpretation of x under context c`
+
+Runtime implementation: `KnowledgeUnderstanding`.
+
+`understanding = interpretation_accuracy × context_fit`
+
+`overlap = min(knowledge, understanding)`
+
+This preserves the distinction between possessing information and interpreting it correctly in context.
+
+### 5. Reported resolution is not verified resolution
+
+`reported_resolution != verified_resolution`
+
+Runtime implementation: `ResolutionState`.
+
+Residual distress, anger, and uncertainty are combined into `residual_load`; `experienced_resolution = 1 - residual_load`. A large positive mismatch means the explicit declaration of closure is ahead of the residual-state estimate.
+
+This should only be used when those residual signals are actually available. It must never be used to overrule a person by pretending the runtime knows their internal state better than they do.
+
+### 6. Earned autonomy
+
+`A(t+1) = clamp(A(t) + gain×validated_executions - penalty×failed_executions)`
+
+Runtime implementation: `AutonomyState.update()`.
+
+The purpose is to reduce repeated micromanagement after validated execution while making failures decrease autonomy instead of being ignored.
+
+### 7. Governed state transitions
+
+The runtime should autonomously execute when:
+
+- the objective is sufficiently clear;
+- evidence is sufficient;
+- permission is present;
+- ambiguity is below threshold;
+- the action is not high-risk or hard to reverse without confirmation.
+
+Runtime implementation: `GovernedTransition.decide()` returning one of:
+
+- `EXECUTE`
+- `CLARIFY`
+- `CONFIRM`
+- `HOLD`
+
+This encodes the preferred operating pattern:
+
+`Observe -> Recall -> Infer -> Execute -> Validate`
+
+with clarification or confirmation as **governed exceptions**, not a default dependency on repeated user instruction.
+
+### 8. Conceptual convergence can include both parties
+
+`converged_target = (user_target×user_weight + agent_target×agent_weight) / total_weight`
+
+Runtime implementation: `converge_targets()`.
+
+Both target vectors must expose identical dimensions; missing dimensions fail closed rather than being guessed. Optional invariant bounds constrain the result.
+
+The function does **not** imply equal authority. Governance determines the weights and invariant bounds.
+
+### 9. Deterministic receipts
+
+`receipt()` hashes the canonical JSON payload with SHA-256 and attaches the constraint:
+
+`HEURISTIC_NOT_HIDDEN_STATE_OR_PSYCHOLOGICAL_GROUND_TRUTH`
+
+This makes each calculation reproducible and auditable.
+
+## POC vs FOC boundary
+
+POC requires:
+
+1. deterministic calculations;
+2. closed-domain validation;
+3. tests for autonomy increase/decrease;
+4. fail-closed behavior on invalid inputs;
+5. explicit confirmation for high-risk / hard-to-reverse transitions;
+6. deterministic receipts.
+
+FOC occurs if the runtime:
+
+- claims to read hidden model states;
+- claims to know a human internal state from these numbers;
+- silently changes weights or thresholds;
+- interprets a heuristic score as scientific truth;
+- uses convergence to erase authority boundaries;
+- treats autonomy as permission to bypass evidence or confirmation gates.
+
+## Downstream integration rule
+
+Do not copy this module blindly into `kopano-sovereign-hub`, RIVM, Cars4Mars, or other application repositories. First establish which runtime consumes the decision surface, then pin the canonical implementation or port it with a receipt and parity tests.

--- a/kopano-core/kopano/orchestration_state_math.py
+++ b/kopano-core/kopano/orchestration_state_math.py
@@ -1,0 +1,327 @@
+"""Governed orchestration-state heuristics for KPGS.
+
+These functions turn recurring conversational design equations into executable,
+validated heuristics. They are *not* claims about hidden model activations,
+psychological ground truth, or objective human-state measurement. Callers must
+supply observable/proxy scores in the closed interval [0, 1].
+
+Core invariants encoded here:
+- orchestration is more than prompting;
+- reported resolution is not automatically verified resolution;
+- meaning depends on context, tone, timing, audience, and delivery;
+- autonomy may increase after validated execution and decrease after failure;
+- conceptual convergence may include both user and agent targets;
+- autonomy stops at genuine ambiguity, insufficient evidence/authority, or
+  high-risk / hard-to-reverse actions without confirmation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from enum import Enum
+import hashlib
+import json
+import math
+from typing import Mapping
+
+
+class ValidationError(ValueError):
+    """Raised when a heuristic input violates its declared domain."""
+
+
+class TransitionDecision(str, Enum):
+    EXECUTE = "EXECUTE"
+    CLARIFY = "CLARIFY"
+    CONFIRM = "CONFIRM"
+    HOLD = "HOLD"
+
+
+def _ratio(name: str, value: float) -> float:
+    value = float(value)
+    if not math.isfinite(value) or value < 0.0 or value > 1.0:
+        raise ValidationError(f"{name} must be a finite ratio in [0, 1]; got {value!r}")
+    return value
+
+
+def _positive(name: str, value: float) -> float:
+    value = float(value)
+    if not math.isfinite(value) or value <= 0.0:
+        raise ValidationError(f"{name} must be finite and > 0; got {value!r}")
+    return value
+
+
+def weighted_mean(values: Mapping[str, float], weights: Mapping[str, float] | None = None) -> float:
+    """Return a normalized weighted mean for named [0,1] signals."""
+    if not values:
+        raise ValidationError("values cannot be empty")
+
+    normalized = {name: _ratio(name, value) for name, value in values.items()}
+    if weights is None:
+        weights = {name: 1.0 for name in normalized}
+
+    if set(weights) != set(normalized):
+        missing = set(normalized) - set(weights)
+        extra = set(weights) - set(normalized)
+        raise ValidationError(f"weights must match values exactly; missing={sorted(missing)} extra={sorted(extra)}")
+
+    checked_weights = {name: _positive(f"weight:{name}", weight) for name, weight in weights.items()}
+    denominator = sum(checked_weights.values())
+    return sum(normalized[name] * checked_weights[name] for name in normalized) / denominator
+
+
+@dataclass(frozen=True)
+class ResponsePressure:
+    """External proxy for competing response-selection pressures.
+
+    The equation mirrors the conversational shorthand:
+      response ∝ learned patterns + context + hierarchy + alignment + salience
+
+    These are caller-supplied proxies; this class cannot inspect model internals.
+    """
+
+    learned_patterns: float
+    context: float
+    instruction_hierarchy: float
+    alignment: float
+    prompt_salience: float
+
+    def score(self, weights: Mapping[str, float] | None = None) -> float:
+        return weighted_mean(asdict(self), weights)
+
+
+@dataclass(frozen=True)
+class OrchestrationState:
+    """State vector for orchestration beyond a single prompt."""
+
+    identity: float
+    state: float
+    history: float
+    permissions: float
+    feedback: float
+    tools: float
+    uncertainty_control: float
+    initiative: float
+
+    def capacity(self, weights: Mapping[str, float] | None = None) -> float:
+        """Heuristic capacity for sustained governed behavior over time."""
+        return weighted_mean(asdict(self), weights)
+
+
+TONE_SENSITIVE_MEANING_WEIGHTS: dict[str, float] = {
+    "words": 1.0,
+    "tone": 2.0,
+    "timing": 1.0,
+    "status": 1.0,
+    "audience": 1.25,
+    "history": 1.25,
+    "delivery": 1.5,
+}
+
+
+@dataclass(frozen=True)
+class MeaningSignal:
+    """Contextual communication signal.
+
+    meaning_received = f(words, tone, timing, status, audience, history, delivery)
+    """
+
+    words: float
+    tone: float
+    timing: float
+    status: float
+    audience: float
+    history: float
+    delivery: float
+
+    def received(self, weights: Mapping[str, float] | None = None) -> float:
+        return weighted_mean(asdict(self), weights)
+
+    def tone_sensitive(self) -> float:
+        return self.received(TONE_SENSITIVE_MEANING_WEIGHTS)
+
+
+@dataclass(frozen=True)
+class KnowledgeUnderstanding:
+    """Separate possession of information from contextual interpretation."""
+
+    knowledge: float
+    interpretation_accuracy: float
+    context_fit: float
+
+    def __post_init__(self) -> None:
+        _ratio("knowledge", self.knowledge)
+        _ratio("interpretation_accuracy", self.interpretation_accuracy)
+        _ratio("context_fit", self.context_fit)
+
+    @property
+    def understanding(self) -> float:
+        # U(x,c): interpretation is only as useful as its contextual fit.
+        return self.interpretation_accuracy * self.context_fit
+
+    @property
+    def overlap(self) -> float:
+        # K ∩ U, bounded by the weaker dimension.
+        return min(self.knowledge, self.understanding)
+
+
+@dataclass(frozen=True)
+class ResolutionState:
+    """Distinguish reported closure from residual state."""
+
+    reported_resolution: float
+    residual_distress: float
+    residual_anger: float
+    residual_uncertainty: float
+
+    def __post_init__(self) -> None:
+        for name, value in asdict(self).items():
+            _ratio(name, value)
+
+    @property
+    def residual_load(self) -> float:
+        return weighted_mean(
+            {
+                "distress": self.residual_distress,
+                "anger": self.residual_anger,
+                "uncertainty": self.residual_uncertainty,
+            }
+        )
+
+    @property
+    def experienced_resolution(self) -> float:
+        return 1.0 - self.residual_load
+
+    @property
+    def mismatch(self) -> float:
+        """Positive when stated resolution exceeds the residual-state estimate."""
+        return max(0.0, self.reported_resolution - self.experienced_resolution)
+
+    def verified(self, *, minimum_resolution: float = 0.8, tolerance: float = 0.2) -> bool:
+        _ratio("minimum_resolution", minimum_resolution)
+        _ratio("tolerance", tolerance)
+        return self.reported_resolution >= minimum_resolution and self.mismatch <= tolerance
+
+
+@dataclass(frozen=True)
+class AutonomyState:
+    """Earned-autonomy update rule.
+
+    A(t+1) = clamp(A(t) + gain*validated - penalty*failed)
+    """
+
+    autonomy: float
+
+    def __post_init__(self) -> None:
+        _ratio("autonomy", self.autonomy)
+
+    def update(
+        self,
+        *,
+        validated_executions: int = 0,
+        failed_executions: int = 0,
+        gain: float = 0.03,
+        penalty: float = 0.08,
+    ) -> "AutonomyState":
+        if validated_executions < 0 or failed_executions < 0:
+            raise ValidationError("execution counts cannot be negative")
+        if gain < 0 or penalty < 0:
+            raise ValidationError("gain and penalty cannot be negative")
+        next_value = self.autonomy + gain * validated_executions - penalty * failed_executions
+        return AutonomyState(min(1.0, max(0.0, next_value)))
+
+
+@dataclass(frozen=True)
+class GovernedTransition:
+    """Decide whether the runtime should execute autonomously or stop."""
+
+    objective_fit: float
+    evidence: float
+    permission: float
+    ambiguity: float
+    risk: float
+    irreversibility: float
+    explicit_confirmation: bool = False
+
+    def __post_init__(self) -> None:
+        for name in ("objective_fit", "evidence", "permission", "ambiguity", "risk", "irreversibility"):
+            _ratio(name, getattr(self, name))
+
+    def decide(
+        self,
+        *,
+        permission_floor: float = 0.8,
+        evidence_floor: float = 0.6,
+        objective_floor: float = 0.6,
+        ambiguity_ceiling: float = 0.4,
+        confirmation_risk: float = 0.7,
+        confirmation_irreversibility: float = 0.7,
+    ) -> TransitionDecision:
+        for name, value in {
+            "permission_floor": permission_floor,
+            "evidence_floor": evidence_floor,
+            "objective_floor": objective_floor,
+            "ambiguity_ceiling": ambiguity_ceiling,
+            "confirmation_risk": confirmation_risk,
+            "confirmation_irreversibility": confirmation_irreversibility,
+        }.items():
+            _ratio(name, value)
+
+        if self.permission < permission_floor or self.objective_fit < objective_floor:
+            return TransitionDecision.HOLD
+        if self.evidence < evidence_floor:
+            return TransitionDecision.HOLD
+        if self.ambiguity > ambiguity_ceiling:
+            return TransitionDecision.CLARIFY
+        if (
+            self.risk >= confirmation_risk
+            or self.irreversibility >= confirmation_irreversibility
+        ) and not self.explicit_confirmation:
+            return TransitionDecision.CONFIRM
+        return TransitionDecision.EXECUTE
+
+
+def converge_targets(
+    user_target: Mapping[str, float],
+    agent_target: Mapping[str, float],
+    *,
+    user_weight: float = 0.5,
+    agent_weight: float = 0.5,
+    invariant_bounds: Mapping[str, tuple[float, float]] | None = None,
+) -> dict[str, float]:
+    """CCP-style conceptual convergence across user and agent target vectors.
+
+    Missing dimensions are rejected rather than guessed. Optional invariant
+    bounds clamp the converged value to a governed range.
+    """
+    if set(user_target) != set(agent_target):
+        raise ValidationError("user_target and agent_target must have identical dimensions")
+    user_weight = _positive("user_weight", user_weight)
+    agent_weight = _positive("agent_weight", agent_weight)
+
+    result: dict[str, float] = {}
+    for key in user_target:
+        u = _ratio(f"user_target:{key}", user_target[key])
+        a = _ratio(f"agent_target:{key}", agent_target[key])
+        value = (u * user_weight + a * agent_weight) / (user_weight + agent_weight)
+
+        if invariant_bounds and key in invariant_bounds:
+            lower, upper = invariant_bounds[key]
+            lower = _ratio(f"bound:{key}:lower", lower)
+            upper = _ratio(f"bound:{key}:upper", upper)
+            if lower > upper:
+                raise ValidationError(f"invalid invariant bounds for {key}: lower > upper")
+            value = min(upper, max(lower, value))
+        result[key] = value
+    return result
+
+
+def receipt(payload: Mapping[str, object]) -> dict[str, object]:
+    """Create a deterministic evidence receipt for a heuristic evaluation."""
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    return {
+        "schema": "kpgs.orchestration-state-math.v1",
+        "sha256": digest,
+        "payload": dict(payload),
+        "constraint": "HEURISTIC_NOT_HIDDEN_STATE_OR_PSYCHOLOGICAL_GROUND_TRUTH",
+    }

--- a/tests/test_orchestration_state_math.py
+++ b/tests/test_orchestration_state_math.py
@@ -1,0 +1,140 @@
+import importlib.util
+from pathlib import Path
+import sys
+import unittest
+
+MODULE_PATH = Path(__file__).parents[1] / "kopano-core" / "kopano" / "orchestration_state_math.py"
+spec = importlib.util.spec_from_file_location("orchestration_state_math", MODULE_PATH)
+mod = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+sys.modules[spec.name] = mod
+spec.loader.exec_module(mod)
+
+
+class OrchestrationStateMathTests(unittest.TestCase):
+    def test_response_pressure_is_bounded(self):
+        signal = mod.ResponsePressure(0.9, 0.8, 1.0, 0.95, 0.7)
+        self.assertGreaterEqual(signal.score(), 0.0)
+        self.assertLessEqual(signal.score(), 1.0)
+
+    def test_meaning_can_weight_tone_and_delivery_more_than_words(self):
+        signal = mod.MeaningSignal(
+            words=0.2,
+            tone=1.0,
+            timing=0.5,
+            status=0.5,
+            audience=0.8,
+            history=0.7,
+            delivery=1.0,
+        )
+        self.assertGreater(signal.tone_sensitive(), signal.received())
+
+    def test_knowing_and_understanding_are_separate_dimensions(self):
+        state = mod.KnowledgeUnderstanding(
+            knowledge=0.95,
+            interpretation_accuracy=0.6,
+            context_fit=0.5,
+        )
+        self.assertEqual(state.knowledge, 0.95)
+        self.assertAlmostEqual(state.understanding, 0.3)
+        self.assertAlmostEqual(state.overlap, 0.3)
+
+    def test_reported_resolution_is_not_automatically_verified(self):
+        state = mod.ResolutionState(
+            reported_resolution=0.95,
+            residual_distress=0.8,
+            residual_anger=0.7,
+            residual_uncertainty=0.6,
+        )
+        self.assertGreater(state.mismatch, 0.5)
+        self.assertFalse(state.verified())
+
+    def test_low_residual_load_can_verify_reported_resolution(self):
+        state = mod.ResolutionState(
+            reported_resolution=0.9,
+            residual_distress=0.05,
+            residual_anger=0.1,
+            residual_uncertainty=0.05,
+        )
+        self.assertTrue(state.verified())
+
+    def test_autonomy_is_earned_and_reduced_by_failures(self):
+        start = mod.AutonomyState(0.5)
+        earned = start.update(validated_executions=4)
+        corrected = earned.update(failed_executions=1)
+        self.assertGreater(earned.autonomy, start.autonomy)
+        self.assertLess(corrected.autonomy, earned.autonomy)
+
+    def test_governed_transition_executes_when_safe_and_clear(self):
+        transition = mod.GovernedTransition(
+            objective_fit=0.95,
+            evidence=0.9,
+            permission=1.0,
+            ambiguity=0.1,
+            risk=0.2,
+            irreversibility=0.2,
+        )
+        self.assertEqual(transition.decide(), mod.TransitionDecision.EXECUTE)
+
+    def test_governed_transition_clarifies_real_ambiguity(self):
+        transition = mod.GovernedTransition(
+            objective_fit=0.9,
+            evidence=0.9,
+            permission=1.0,
+            ambiguity=0.8,
+            risk=0.1,
+            irreversibility=0.1,
+        )
+        self.assertEqual(transition.decide(), mod.TransitionDecision.CLARIFY)
+
+    def test_governed_transition_requires_confirmation_for_irreversible_action(self):
+        transition = mod.GovernedTransition(
+            objective_fit=0.9,
+            evidence=0.9,
+            permission=1.0,
+            ambiguity=0.1,
+            risk=0.4,
+            irreversibility=0.9,
+        )
+        self.assertEqual(transition.decide(), mod.TransitionDecision.CONFIRM)
+        confirmed = mod.GovernedTransition(
+            objective_fit=0.9,
+            evidence=0.9,
+            permission=1.0,
+            ambiguity=0.1,
+            risk=0.4,
+            irreversibility=0.9,
+            explicit_confirmation=True,
+        )
+        self.assertEqual(confirmed.decide(), mod.TransitionDecision.EXECUTE)
+
+    def test_ccp_convergence_includes_both_targets(self):
+        result = mod.converge_targets(
+            {"execution": 1.0, "reflection": 0.2},
+            {"execution": 0.6, "reflection": 0.8},
+            user_weight=0.5,
+            agent_weight=0.5,
+        )
+        self.assertAlmostEqual(result["execution"], 0.8)
+        self.assertAlmostEqual(result["reflection"], 0.5)
+
+    def test_convergence_respects_invariant_bounds(self):
+        result = mod.converge_targets(
+            {"risk": 0.9},
+            {"risk": 0.8},
+            invariant_bounds={"risk": (0.0, 0.4)},
+        )
+        self.assertEqual(result["risk"], 0.4)
+
+    def test_receipt_is_deterministic(self):
+        first = mod.receipt({"a": 1, "b": 2})
+        second = mod.receipt({"b": 2, "a": 1})
+        self.assertEqual(first["sha256"], second["sha256"])
+
+    def test_invalid_ratio_fails_closed(self):
+        with self.assertRaises(mod.ValidationError):
+            mod.ResponsePressure(1.2, 0.8, 1.0, 0.9, 0.7).score()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What this does

Turns recurring KPGS equations from our orchestration discussions into executable, validated heuristics instead of leaving them as chat-only notation.

### Added
- `kopano-core/kopano/orchestration_state_math.py`
  - response-pressure proxy
  - orchestration state vector
  - tone/context-sensitive meaning function
  - knowledge vs understanding separation
  - reported vs residual resolution check
  - earned-autonomy update rule
  - governed EXECUTE / CLARIFY / CONFIRM / HOLD transitions
  - user+agent conceptual convergence with invariant bounds
  - deterministic SHA-256 receipts
- `tests/test_orchestration_state_math.py`
- `governance/orchestration-state-math/README.md`

## Governance boundary

The implementation explicitly labels these values as caller-supplied governance heuristics. It does **not** claim access to hidden transformer activations or objective psychological ground truth.

## Repo placement decision

This belongs canonically in `Introduction-to-MCP` because CCP/PKA/POC-vs-FOC/APU/stateless-renter governance already lives here. I did not duplicate the implementation into `kopano-sovereign-hub`; downstream runtimes should consume or port it with pinned receipts/parity tests to avoid drift.

## POC intent

The operating rule encoded is:

`Observe -> Recall -> Infer -> Execute -> Validate`

Clarification/confirmation becomes a governed exception for real ambiguity, insufficient authority/evidence, or high-risk/hard-to-reverse actions—not the default response to an already-established objective.