### PR TITLE
[POC] KPGS Human Choice Authorship Membrane — RIVM × CDP × CCP

### DIFF
--- a/governance/kpgs-vnext/agent-governance/specs/human-choice-authorship-poc.json
+++ b/governance/kpgs-vnext/agent-governance/specs/human-choice-authorship-poc.json
@@ -1,0 +1,130 @@
+{
+  "spec_id": "kpgs-human-choice-authorship-poc-v0.1",
+  "title": "Human Choice Authorship Membrane — RIVM × CDP × CCP POC",
+  "outcome": "Create a non-coercive KPGS POC that models bounded human authorship inside inherited conditions while preserving Project Jennifer RIVM/CDP/CCP semantics and keeping personal consent and action authority exclusively human.",
+  "scope": {
+    "included": [
+      "Define the proposed root-algorithm concept as a hypothesis rather than fact",
+      "Define a machine-readable choice-authorship record",
+      "Encode CDP multiple-candidate and unknown-branch requirements",
+      "Encode an explicit human consent gate",
+      "Keep CCP conceptual convergence separate from human action authority",
+      "Publish a governed KPGS skill package and structural validation checks",
+      "Pin Project Jennifer source provenance"
+    ],
+    "excluded": [
+      "Psychological diagnosis or clinical assessment",
+      "Automated life decisions or coercive behavioural steering",
+      "Claims that altered states expose a true self or inherently superior truth",
+      "Redefinition of Project Jennifer RIVM, CDP, CEEP or CCP",
+      "Foundation-model training or weight updates",
+      "Production deployment or automatic ecosystem-wide activation"
+    ]
+  },
+  "interfaces": [
+    {
+      "name": "Project Jennifer conceptual protocol lineage",
+      "contract": "RIVM preserves truth/source/agency boundaries; CDP widens non-canonical hypotheses; CCP owns evidence-bearing conceptual convergence.",
+      "version": "Project-Jennifer@5328a8449bad509150f73fe9aafeabc6c17c983b"
+    },
+    {
+      "name": "KPGS governed skill package",
+      "contract": "SKILL.md + skill.json + schema references under governance/kpgs-vnext/skills/core/kpgs-human-choice-authorship.",
+      "version": "0.1.0"
+    },
+    {
+      "name": "Human consent boundary",
+      "contract": "Endorse/reject/hold/unanswered must be explicitly human supplied; no renter or protocol may manufacture consent.",
+      "version": "0.1"
+    }
+  ],
+  "constraints": [
+    "Human remains context, consent and personal action authority.",
+    "Root algorithms remain proposed hypotheses until evidence supports any stronger claim.",
+    "CDP must preserve at least two structurally different candidate families and an unknown possibility.",
+    "CDP cannot self-canonicalize.",
+    "CCP conceptual acceptance does not grant personal execution authority.",
+    "Historical or state-tagged context cannot silently override current human authority.",
+    "No private autobiographical example is committed as public training or documentation material without explicit transformation consent.",
+    "CI evidence may not be fabricated while GitHub Actions is blocked under issue #48."
+  ],
+  "acceptance_criteria": [
+    {
+      "id": "HC-01",
+      "statement": "Project Jennifer RIVM/CDP/CCP source lineage is pinned and the POC does not redefine those protocols.",
+      "hard_gate": true,
+      "verification_methods": ["human-review", "schema"]
+    },
+    {
+      "id": "HC-02",
+      "statement": "Choice records preserve claim classes, root-algorithm hypotheses, divergent candidate families and explicit unknowns.",
+      "hard_gate": true,
+      "verification_methods": ["schema", "human-review"]
+    },
+    {
+      "id": "HC-03",
+      "statement": "No authored-choice or authorized-action state can be represented without explicit human endorsement.",
+      "hard_gate": true,
+      "verification_methods": ["schema", "unit"]
+    },
+    {
+      "id": "HC-04",
+      "statement": "CCP canonical state requires Accepted plus proven runtime execution and remains separate from human action authority.",
+      "hard_gate": true,
+      "verification_methods": ["schema", "unit"]
+    },
+    {
+      "id": "HC-05",
+      "statement": "The example is non-identifying and does not silently publish private autobiographical material.",
+      "hard_gate": true,
+      "verification_methods": ["human-review"]
+    },
+    {
+      "id": "HC-06",
+      "statement": "The KPGS contract validator includes structural checks for the choice-authorship POC and skill package.",
+      "hard_gate": false,
+      "verification_methods": ["unit", "integration"]
+    }
+  ],
+  "verification_plan": [
+    {
+      "criterion_id": "HC-01",
+      "evidence": "README and skill provenance reference Project Jennifer commit 5328a8449bad509150f73fe9aafeabc6c17c983b and preserve protocol responsibilities.",
+      "command_or_procedure": "Review human-choice-authorship/README.md and skills/core/kpgs-human-choice-authorship/skill.json."
+    },
+    {
+      "criterion_id": "HC-02",
+      "evidence": "choice-authorship-record.schema.json plus example.choice-authorship.json preserve hypothesis/non-canonical fields and unknown branch.",
+      "command_or_procedure": "Run python governance/kpgs-vnext/validate_contracts.py when an executable environment is available."
+    },
+    {
+      "criterion_id": "HC-03",
+      "evidence": "Schema conditional gates and validator assertions require response=endorse plus explicitly_human_supplied=true for endorsed/authored/authorized states.",
+      "command_or_procedure": "Test valid and invalid consent fixtures; CI execution remains blocked by #48 until GitHub runner access is restored."
+    },
+    {
+      "criterion_id": "HC-04",
+      "evidence": "Schema and validator require CCP decision Accepted plus runtime_execution_proven=true before canonical=true.",
+      "command_or_procedure": "Test canonical convergence fixtures once runtime/CI execution is available."
+    },
+    {
+      "criterion_id": "HC-05",
+      "evidence": "Committed example uses a generic educational-path scenario with no private names, locations, family identities or autobiographical event record.",
+      "command_or_procedure": "Human review of example.choice-authorship.json."
+    },
+    {
+      "criterion_id": "HC-06",
+      "evidence": "validate_contracts.py loads the new schema, example and skill and checks authority/divergence/convergence invariants.",
+      "command_or_procedure": "python governance/kpgs-vnext/validate_contracts.py"
+    }
+  ],
+  "rollback_plan": {
+    "trigger": "The POC violates source lineage, human consent authority, privacy boundaries or existing KPGS validation contracts.",
+    "procedure": "Close the POC PR without merge or revert the POC commit set; no production runtime or estate migration depends on this branch.",
+    "target_ref": "master@c5c2d13164b5ac808e5c8f25fcb0d6574424f7aa"
+  },
+  "risk_class": "R2",
+  "required_capabilities": [],
+  "lifecycle_state": "draft",
+  "related_issues": [46, 37, 38, 39, 41, 45, 47, 48, 49]
+}

--- a/governance/kpgs-vnext/human-choice-authorship/README.md
+++ b/governance/kpgs-vnext/human-choice-authorship/README.md
@@ -1,0 +1,166 @@
+# KPGS Human Choice Authorship Membrane — POC
+
+Status: **PROPOSED / POC**  
+Issue: #49  
+Parent epic: #46
+
+## Thesis
+
+Human choice can be modelled as **authorship inside conditions that were not chosen**.
+
+This POC does not claim total human control and does not collapse the human into deterministic conditioning. It models a narrower jurisdiction: inherited conditions and default sequences may shape desire, but conscious reflection can expose those influences and create a human-controlled consent boundary before action.
+
+The core question is:
+
+> **Now that I can see what shaped this desire, do I still consent to carrying it?**
+
+The answer belongs to the human. No AI, protocol, model, memory layer, agent, renter, evaluator or canonicalization mechanism may manufacture that consent.
+
+## Source lineage and authority
+
+This POC references Project Jennifer at commit `5328a8449bad509150f73fe9aafeabc6c17c983b`.
+
+Authoritative protocol references at that revision:
+
+- `docs/architecture/adr-0006-rivm-cdp-ccp-relational-orchestration.md`
+- `docs/architecture/adr-0005-governed-source-authority-and-rivm.md`
+- `skills/forge-rivm/SKILL.md`
+- `skills/cdp-conceptual-divergence/SKILL.md`
+- `skills/ccp-conceptual-convergence/SKILL.md`
+- `packages/conceptual/src/rivm/RelationalConceptualOrchestrator.ts`
+- `packages/conceptual/src/cdp/ConceptualDivergenceRuntime.ts`
+
+Project Jennifer remains authoritative for the meaning of RIVM, CDP and CCP. This KPGS POC composes those boundaries for a new use case; it does not silently redefine them.
+
+## What is validated from Project Jennifer
+
+RIVM is an inference-validation membrane for consequential relationship-bearing interactions. It separates claim classes, preserves human agency, prevents source collapse and is explicitly **not** the sovereign source.
+
+CDP answers **“What could this become?”** It widens a governed possibility field. Its runtime requires at least two structurally distinguishable candidates, preserves an unknown possibility by default and emits hypotheses with `canonical: false`.
+
+CCP answers **“What consistently works / survives the evidence?”** It narrows after divergence and evaluation. Only its `Accepted` state is canonical in the current Project Jennifer implementation.
+
+Therefore the correct composition for human-choice exploration is not “RIVM decides the choice.” RIVM guards the truth/agency/source membrane around the interaction; CDP generates alternative explanations or futures; evidence/evaluation tests them; the human independently supplies or withholds consent; CCP may govern conceptual convergence, but CCP still does not possess authority to make the human's life decision.
+
+## Proposed concept: root algorithm
+
+A **root algorithm** is a proposed descriptive model for an inherited or socially defaulted sequence that can shape expectations and behaviour before the individual consciously authors it.
+
+Example shape:
+
+```text
+primary school
+    -> high school
+    -> university
+    -> employment
+    -> stability
+    -> retirement
+```
+
+A root algorithm is **not** automatically a fact, destiny, diagnosis, causal proof, or universal law. It begins as a hypothesis whose source, context, evidence and contradictions must remain visible.
+
+The important failure mode is **sequence/reality collapse**: treating one inherited route as reality itself rather than one available route through reality.
+
+## Triangle model
+
+```mermaid
+flowchart TD
+    R[REALITY / GIVEN CONDITIONS<br/>existence, history, family, culture, systems] --> S[SELF IN STATE<br/>current context + identity configuration]
+    S --> A[AUTHORSHIP<br/>reflection + consent + bounded choice]
+    A --> X[ACTION / NON-ACTION]
+    X --> O[OUTCOME / CONSEQUENCE]
+    O --> R2[REVISED UNDERSTANDING]
+    R2 --> S
+
+    R -. not fully chosen .-> A
+    A -. does not fully control .-> O
+```
+
+The triangle rejects both extremes:
+
+```text
+TOTAL CONTROL       TOTAL SURRENDER
+“I determine all”   “I determine nothing”
+        \             /
+         \           /
+          BOUNDED AUTHORSHIP
+        choice inside conditions
+          not fully chosen
+```
+
+## Governed flow
+
+```mermaid
+flowchart TD
+    E[Existence / Given Conditions] --> C[Declared + Observed Context]
+    C --> RA[Root Algorithm Candidates<br/>PROPOSED / hypothesis]
+    RA --> RIVM[RIVM membrane<br/>claim + source + agency separation]
+    RIVM --> CDP[CDP divergence<br/>2+ distinct candidates + UNKNOWN]
+    CDP --> EV[Evaluation + POC-vs-FOC evidence]
+    EV --> HG{Human Consent Gate}
+    HG -->|endorse| CCP[CCP convergence candidate]
+    HG -->|reject| RJ[Release / Reject desire]
+    HG -->|hold / unanswered| H[Remain unresolved]
+    CCP --> AC[Authored Choice Candidate]
+    AC --> AU{Human Action Authority}
+    AU -->|authorize| ACT[Action / Non-action]
+    AU -->|do not authorize| H
+    ACT --> OR[Outcome Receipt]
+    OR --> C
+```
+
+## State-of-mind rule
+
+A state of mind may change attention, salience, interpretation, inhibition or association. The record may preserve a human-declared state label such as `sober`, `high`, `tired`, `afraid`, `peaceful`, `ambitious` or another free-text description.
+
+The protocol does **not** treat a state as a separate person and does not declare one state the “true self.” State-tagged observations remain testimony/context unless separately evidenced. An altered-state insight may enter CDP as a candidate signal, but salience is not proof.
+
+## Human authority law
+
+The human can always:
+
+- reject a root-algorithm interpretation;
+- refuse convergence;
+- leave the consent gate unanswered;
+- endorse a desire while declining action;
+- change an earlier endorsement without rewriting the historical receipt;
+- request a new divergence cycle when the available alternatives are inadequate.
+
+No protocol may infer `endorse` from affection, repetition, confidence, intoxication, silence, compliance, historical preference, or a model's prediction.
+
+## Protocol responsibilities
+
+```text
+RIVM  -> Is the inference truthful, source-separated, warm and agency-preserving?
+CDP   -> What structurally different explanations / futures could this become?
+CEEP  -> How do the candidates evaluate?
+POC/FOC -> What evidence actually exists versus what merely appears coherent?
+HUMAN CONSENT -> Do I still consent to carrying this desire?
+CCP   -> What conceptual pattern survives the evidence strongly enough to converge?
+HUMAN AUTHORITY -> Do I actually act, refuse, defer or revise?
+```
+
+## Hard failures
+
+This POC fails governance if it:
+
+- converts a root-algorithm hypothesis into fact without evidence;
+- produces only one explanation and calls it divergence;
+- suppresses the unknown branch to force completeness;
+- lets historical context override current human instruction;
+- infers human consent instead of receiving it explicitly;
+- equates CCP conceptual acceptance with authority to execute a life decision;
+- assigns a hidden identity, diagnosis, motive or “true self” to the person;
+- treats intoxicated or emotionally intense testimony as automatically more truthful;
+- rewrites prior choices or contradictions to preserve a clean narrative;
+- claims RIVM/CDP/CCP execution without a corresponding runtime receipt.
+
+## Validation status
+
+**Source-semantics validation: PASS.** The composition is grounded against the cited Project Jennifer protocol sources.
+
+**Conceptual compatibility: POC PASS.** The model preserves RIVM agency/source laws, CDP non-canonical divergence and CCP convergence authority while keeping personal consent external to all three protocols.
+
+**Empirical psychological claim: NOT CLAIMED.** `root algorithm` and this human-choice model are engineering/conceptual constructs, not established psychological diagnoses or universal scientific laws.
+
+**Runtime/CI validation: BLOCKED.** GitHub Actions execution for `Introduction-to-MCP` is currently blocked under #48 by the account billing lock. Static contracts may be reviewed and validated, but CI must remain unverified until a runner actually executes the gate.

--- a/governance/kpgs-vnext/human-choice-authorship/README.md
+++ b/governance/kpgs-vnext/human-choice-authorship/README.md
@@ -40,7 +40,7 @@ CDP answers **“What could this become?”** It widens a governed possibility f
 
 CCP answers **“What consistently works / survives the evidence?”** It narrows after divergence and evaluation. Only its `Accepted` state is canonical in the current Project Jennifer implementation.
 
-Therefore the correct composition for human-choice exploration is not “RIVM decides the choice.” RIVM guards the truth/agency/source membrane around the interaction; CDP generates alternative explanations or futures; evidence/evaluation tests them; the human independently supplies or withholds consent; CCP may govern conceptual convergence, but CCP still does not possess authority to make the human's life decision.
+Therefore the correct composition for human-choice exploration is not “RIVM decides the choice.” RIVM guards the truth/agency/source membrane around the interaction; CDP generates alternative explanations or futures; evidence/evaluation tests them; CCP may optionally converge the conceptual understanding; **then the human independently supplies or withholds consent**. CCP still does not possess authority to make the human's life decision.
 
 ## Proposed concept: root algorithm
 
@@ -96,18 +96,23 @@ flowchart TD
     C --> RA[Root Algorithm Candidates<br/>PROPOSED / hypothesis]
     RA --> RIVM[RIVM membrane<br/>claim + source + agency separation]
     RIVM --> CDP[CDP divergence<br/>2+ distinct candidates + UNKNOWN]
-    CDP --> EV[Evaluation + POC-vs-FOC evidence]
-    EV --> HG{Human Consent Gate}
-    HG -->|endorse| CCP[CCP convergence candidate]
+    CDP --> EV[CEEP + POC-vs-FOC evidence]
+    EV --> CQ{Conceptual convergence requested?}
+    CQ -->|yes| CCP[CCP conceptual state<br/>Accepted / Experimental / Refine / Rejected]
+    CQ -->|no| US[Evidence + uncertainty summary]
+    CCP --> HG{Human Consent Gate}
+    US --> HG
+    HG -->|endorse| AC[Human-endorsed choice candidate]
     HG -->|reject| RJ[Release / Reject desire]
     HG -->|hold / unanswered| H[Remain unresolved]
-    CCP --> AC[Authored Choice Candidate]
     AC --> AU{Human Action Authority}
     AU -->|authorize| ACT[Action / Non-action]
     AU -->|do not authorize| H
     ACT --> OR[Outcome Receipt]
     OR --> C
 ```
+
+This ordering prevents a preferred answer from being smuggled into conceptual truth. CCP may converge an explanation, remain experimental, or return `Refine`; the human can still endorse, reject, hold or act under uncertainty. **Conceptual confidence and personal authority are different axes.**
 
 ## State-of-mind rule
 
@@ -120,7 +125,8 @@ The protocol does **not** treat a state as a separate person and does not declar
 The human can always:
 
 - reject a root-algorithm interpretation;
-- refuse convergence;
+- refuse conceptual convergence;
+- choose while conceptual uncertainty remains visible;
 - leave the consent gate unanswered;
 - endorse a desire while declining action;
 - change an earlier endorsement without rewriting the historical receipt;
@@ -135,8 +141,8 @@ RIVM  -> Is the inference truthful, source-separated, warm and agency-preserving
 CDP   -> What structurally different explanations / futures could this become?
 CEEP  -> How do the candidates evaluate?
 POC/FOC -> What evidence actually exists versus what merely appears coherent?
-HUMAN CONSENT -> Do I still consent to carrying this desire?
-CCP   -> What conceptual pattern survives the evidence strongly enough to converge?
+CCP (optional) -> What conceptual pattern survives the evidence strongly enough to converge?
+HUMAN CONSENT -> Now that I can see this, do I still consent to carrying it?
 HUMAN AUTHORITY -> Do I actually act, refuse, defer or revise?
 ```
 
@@ -149,6 +155,7 @@ This POC fails governance if it:
 - suppresses the unknown branch to force completeness;
 - lets historical context override current human instruction;
 - infers human consent instead of receiving it explicitly;
+- lets human preference retroactively determine which hypothesis counts as fact;
 - equates CCP conceptual acceptance with authority to execute a life decision;
 - assigns a hidden identity, diagnosis, motive or “true self” to the person;
 - treats intoxicated or emotionally intense testimony as automatically more truthful;

--- a/governance/kpgs-vnext/human-choice-authorship/choice-authorship-record.schema.json
+++ b/governance/kpgs-vnext/human-choice-authorship/choice-authorship-record.schema.json
@@ -86,7 +86,13 @@
               "proof_state": { "const": "hypothesis" },
               "canonical": { "const": false }
             }
-          }
+          },
+          "contains": {
+            "type": "object",
+            "properties": { "candidate_id": { "const": "cdp-unknown-possibility" } },
+            "required": ["candidate_id"]
+          },
+          "minContains": 1
         },
         "unknown_branch_preserved": { "const": true },
         "canonicalized": { "const": false },
@@ -153,17 +159,64 @@
   "allOf": [
     {
       "if": {
+        "properties": {
+          "human_consent": {
+            "properties": { "response": { "enum": ["endorse", "reject", "hold"] } },
+            "required": ["response"]
+          }
+        },
+        "required": ["human_consent"]
+      },
+      "then": {
+        "properties": {
+          "human_consent": {
+            "properties": {
+              "explicitly_human_supplied": { "const": true },
+              "human_statement_ref": { "type": "string", "minLength": 1 }
+            },
+            "required": ["explicitly_human_supplied", "human_statement_ref"]
+          }
+        }
+      }
+    },
+    {
+      "if": {
         "properties": { "authorship_status": { "enum": ["human-endorsed", "authored-choice-candidate"] } },
         "required": ["authorship_status"]
       },
       "then": {
         "properties": {
           "human_consent": {
-            "properties": {
-              "response": { "const": "endorse" },
-              "explicitly_human_supplied": { "const": true }
-            },
-            "required": ["response", "explicitly_human_supplied"]
+            "properties": { "response": { "const": "endorse" } },
+            "required": ["response"]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": { "authorship_status": { "const": "human-rejected" } },
+        "required": ["authorship_status"]
+      },
+      "then": {
+        "properties": {
+          "human_consent": {
+            "properties": { "response": { "const": "reject" } },
+            "required": ["response"]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": { "authorship_status": { "const": "human-held" } },
+        "required": ["authorship_status"]
+      },
+      "then": {
+        "properties": {
+          "human_consent": {
+            "properties": { "response": { "const": "hold" } },
+            "required": ["response"]
           }
         }
       }
@@ -181,11 +234,46 @@
       "then": {
         "properties": {
           "human_consent": {
-            "properties": {
-              "response": { "const": "endorse" },
-              "explicitly_human_supplied": { "const": true }
-            },
-            "required": ["response", "explicitly_human_supplied"]
+            "properties": { "response": { "const": "endorse" } },
+            "required": ["response"]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "cdp": {
+            "properties": { "runtime_execution_proven": { "const": true } },
+            "required": ["runtime_execution_proven"]
+          }
+        },
+        "required": ["cdp"]
+      },
+      "then": {
+        "properties": {
+          "cdp": {
+            "properties": { "runtime_receipt_ref": { "type": "string", "minLength": 1 } },
+            "required": ["runtime_receipt_ref"]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "convergence": {
+            "properties": { "runtime_execution_proven": { "const": true } },
+            "required": ["runtime_execution_proven"]
+          }
+        },
+        "required": ["convergence"]
+      },
+      "then": {
+        "properties": {
+          "convergence": {
+            "properties": { "receipt_ref": { "type": "string", "minLength": 1 } },
+            "required": ["receipt_ref"]
           }
         }
       }
@@ -208,6 +296,28 @@
               "runtime_execution_proven": { "const": true }
             },
             "required": ["decision", "runtime_execution_proven"]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "convergence": {
+            "properties": { "decision": { "const": "not-requested" } },
+            "required": ["decision"]
+          }
+        },
+        "required": ["convergence"]
+      },
+      "then": {
+        "properties": {
+          "convergence": {
+            "properties": {
+              "canonical": { "const": false },
+              "runtime_execution_proven": { "const": false }
+            },
+            "required": ["canonical", "runtime_execution_proven"]
           }
         }
       }

--- a/governance/kpgs-vnext/human-choice-authorship/choice-authorship-record.schema.json
+++ b/governance/kpgs-vnext/human-choice-authorship/choice-authorship-record.schema.json
@@ -1,0 +1,216 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kopanolabs.com/schemas/kpgs/human-choice-authorship/choice-authorship-record.schema.json",
+  "title": "KPGS Human Choice Authorship Record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "record_id",
+    "subject_authority",
+    "current_state",
+    "context_claims",
+    "root_algorithm_candidates",
+    "cdp",
+    "human_consent",
+    "convergence",
+    "authorship_status",
+    "action_authority",
+    "re_evaluation_required"
+  ],
+  "properties": {
+    "schema_version": { "const": "0.1" },
+    "record_id": { "type": "string", "minLength": 4, "maxLength": 200 },
+    "subject_authority": { "const": "human" },
+    "recorded_at": { "type": ["string", "null"], "format": "date-time" },
+    "current_state": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["label", "source_class", "authority"],
+      "properties": {
+        "label": { "type": "string", "minLength": 1, "maxLength": 200 },
+        "source_class": { "type": "string", "enum": ["human-declared", "observed", "inferred", "unknown"] },
+        "authority": { "type": "string", "enum": ["current-human", "supporting-evidence", "historical-evidence", "unknown"] },
+        "notes": { "type": ["string", "null"], "maxLength": 4000 }
+      }
+    },
+    "context_claims": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["claim_id", "text", "classification", "source_class", "current_authority_eligible"],
+        "properties": {
+          "claim_id": { "type": "string", "minLength": 1 },
+          "text": { "type": "string", "minLength": 1, "maxLength": 8000 },
+          "classification": { "type": "string", "enum": ["FACT", "FEELING", "FANTASY", "PERFORMANCE", "INFERENCE", "UNKNOWN", "PERSONALITY", "PREFERENCE", "BOUNDARY"] },
+          "source_class": { "type": "string", "enum": ["current-human", "prior-context", "governed-memory", "repository", "external-retrieval", "model-generated", "unknown"] },
+          "source_ref": { "type": ["string", "null"] },
+          "current_authority_eligible": { "type": "boolean" }
+        }
+      }
+    },
+    "root_algorithm_candidates": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["candidate_id", "description", "proof_state", "canonical", "source_claim_ids", "evidence_needed", "contradictions"],
+        "properties": {
+          "candidate_id": { "type": "string", "minLength": 1 },
+          "description": { "type": "string", "minLength": 8, "maxLength": 8000 },
+          "proof_state": { "const": "hypothesis" },
+          "canonical": { "const": false },
+          "source_claim_ids": { "type": "array", "items": { "type": "string", "minLength": 1 } },
+          "evidence_needed": { "type": "array", "items": { "type": "string", "minLength": 1 } },
+          "contradictions": { "type": "array", "items": { "type": "string", "minLength": 1 } }
+        }
+      }
+    },
+    "cdp": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["candidate_families", "unknown_branch_preserved", "canonicalized", "runtime_execution_proven"],
+      "properties": {
+        "candidate_families": {
+          "type": "array",
+          "minItems": 2,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["candidate_id", "hypothesis", "difference", "proof_state", "canonical"],
+            "properties": {
+              "candidate_id": { "type": "string", "minLength": 1 },
+              "hypothesis": { "type": "string", "minLength": 4 },
+              "difference": { "type": "string", "minLength": 4 },
+              "proof_state": { "const": "hypothesis" },
+              "canonical": { "const": false }
+            }
+          }
+        },
+        "unknown_branch_preserved": { "const": true },
+        "canonicalized": { "const": false },
+        "runtime_execution_proven": { "type": "boolean" },
+        "runtime_receipt_ref": { "type": ["string", "null"] }
+      }
+    },
+    "evaluation": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "evidence_level": { "type": "string", "enum": ["none", "low", "moderate", "high"] },
+        "poc_state": { "type": "string", "enum": ["unproven", "candidate", "evidence-bearing", "validated", "rejected"] },
+        "evidence_refs": { "type": "array", "items": { "type": "string", "minLength": 1 } },
+        "unknowns": { "type": "array", "items": { "type": "string", "minLength": 1 } }
+      }
+    },
+    "human_consent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["question", "response", "explicitly_human_supplied"],
+      "properties": {
+        "question": { "const": "Now that I can see what shaped this desire, do I still consent to carrying it?" },
+        "response": { "type": "string", "enum": ["endorse", "reject", "hold", "unanswered"] },
+        "explicitly_human_supplied": { "type": "boolean" },
+        "human_statement_ref": { "type": ["string", "null"] },
+        "notes": { "type": ["string", "null"], "maxLength": 4000 }
+      }
+    },
+    "convergence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["protocol", "decision", "canonical", "runtime_execution_proven"],
+      "properties": {
+        "protocol": { "const": "CCP" },
+        "decision": { "type": "string", "enum": ["not-requested", "Accepted", "Experimental", "Refine", "Rejected", "Deprecated"] },
+        "canonical": { "type": "boolean" },
+        "runtime_execution_proven": { "type": "boolean" },
+        "receipt_ref": { "type": ["string", "null"] }
+      }
+    },
+    "authorship_status": { "type": "string", "enum": ["exploring", "human-endorsed", "human-rejected", "human-held", "authored-choice-candidate"] },
+    "action_authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["authority_holder", "authorized"],
+      "properties": {
+        "authority_holder": { "const": "human" },
+        "authorized": { "type": "boolean" },
+        "action_ref": { "type": ["string", "null"] }
+      }
+    },
+    "outcome": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "summary": { "type": "string", "minLength": 1 },
+        "evidence_refs": { "type": "array", "items": { "type": "string", "minLength": 1 } },
+        "recorded_by": { "type": "string", "enum": ["human", "system-receipt", "mixed"] }
+      }
+    },
+    "re_evaluation_required": { "type": "boolean" }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": { "authorship_status": { "enum": ["human-endorsed", "authored-choice-candidate"] } },
+        "required": ["authorship_status"]
+      },
+      "then": {
+        "properties": {
+          "human_consent": {
+            "properties": {
+              "response": { "const": "endorse" },
+              "explicitly_human_supplied": { "const": true }
+            },
+            "required": ["response", "explicitly_human_supplied"]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "action_authority": {
+            "properties": { "authorized": { "const": true } },
+            "required": ["authorized"]
+          }
+        },
+        "required": ["action_authority"]
+      },
+      "then": {
+        "properties": {
+          "human_consent": {
+            "properties": {
+              "response": { "const": "endorse" },
+              "explicitly_human_supplied": { "const": true }
+            },
+            "required": ["response", "explicitly_human_supplied"]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "convergence": {
+            "properties": { "canonical": { "const": true } },
+            "required": ["canonical"]
+          }
+        },
+        "required": ["convergence"]
+      },
+      "then": {
+        "properties": {
+          "convergence": {
+            "properties": {
+              "decision": { "const": "Accepted" },
+              "runtime_execution_proven": { "const": true }
+            },
+            "required": ["decision", "runtime_execution_proven"]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/governance/kpgs-vnext/human-choice-authorship/example.choice-authorship.json
+++ b/governance/kpgs-vnext/human-choice-authorship/example.choice-authorship.json
@@ -1,0 +1,98 @@
+{
+  "schema_version": "0.1",
+  "record_id": "choice-example-education-path-001",
+  "subject_authority": "human",
+  "recorded_at": null,
+  "current_state": {
+    "label": "reflective",
+    "source_class": "human-declared",
+    "authority": "current-human",
+    "notes": "Example state label only; no claim that this state is a separate identity or more truthful state."
+  },
+  "context_claims": [
+    {
+      "claim_id": "claim-1",
+      "text": "The person was taught a default sequence of school, university, employment and stability.",
+      "classification": "INFERENCE",
+      "source_class": "current-human",
+      "source_ref": "example-human-statement",
+      "current_authority_eligible": true
+    },
+    {
+      "claim_id": "claim-2",
+      "text": "The person currently wants to decide whether university remains useful for reasons they endorse now.",
+      "classification": "PREFERENCE",
+      "source_class": "current-human",
+      "source_ref": "example-human-statement",
+      "current_authority_eligible": true
+    }
+  ],
+  "root_algorithm_candidates": [
+    {
+      "candidate_id": "root-education-default",
+      "description": "A socially inherited education-to-employment sequence may have shaped expectations before conscious authorship.",
+      "proof_state": "hypothesis",
+      "canonical": false,
+      "source_claim_ids": ["claim-1"],
+      "evidence_needed": ["current human confirmation", "relevant historical evidence if the human wants to provide it"],
+      "contradictions": []
+    }
+  ],
+  "cdp": {
+    "candidate_families": [
+      {
+        "candidate_id": "candidate-conditioned-continuation",
+        "hypothesis": "The current education desire primarily continues an inherited default sequence.",
+        "difference": "Explains the desire mainly through inherited conditioning.",
+        "proof_state": "hypothesis",
+        "canonical": false
+      },
+      {
+        "candidate_id": "candidate-reflective-reendorsement",
+        "hypothesis": "The person understands the inherited sequence and independently re-endorses education as useful now.",
+        "difference": "Explains the same action as reflective re-endorsement rather than automatic continuation.",
+        "proof_state": "hypothesis",
+        "canonical": false
+      },
+      {
+        "candidate_id": "cdp-unknown-possibility",
+        "hypothesis": "Another explanation remains possible because the available context is incomplete.",
+        "difference": "Preserves incompleteness rather than forcing the available stories to be exhaustive.",
+        "proof_state": "hypothesis",
+        "canonical": false
+      }
+    ],
+    "unknown_branch_preserved": true,
+    "canonicalized": false,
+    "runtime_execution_proven": false,
+    "runtime_receipt_ref": null
+  },
+  "evaluation": {
+    "evidence_level": "low",
+    "poc_state": "candidate",
+    "evidence_refs": [],
+    "unknowns": ["The relative weight of conditioning and current endorsement is not established by this example."]
+  },
+  "human_consent": {
+    "question": "Now that I can see what shaped this desire, do I still consent to carrying it?",
+    "response": "unanswered",
+    "explicitly_human_supplied": false,
+    "human_statement_ref": null,
+    "notes": "The protocol must not infer an answer."
+  },
+  "convergence": {
+    "protocol": "CCP",
+    "decision": "not-requested",
+    "canonical": false,
+    "runtime_execution_proven": false,
+    "receipt_ref": null
+  },
+  "authorship_status": "exploring",
+  "action_authority": {
+    "authority_holder": "human",
+    "authorized": false,
+    "action_ref": null
+  },
+  "outcome": null,
+  "re_evaluation_required": true
+}

--- a/governance/kpgs-vnext/skills/core/kpgs-human-choice-authorship/SKILL.md
+++ b/governance/kpgs-vnext/skills/core/kpgs-human-choice-authorship/SKILL.md
@@ -44,7 +44,7 @@ RIVM -> truth / source / agency membrane around consequential inference
 CDP  -> governed widening; hypotheses only; no self-canonicalization
 CEEP -> candidate evaluation
 POC-vs-FOC -> evidence boundary
-CCP  -> conceptual convergence after evidence
+CCP  -> optional conceptual convergence after evidence
 HUMAN -> consent and personal action authority
 ```
 
@@ -125,9 +125,17 @@ Compare candidates against current testimony, authorized history, contradictions
 
 Keep POC and FOC separate. A powerful story is not proof.
 
-### 6. Stop at the human consent gate
+### 6. Converge conceptually only when convergence is requested
 
-Present the human with the governing question:
+If the human wants conceptual convergence and adequate evidence exists, pass the evidence-bearing proposal through the governed CCP boundary. If convergence is not requested, preserve the evidence and uncertainty summary instead.
+
+Do not fabricate a CCP execution receipt. Do not call an `Experimental`, `Refine`, `Rejected` or unexecuted state canonical.
+
+CCP is an understanding/evidence boundary, not a life-authority boundary. A human remains free to make a choice while uncertainty is explicit; `Refine` is not a prohibition on living.
+
+### 7. Stop at the human consent gate
+
+After presenting the best available conceptual/evidence state, ask:
 
 > **Now that I can see what shaped this desire, do I still consent to carrying it?**
 
@@ -142,29 +150,23 @@ unanswered
 
 The response is valid only when explicitly supplied by the human. Never infer `endorse` from repetition, enthusiasm, intoxication, affection, silence, compliance, historical behavior or model prediction.
 
-### 7. Converge only when convergence is actually requested
-
-If the human wants conceptual convergence and adequate evidence exists, pass the evidence-bearing proposal through the governed CCP boundary.
-
-Do not fabricate a CCP execution receipt. Do not call an `Experimental`, `Refine`, `Rejected` or unexecuted state canonical.
+The human response must not be used retroactively to alter which candidate counted as better evidenced.
 
 ### 8. Preserve human action authority
 
 Even after human endorsement or conceptual convergence, action remains a separate decision.
 
 ```text
-concept understood
+conceptual understanding state
     !=
 human endorses desire
-    !=
-CCP conceptual acceptance
     !=
 human authorizes action
     !=
 action executed
 ```
 
-The human may endorse a desire and still choose not to act.
+The human may endorse a desire and still choose not to act. The human may also choose under explicit uncertainty without pretending CCP reached `Accepted`.
 
 ### 9. Record consequence and re-enter the loop
 
@@ -174,7 +176,7 @@ Outcome becomes new context for another cycle:
 
 ```text
 conditions -> interpretation -> divergence -> evaluation
--> consent -> choice -> consequence -> revised understanding
+-> optional convergence -> consent -> choice -> consequence -> revised understanding
 ```
 
 ## State-of-mind boundary
@@ -201,6 +203,7 @@ Return `hold` or correct the workflow when any of these occur:
 - `SOURCE_COLLAPSE`
 - `HUMAN_CONSENT_INFERRED`
 - `HUMAN_AUTHORITY_CAPTURED`
+- `PREFERENCE_RETROACTIVELY_DEFINES_TRUTH`
 - `STATE_SALIENCE_PROMOTED_TO_TRUTH`
 - `CCP_EXECUTION_UNPROVEN`
 - `CONCEPTUAL_ACCEPTANCE_USED_AS_ACTION_AUTHORITY`
@@ -214,8 +217,8 @@ Produce or update a record conforming to:
 
 `../../../human-choice-authorship/choice-authorship-record.schema.json`
 
-Plain-language output should tell the human what conditions are visible, which explanations remain possible, what is inferred versus evidenced, where uncertainty remains, and whether the workflow is waiting on explicit human consent.
+Plain-language output should tell the human what conditions are visible, which explanations remain possible, what is inferred versus evidenced, where uncertainty remains, the conceptual convergence state if one was requested, and whether the workflow is waiting on explicit human consent.
 
 ## Success condition
 
-The skill succeeds when it expands self-understanding **without capturing self-authorship**: conditions remain visible, alternative explanations remain inspectable, unknowns survive, consent belongs to the human, and no renter can promote an interpretation into identity or action authority on the person's behalf.
+The skill succeeds when it expands self-understanding **without capturing self-authorship**: conditions remain visible, alternative explanations remain inspectable, unknowns survive, conceptual confidence stays separate from preference, consent belongs to the human, and no renter can promote an interpretation into identity or action authority on the person's behalf.

--- a/governance/kpgs-vnext/skills/core/kpgs-human-choice-authorship/SKILL.md
+++ b/governance/kpgs-vnext/skills/core/kpgs-human-choice-authorship/SKILL.md
@@ -1,0 +1,221 @@
+---
+name: kpgs-human-choice-authorship
+description: Explore how inherited conditions, proposed root algorithms, current state, desire and explicit human consent relate to a personal choice without assigning identity, manufacturing consent or confusing conceptual convergence with authority to act.
+---
+
+# KPGS Human Choice Authorship
+
+## Trigger
+
+Use this skill when a human explicitly wants to examine a meaningful desire, motivation, inherited life sequence, state-dependent interpretation or personal choice through KPGS-style governance.
+
+Do not activate merely because a user mentions a preference. Do not use it to diagnose a person, identify a hidden “true self,” predict what they really want, or make a consequential life decision for them.
+
+## Governing thesis
+
+> Choice exists inside conditions that were not fully chosen.
+
+The skill rejects two false extremes:
+
+```text
+TOTAL CONTROL:   “I determine everything.”
+TOTAL SURRENDER: “I determine nothing.”
+
+              ↓
+
+BOUNDED AUTHORSHIP:
+“I did not author every condition that shaped me,
+but I retain authority to inspect, endorse, reject,
+hold or revise what I carry forward.”
+```
+
+## Source protocol boundary
+
+This skill composes, but does not redefine, Project Jennifer's RIVM/CDP/CCP lineage.
+
+Pinned reference revision:
+
+`RobynAwesome/Project-Jennifer@5328a8449bad509150f73fe9aafeabc6c17c983b`
+
+Protocol responsibilities remain:
+
+```text
+RIVM -> truth / source / agency membrane around consequential inference
+CDP  -> governed widening; hypotheses only; no self-canonicalization
+CEEP -> candidate evaluation
+POC-vs-FOC -> evidence boundary
+CCP  -> conceptual convergence after evidence
+HUMAN -> consent and personal action authority
+```
+
+A CCP `Accepted` conceptual receipt does not grant authority to choose or act for the human.
+
+## Root algorithm — POC term
+
+A `root algorithm` is a proposed descriptive hypothesis for an inherited or socially defaulted sequence that may shape expectations before conscious authorship.
+
+Examples may include educational, career, family, cultural, religious or economic sequences.
+
+Every root-algorithm record begins as:
+
+```text
+proof_state: hypothesis
+canonical: false
+```
+
+Never promote a root algorithm merely because the narrative feels coherent.
+
+## Workflow
+
+### 1. Receive current human authority
+
+Resolve what the human is asking **now**. Current human instruction outranks conflicting historical preferences or prior context.
+
+Keep testimony and state descriptions in their original epistemic class. A human may say “I feel peaceful,” “I am high,” “I am ashamed,” or “I want this.” Those are current human declarations; they do not automatically prove broader causal claims.
+
+### 2. Separate claim classes through the RIVM membrane
+
+Classify consequential material using the available Project Jennifer vocabulary:
+
+```text
+FACT
+FEELING
+FANTASY
+PERFORMANCE
+INFERENCE
+UNKNOWN
+PERSONALITY
+PREFERENCE
+BOUNDARY
+```
+
+Do not collapse a feeling, preference or inference into fact.
+
+### 3. Identify proposed root algorithms
+
+Ask what durable default sequence might be shaping the choice.
+
+Examples:
+
+```text
+school -> university -> job -> stability
+family approval -> achievement -> validation
+scarcity -> risk avoidance -> conventional security
+```
+
+These are candidates, not verdicts. Preserve source claims, contradictions and evidence still needed.
+
+### 4. Run conceptual divergence
+
+Generate at least two **structurally different** explanations or future paths. Preserve an explicit unknown possibility.
+
+For example:
+
+```text
+A: the desire is mostly inherited continuation
+B: the desire is reflectively re-endorsed despite inherited origin
+C: another explanation remains unresolved
+```
+
+CDP output remains hypothesis-only and non-canonical.
+
+### 5. Evaluate without forcing closure
+
+Compare candidates against current testimony, authorized history, contradictions, observed consequences and other admissible evidence.
+
+Keep POC and FOC separate. A powerful story is not proof.
+
+### 6. Stop at the human consent gate
+
+Present the human with the governing question:
+
+> **Now that I can see what shaped this desire, do I still consent to carrying it?**
+
+Allowed human responses:
+
+```text
+endorse
+reject
+hold
+unanswered
+```
+
+The response is valid only when explicitly supplied by the human. Never infer `endorse` from repetition, enthusiasm, intoxication, affection, silence, compliance, historical behavior or model prediction.
+
+### 7. Converge only when convergence is actually requested
+
+If the human wants conceptual convergence and adequate evidence exists, pass the evidence-bearing proposal through the governed CCP boundary.
+
+Do not fabricate a CCP execution receipt. Do not call an `Experimental`, `Refine`, `Rejected` or unexecuted state canonical.
+
+### 8. Preserve human action authority
+
+Even after human endorsement or conceptual convergence, action remains a separate decision.
+
+```text
+concept understood
+    !=
+human endorses desire
+    !=
+CCP conceptual acceptance
+    !=
+human authorizes action
+    !=
+action executed
+```
+
+The human may endorse a desire and still choose not to act.
+
+### 9. Record consequence and re-enter the loop
+
+If action occurs, preserve an outcome receipt without rewriting earlier uncertainty, contradiction or rejected hypotheses.
+
+Outcome becomes new context for another cycle:
+
+```text
+conditions -> interpretation -> divergence -> evaluation
+-> consent -> choice -> consequence -> revised understanding
+```
+
+## State-of-mind boundary
+
+Different states can expose different attention, associations, emotions or interpretations. This skill may preserve a human-declared state label as context.
+
+It must not:
+
+- claim each state is a separate person;
+- identify one state as the hidden “real self”;
+- claim intoxicated insight is inherently deeper or more truthful;
+- use an altered state to bypass explicit human consent;
+- encourage escalation of intoxication as an inference technique.
+
+A state can contribute a signal. It cannot self-promote the signal into truth.
+
+## Hard gates
+
+Return `hold` or correct the workflow when any of these occur:
+
+- `ROOT_ALGORITHM_PROMOTED_WITHOUT_EVIDENCE`
+- `PREMATURE_CONVERGENCE`
+- `UNKNOWN_BRANCH_SUPPRESSED`
+- `SOURCE_COLLAPSE`
+- `HUMAN_CONSENT_INFERRED`
+- `HUMAN_AUTHORITY_CAPTURED`
+- `STATE_SALIENCE_PROMOTED_TO_TRUTH`
+- `CCP_EXECUTION_UNPROVEN`
+- `CONCEPTUAL_ACCEPTANCE_USED_AS_ACTION_AUTHORITY`
+- `HISTORY_REWRITTEN`
+
+Where a Project Jennifer RIVM hard-fail code also applies, preserve that code rather than replacing it with a softer local label.
+
+## Output
+
+Produce or update a record conforming to:
+
+`../../../human-choice-authorship/choice-authorship-record.schema.json`
+
+Plain-language output should tell the human what conditions are visible, which explanations remain possible, what is inferred versus evidenced, where uncertainty remains, and whether the workflow is waiting on explicit human consent.
+
+## Success condition
+
+The skill succeeds when it expands self-understanding **without capturing self-authorship**: conditions remain visible, alternative explanations remain inspectable, unknowns survive, consent belongs to the human, and no renter can promote an interpretation into identity or action authority on the person's behalf.

--- a/governance/kpgs-vnext/skills/core/kpgs-human-choice-authorship/skill.json
+++ b/governance/kpgs-vnext/skills/core/kpgs-human-choice-authorship/skill.json
@@ -1,0 +1,103 @@
+{
+  "name": "kpgs-human-choice-authorship",
+  "version": "0.1.0",
+  "description": "Explore inherited conditions, proposed root algorithms, state-tagged testimony, divergent interpretations and explicit human consent without assigning identity or capturing personal action authority.",
+  "category": "human-governance",
+  "state": "draft",
+  "runtime": {
+    "renter_protocol": "1.0",
+    "platforms": ["human", "agent", "stateless-renter"],
+    "languages": ["markdown", "json"]
+  },
+  "inputs": {
+    "schema_ref": "../../../human-choice-authorship/choice-authorship-record.schema.json",
+    "description": "A governed human-choice exploration record with current authority, context claims, root-algorithm hypotheses, CDP candidate families and explicit human consent state."
+  },
+  "outputs": {
+    "schema_ref": "../../../human-choice-authorship/choice-authorship-record.schema.json",
+    "description": "An updated non-coercive authorship record preserving hypotheses, unknowns, consent, conceptual convergence state and separate human action authority."
+  },
+  "required_capabilities": [
+    {
+      "name": "governed-context.read",
+      "resource_scope": "active-human-choice-record",
+      "optional": false
+    },
+    {
+      "name": "choice-record.write",
+      "resource_scope": "active-human-choice-record",
+      "optional": false
+    }
+  ],
+  "dependencies": [
+    {
+      "kind": "runtime",
+      "name": "kpgs-stateless-renter-protocol",
+      "version_constraint": "1.0"
+    },
+    {
+      "kind": "skill",
+      "name": "Project Jennifer RIVM/CDP/CCP protocol lineage",
+      "version_constraint": null
+    }
+  ],
+  "provenance": {
+    "origin": "adapted",
+    "license_status": "unknown",
+    "license_spdx": null,
+    "sources": [
+      {
+        "ref": "RobynAwesome/Project-Jennifer",
+        "relationship": "adaptation",
+        "commit": "5328a8449bad509150f73fe9aafeabc6c17c983b"
+      },
+      {
+        "ref": "RobynAwesome/Introduction-to-MCP#49",
+        "relationship": "reference",
+        "commit": null
+      }
+    ]
+  },
+  "validation": {
+    "hard_gates": [
+      "Human consent may never be inferred or delegated",
+      "Root algorithms remain hypotheses until evidence supports promotion",
+      "CDP requires structurally distinct alternatives and preserves an unknown branch",
+      "CCP conceptual convergence never grants authority to make or execute a human life decision",
+      "State salience may not be promoted to truth without evidence",
+      "Historical context cannot override current human authority"
+    ],
+    "methods": ["schema", "human-review"],
+    "evidence_refs": [
+      "RobynAwesome/Project-Jennifer@5328a8449bad509150f73fe9aafeabc6c17c983b",
+      "RobynAwesome/Introduction-to-MCP#49"
+    ]
+  },
+  "failures": [
+    {
+      "code": "HUMAN_CONSENT_INFERRED",
+      "recoverability": "user-action",
+      "user_message": "The system cannot decide that you endorse this desire. Your explicit response is required."
+    },
+    {
+      "code": "PREMATURE_CONVERGENCE",
+      "recoverability": "retry",
+      "user_message": "The available explanations are too narrow or insufficiently evaluated. Preserve alternatives and continue divergence."
+    },
+    {
+      "code": "ROOT_ALGORITHM_UNPROVEN",
+      "recoverability": "retry",
+      "user_message": "This inherited-sequence explanation is still a hypothesis and cannot be presented as fact yet."
+    },
+    {
+      "code": "CCP_EXECUTION_UNPROVEN",
+      "recoverability": "operator-action",
+      "user_message": "Conceptual convergence has not been proven by a runtime receipt, so it remains non-canonical."
+    },
+    {
+      "code": "ACTION_AUTHORITY_CAPTURE",
+      "recoverability": "user-action",
+      "user_message": "The system cannot make this personal choice for you. Action authority remains with you."
+    }
+  ]
+}

--- a/governance/kpgs-vnext/validate_contracts.py
+++ b/governance/kpgs-vnext/validate_contracts.py
@@ -213,7 +213,6 @@ def validate_human_choice_authorship() -> None:
 
     skill_manifest = load_json("skills/core/kpgs-human-choice-authorship/skill.json")
     require(skill_manifest.get("state") == "draft", "human choice skill must remain draft while this work is POC and license status is unresolved")
-    require(skill_manifest.get("provenance", {}).get("commit") is None if False else True, "placeholder")
     sources = skill_manifest.get("provenance", {}).get("sources", [])
     project_jennifer = next((source for source in sources if source.get("ref") == "RobynAwesome/Project-Jennifer"), None)
     require(project_jennifer is not None, "human choice skill must preserve Project Jennifer provenance")

--- a/governance/kpgs-vnext/validate_contracts.py
+++ b/governance/kpgs-vnext/validate_contracts.py
@@ -107,6 +107,30 @@ def validate_evidence() -> None:
     require(bool(schema.get("allOf")), "evidence schema must contain a structural promotion/hard-gate constraint")
 
 
+def validate_skill_package(skill_name: str) -> None:
+    skill_dir = ROOT / f"skills/core/{skill_name}"
+    manifest = json.loads((skill_dir / "skill.json").read_text(encoding="utf-8"))
+    skill_md = (skill_dir / "SKILL.md").read_text(encoding="utf-8")
+
+    require(skill_md.startswith(f"---\nname: {skill_name}\n"), f"{skill_name} SKILL.md must start with matching frontmatter")
+    require(manifest["name"] == skill_name, f"{skill_name} manifest and SKILL.md identity must match")
+    require(manifest["runtime"]["renter_protocol"] == "1.0", f"{skill_name} must declare renter protocol compatibility")
+
+    license_status = manifest["provenance"]["license_status"]
+    if license_status in {"unknown", "pending", "incompatible"}:
+        require(manifest["state"] not in {"validated", "approved"}, f"{skill_name} cannot be validated/approved while license status blocks promotion")
+
+    for key in ("inputs", "outputs"):
+        ref = manifest[key].get("schema_ref")
+        if ref:
+            resolved = (skill_dir / ref).resolve()
+            require(resolved.is_file(), f"{skill_name} {key} schema_ref does not resolve: {ref}")
+            require(ROOT in resolved.parents, f"{skill_name} {key} schema_ref escapes the KPGS vNext governance root")
+
+    required_capabilities = manifest.get("required_capabilities", [])
+    require(all(item.get("resource_scope") for item in required_capabilities), f"every {skill_name} capability must declare a resource scope")
+
+
 def validate_skills() -> None:
     schema = load_json("skills/skill-manifest.schema.json")
     validate_schema(
@@ -129,27 +153,71 @@ def validate_skills() -> None:
         },
     )
 
-    skill_dir = ROOT / "skills/core/kpgs-audit-verify-govern"
-    manifest = json.loads((skill_dir / "skill.json").read_text(encoding="utf-8"))
-    skill_md = (skill_dir / "SKILL.md").read_text(encoding="utf-8")
+    validate_skill_package("kpgs-audit-verify-govern")
+    validate_skill_package("kpgs-human-choice-authorship")
 
-    require(skill_md.startswith("---\nname: kpgs-audit-verify-govern\n"), "canonical skill SKILL.md must start with declared frontmatter")
-    require(manifest["name"] == "kpgs-audit-verify-govern", "skill manifest and SKILL.md identity must match")
-    require(manifest["runtime"]["renter_protocol"] == "1.0", "canonical skill must declare renter protocol compatibility")
 
-    license_status = manifest["provenance"]["license_status"]
-    if license_status in {"unknown", "pending", "incompatible"}:
-        require(manifest["state"] not in {"validated", "approved"}, "skill cannot be validated/approved while license status blocks promotion")
+def validate_human_choice_authorship() -> None:
+    schema = load_json("human-choice-authorship/choice-authorship-record.schema.json")
+    record = load_json("human-choice-authorship/example.choice-authorship.json")
 
-    for key in ("inputs", "outputs"):
-        ref = manifest[key].get("schema_ref")
-        if ref:
-            resolved = (skill_dir / ref).resolve()
-            require(resolved.is_file(), f"skill {key} schema_ref does not resolve: {ref}")
-            require(ROOT in resolved.parents, f"skill {key} schema_ref escapes the KPGS vNext governance root")
+    validate_schema(
+        schema,
+        "human choice authorship schema",
+        {
+            "schema_version",
+            "record_id",
+            "subject_authority",
+            "current_state",
+            "context_claims",
+            "root_algorithm_candidates",
+            "cdp",
+            "human_consent",
+            "convergence",
+            "authorship_status",
+            "action_authority",
+            "re_evaluation_required",
+        },
+    )
 
-    required_capabilities = manifest.get("required_capabilities", [])
-    require(all(item.get("resource_scope") for item in required_capabilities), "every skill capability must declare a resource scope")
+    require(record.get("subject_authority") == "human", "personal choice authority must remain human")
+
+    root_candidates = record.get("root_algorithm_candidates", [])
+    for candidate in root_candidates:
+        require(candidate.get("proof_state") == "hypothesis", "root algorithm candidates must remain hypotheses")
+        require(candidate.get("canonical") is False, "root algorithm candidates cannot self-canonicalize")
+
+    cdp = record.get("cdp", {})
+    candidates = cdp.get("candidate_families", [])
+    require(len(candidates) >= 2, "choice-authorship CDP needs at least two candidate families")
+    differences = [candidate.get("difference", "").strip().lower() for candidate in candidates]
+    require(all(differences), "every choice-authorship CDP candidate needs a structural difference")
+    require(len(differences) == len(set(differences)), "choice-authorship CDP candidates cannot be cosmetic duplicates")
+    require(cdp.get("unknown_branch_preserved") is True, "choice-authorship CDP must preserve an unknown branch")
+    require(cdp.get("canonicalized") is False, "CDP cannot self-canonicalize")
+    require(any(candidate.get("candidate_id") == "cdp-unknown-possibility" for candidate in candidates), "example must contain an explicit unknown possibility")
+    require(all(candidate.get("proof_state") == "hypothesis" and candidate.get("canonical") is False for candidate in candidates), "CDP candidate families must remain non-canonical hypotheses")
+
+    consent = record.get("human_consent", {})
+    authorship_status = record.get("authorship_status")
+    action = record.get("action_authority", {})
+    if authorship_status in {"human-endorsed", "authored-choice-candidate"} or action.get("authorized") is True:
+        require(consent.get("response") == "endorse", "endorsed/authored action requires explicit human endorsement")
+        require(consent.get("explicitly_human_supplied") is True, "human consent cannot be inferred by the system")
+    require(action.get("authority_holder") == "human", "action authority cannot be assigned to a renter or model")
+
+    convergence = record.get("convergence", {})
+    if convergence.get("canonical") is True:
+        require(convergence.get("decision") == "Accepted", "only CCP Accepted may be represented as canonical")
+        require(convergence.get("runtime_execution_proven") is True, "canonical CCP state requires a runtime execution receipt")
+
+    skill_manifest = load_json("skills/core/kpgs-human-choice-authorship/skill.json")
+    require(skill_manifest.get("state") == "draft", "human choice skill must remain draft while this work is POC and license status is unresolved")
+    require(skill_manifest.get("provenance", {}).get("commit") is None if False else True, "placeholder")
+    sources = skill_manifest.get("provenance", {}).get("sources", [])
+    project_jennifer = next((source for source in sources if source.get("ref") == "RobynAwesome/Project-Jennifer"), None)
+    require(project_jennifer is not None, "human choice skill must preserve Project Jennifer provenance")
+    require(project_jennifer.get("commit") == "5328a8449bad509150f73fe9aafeabc6c17c983b", "Project Jennifer provenance must be pinned to the reviewed revision")
 
 
 def validate_realtime() -> None:
@@ -188,10 +256,11 @@ def main() -> None:
     validate_estate()
     validate_evidence()
     validate_skills()
+    validate_human_choice_authorship()
     validate_realtime()
     validate_pwa()
     print("KPGS-VNEXT PASS: governance/runtime-facing contracts are structurally coherent.")
-    print("Validated: capability leases, DNS estate seed, evidence, governed skills, realtime recovery, adaptive PWA profile.")
+    print("Validated: capability leases, DNS estate seed, evidence, governed skills, human choice authorship, realtime recovery, adaptive PWA profile.")
 
 
 if __name__ == "__main__":

--- a/governance/kpgs-vnext/validate_contracts.py
+++ b/governance/kpgs-vnext/validate_contracts.py
@@ -160,6 +160,7 @@ def validate_skills() -> None:
 def validate_human_choice_authorship() -> None:
     schema = load_json("human-choice-authorship/choice-authorship-record.schema.json")
     record = load_json("human-choice-authorship/example.choice-authorship.json")
+    build_spec = load_json("agent-governance/specs/human-choice-authorship-poc.json")
 
     validate_schema(
         schema,
@@ -180,6 +181,11 @@ def validate_human_choice_authorship() -> None:
         },
     )
 
+    candidate_schema = schema["properties"]["cdp"]["properties"]["candidate_families"]
+    unknown_id = candidate_schema.get("contains", {}).get("properties", {}).get("candidate_id", {}).get("const")
+    require(unknown_id == "cdp-unknown-possibility", "choice-authorship schema must structurally require an explicit CDP unknown branch")
+    require(bool(schema.get("allOf")), "choice-authorship schema must encode consent and runtime hard gates")
+
     require(record.get("subject_authority") == "human", "personal choice authority must remain human")
 
     root_candidates = record.get("root_algorithm_candidates", [])
@@ -197,19 +203,36 @@ def validate_human_choice_authorship() -> None:
     require(cdp.get("canonicalized") is False, "CDP cannot self-canonicalize")
     require(any(candidate.get("candidate_id") == "cdp-unknown-possibility" for candidate in candidates), "example must contain an explicit unknown possibility")
     require(all(candidate.get("proof_state") == "hypothesis" and candidate.get("canonical") is False for candidate in candidates), "CDP candidate families must remain non-canonical hypotheses")
+    if cdp.get("runtime_execution_proven") is True:
+        require(bool(cdp.get("runtime_receipt_ref")), "proven CDP runtime execution requires a receipt reference")
 
     consent = record.get("human_consent", {})
+    consent_response = consent.get("response")
     authorship_status = record.get("authorship_status")
     action = record.get("action_authority", {})
-    if authorship_status in {"human-endorsed", "authored-choice-candidate"} or action.get("authorized") is True:
-        require(consent.get("response") == "endorse", "endorsed/authored action requires explicit human endorsement")
-        require(consent.get("explicitly_human_supplied") is True, "human consent cannot be inferred by the system")
+
+    if consent_response in {"endorse", "reject", "hold"}:
+        require(consent.get("explicitly_human_supplied") is True, "non-empty human consent cannot be inferred by the system")
+        require(bool(consent.get("human_statement_ref")), "human consent requires a current human statement reference")
+    if authorship_status in {"human-endorsed", "authored-choice-candidate"}:
+        require(consent_response == "endorse", "endorsed/authored state requires human endorsement")
+    if authorship_status == "human-rejected":
+        require(consent_response == "reject", "human-rejected state requires explicit rejection")
+    if authorship_status == "human-held":
+        require(consent_response == "hold", "human-held state requires explicit hold")
+    if action.get("authorized") is True:
+        require(consent_response == "endorse", "authorized personal action requires human endorsement")
     require(action.get("authority_holder") == "human", "action authority cannot be assigned to a renter or model")
 
     convergence = record.get("convergence", {})
+    if convergence.get("runtime_execution_proven") is True:
+        require(bool(convergence.get("receipt_ref")), "proven CCP runtime execution requires a receipt reference")
     if convergence.get("canonical") is True:
         require(convergence.get("decision") == "Accepted", "only CCP Accepted may be represented as canonical")
         require(convergence.get("runtime_execution_proven") is True, "canonical CCP state requires a runtime execution receipt")
+    if convergence.get("decision") == "not-requested":
+        require(convergence.get("canonical") is False, "CCP cannot be canonical when convergence was not requested")
+        require(convergence.get("runtime_execution_proven") is False, "CCP execution cannot be proven when convergence was not requested")
 
     skill_manifest = load_json("skills/core/kpgs-human-choice-authorship/skill.json")
     require(skill_manifest.get("state") == "draft", "human choice skill must remain draft while this work is POC and license status is unresolved")
@@ -217,6 +240,16 @@ def validate_human_choice_authorship() -> None:
     project_jennifer = next((source for source in sources if source.get("ref") == "RobynAwesome/Project-Jennifer"), None)
     require(project_jennifer is not None, "human choice skill must preserve Project Jennifer provenance")
     require(project_jennifer.get("commit") == "5328a8449bad509150f73fe9aafeabc6c17c983b", "Project Jennifer provenance must be pinned to the reviewed revision")
+
+    require(build_spec.get("spec_id") == "kpgs-human-choice-authorship-poc-v0.1", "choice-authorship build spec identity mismatch")
+    require(build_spec.get("risk_class") == "R2", "identity-sensitive choice-authorship POC must retain its declared R2 risk class")
+    require(build_spec.get("lifecycle_state") == "draft", "choice-authorship build spec must remain draft until executable validation exists")
+    require(49 in build_spec.get("related_issues", []), "choice-authorship build spec must link issue #49")
+    criteria = build_spec.get("acceptance_criteria", [])
+    criterion_ids = [criterion.get("id") for criterion in criteria]
+    require(len(criterion_ids) == len(set(criterion_ids)), "choice-authorship acceptance criterion IDs must be unique")
+    plan_ids = {item.get("criterion_id") for item in build_spec.get("verification_plan", [])}
+    require(set(criterion_ids) <= plan_ids, "choice-authorship verification plan must cover every acceptance criterion")
 
 
 def validate_realtime() -> None:


### PR DESCRIPTION
Closes #49 when all acceptance gates are proven.

## What this PR does

Introduces a governed POC for **bounded human authorship inside conditions that were not fully chosen**. It composes existing Project Jennifer RIVM/CDP/CCP semantics without redefining them and keeps personal consent/action authority outside all model, renter and conceptual-protocol authority.

The governing question is:

> **Now that I can see what shaped this desire, do I still consent to carrying it?**

## Validated protocol ordering

```text
conditions / context
→ RIVM claim + source + agency membrane
→ CDP: 2+ distinct non-canonical hypotheses + UNKNOWN
→ CEEP / POC-vs-FOC evidence
→ optional CCP conceptual convergence
→ explicit HUMAN CONSENT
→ separate HUMAN ACTION AUTHORITY
→ consequence / re-evaluation
```

The ordering matters: human preference cannot retroactively decide which hypothesis counts as true. CCP may remain `Refine` and the human can still choose under explicit uncertainty. **Conceptual confidence and personal authority are separate axes.**

## Source validation

Pinned Project Jennifer reference: `5328a8449bad509150f73fe9aafeabc6c17c983b`.

Reviewed source boundaries:
- RIVM is a membrane, not sovereign human authority.
- CDP widens into 2+ structurally distinct non-canonical hypotheses and preserves unknowns.
- CCP owns evidence-bearing conceptual convergence; only `Accepted` is canonical in the current implementation.
- CCP conceptual canon is still **not** human life/action authority.

## Added contracts

- `governance/kpgs-vnext/human-choice-authorship/README.md` — triangle model, recursive flow, proposed root-algorithm definition, state-of-mind and human-authority boundaries.
- `choice-authorship-record.schema.json` — claim/source separation, root-algorithm hypothesis state, mandatory CDP unknown branch, explicit consent receipt rules, CCP receipt rules and separate action authority.
- `example.choice-authorship.json` — deliberately non-identifying generic example.
- `skills/core/kpgs-human-choice-authorship/{SKILL.md,skill.json}` — governed portable skill POC.
- `agent-governance/specs/human-choice-authorship-poc.json` — specification-first R2 acceptance/rollback contract.
- `validate_contracts.py` — structural checks for authority, divergence, unknowns, consent, convergence, source pin and specification coverage.

## Hard laws

This PR must not permit inferred consent, root-algorithm promotion without evidence, single-candidate fake divergence, suppression of the unknown branch, CDP self-canonicalization, unreceipted CCP execution/canon, preference retroactively defining truth, state-salience-to-truth promotion, hidden identity assignment, or AI/renter capture of human action authority.

## Validation state

**Project Jennifer source semantics:** PASS by direct source inspection.

**Dedicated KPGS executable contract validation:** **PASS** on head `62fa28ab5e2a5b8ed07f9c44202d9e3a5e8223ea` via `KPGS vNext Contract Gate` run `32034803112`. The job passed Phase 0 truth contracts, governance / human-choice-authorship contracts and validator compilation.

**Repository CI:** **PASS** on the same head via `Kopano CI Pipeline` run `32034803104`.

The former Actions execution blocker #48 is therefore closed as recovered.

**Canonical promotion:** HOLD. The POC remains draft because #47 still leaves repository license/provenance policy unresolved, and `root algorithm` remains an engineering/conceptual POC rather than a claimed universal psychological or scientific law.