### PR TITLE
[Governance] KPGS license decision + contribution provenance gate

### DIFF
--- a/.github/workflows/kpgs-vnext-phase0-gate.yml
+++ b/.github/workflows/kpgs-vnext-phase0-gate.yml
@@ -4,10 +4,16 @@ on:
   push:
     paths:
       - "governance/kpgs-vnext/**"
+      - "CONTRIBUTING.md"
+      - "THIRD_PARTY_NOTICES.md"
+      - "LICENSE"
       - ".github/workflows/kpgs-vnext-phase0-gate.yml"
   pull_request:
     paths:
       - "governance/kpgs-vnext/**"
+      - "CONTRIBUTING.md"
+      - "THIRD_PARTY_NOTICES.md"
+      - "LICENSE"
       - ".github/workflows/kpgs-vnext-phase0-gate.yml"
   workflow_dispatch:
 
@@ -39,8 +45,12 @@ jobs:
       - name: Validate governance substrate contracts
         run: python governance/kpgs-vnext/validate_contracts.py
 
+      - name: Validate license and provenance policy
+        run: python governance/kpgs-vnext/licensing/validate_license_policy.py
+
       - name: Compile validators
         run: >-
           python -m py_compile
           governance/kpgs-vnext/validate_phase0.py
           governance/kpgs-vnext/validate_contracts.py
+          governance/kpgs-vnext/licensing/validate_license_policy.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# Contributing to Introduction-to-MCP
+
+This repository is governed by KPGS provenance and promotion rules.
+
+## Current license status
+
+The repository-wide license decision is **pending explicit human-owner approval** under issue #47. Do not assume that absence of a root `LICENSE` file grants reuse permission, and do not label repository-authored material with a repository-wide SPDX identifier until the decision record authorizes it.
+
+See `governance/kpgs-vnext/licensing/license-decision.json` and `governance/kpgs-vnext/licensing/PROVENANCE_AND_LICENSE_POLICY.md`.
+
+## Contribution requirements
+
+For original contributions, identify the contributor and affected paths and confirm that the contribution does not knowingly include material the contributor lacks permission to submit.
+
+For adapted, imported, vendored, generated or fork-derived material, include provenance sufficient to identify:
+
+- source/upstream project;
+- exact version/commit where practical;
+- source relationship (`reference`, `adaptation`, `import`, `vendor`, `generated`);
+- upstream license or explicit `unknown`;
+- attribution/NOTICE obligations;
+- local modifications;
+- security review state for executable material.
+
+## Promotion rule
+
+Functional correctness alone does not make third-party material canonical. If source, license, compatibility, attribution or authorization is unresolved, the artifact remains `reference`, `pending` or `unknown` and must not be promoted to `validated` / `approved` on licensing grounds.
+
+## Generated material
+
+Generated code/docs/assets must preserve source lineage and human review. Generation never erases restrictions inherited from source code, prompts containing protected material, input assets or external dependencies.
+
+## Third-party notices
+
+When attribution is required, update `THIRD_PARTY_NOTICES.md` and any source-level notices required by the upstream license.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,24 @@
+# Third-Party Notices
+
+This file records third-party attribution required by material admitted into `RobynAwesome/Introduction-to-MCP`.
+
+The presence of an entry here does not replace source-level notices or license files required by an upstream license.
+
+## Registry
+
+No new third-party attribution entry is declared by issue #47 itself.
+
+For future entries use:
+
+```text
+Component / artifact:
+Upstream project / owner:
+Source reference:
+Version / commit:
+Upstream license:
+Required notice / attribution:
+Local consuming paths:
+Provenance evidence:
+```
+
+Unknown attribution obligations block canonical import until resolved.

--- a/governance/kpgs-vnext/licensing/PROVENANCE_AND_LICENSE_POLICY.md
+++ b/governance/kpgs-vnext/licensing/PROVENANCE_AND_LICENSE_POLICY.md
@@ -1,0 +1,125 @@
+# KPGS Repository Provenance and License Policy
+
+Status: **PROPOSED GOVERNANCE POLICY**  
+Issue: #47  
+Repository: `RobynAwesome/Introduction-to-MCP`
+
+## 1. Current legal state
+
+The repository currently has no root `LICENSE` file and no canonical repository-wide SPDX identifier. KPGS therefore treats the repository license state as **undecided** until the human repository owner explicitly chooses a license model.
+
+The machine-readable source of this status is:
+
+`governance/kpgs-vnext/licensing/license-decision.json`
+
+A recommendation is not authorization. No agent, model, renter, CI process or maintainer automation may convert `RECOMMENDED_NOT_AUTHORIZED` into a repository license.
+
+## 2. Human decision boundary
+
+The repository owner must explicitly choose one of the supported policy states before repository-authored material can inherit a canonical repository license:
+
+- `MIT`
+- `Apache-2.0`
+- `PROPRIETARY`
+- `UNLICENSED`
+- `PATH_SPECIFIC`
+
+If `PATH_SPECIFIC` is chosen, each governed path must expose its own license evidence and SPDX/proprietary state. A path-specific license may not silently overwrite an upstream third-party license.
+
+## 3. Contribution provenance
+
+Every adapted, imported, vendored, copied, generated or fork-derived artifact admitted into canonical KPGS surfaces must preserve:
+
+- origin repository or source reference;
+- exact upstream commit/tag/version when available;
+- relationship: `reference | inspiration | adaptation | import | vendor | generated`;
+- upstream license/SPDX or explicit `unknown`;
+- attribution/NOTICE requirements;
+- local human reviewer;
+- compatibility decision and evidence reference;
+- modifications made locally;
+- security review state where executable code is involved.
+
+Unknown provenance is a promotion blocker, not permission to infer a license.
+
+## 4. Import / compatibility law
+
+### Reference-only
+
+Material may be studied as `reference` when no code/assets are imported. Reference status does not grant permission to copy unlicensed or incompatible material.
+
+### Adaptation / import / vendor
+
+Before canonical admission:
+
+1. upstream source must be identified;
+2. upstream license must be known or explicit permission must exist;
+3. required attribution/NOTICE must be preserved;
+4. target path license must be known;
+5. compatibility must be evaluated against the target path;
+6. executable material must pass security and governance review;
+7. the resulting manifest must retain source lineage.
+
+While this repository's root license decision remains pending, KPGS must not claim deterministic repository-wide compatibility for new adapted/imported code. Such artifacts remain `pending`, `reference`, or separately licensed by path.
+
+## 5. Existing third-party material
+
+A later repository license declaration applies only where the repository owner has the legal authority to license the material.
+
+It must not:
+
+- overwrite an existing third-party license;
+- remove copyright notices;
+- remove required attribution;
+- convert noncommercial/research-only material into commercial material;
+- convert unlicensed reference material into reusable code;
+- imply ownership of upstream work.
+
+## 6. NOTICE / attribution
+
+Where an upstream license or permission requires attribution, preserve it in the nearest appropriate source file and/or `THIRD_PARTY_NOTICES.md`.
+
+The notice record should include:
+
+- component/artifact name;
+- upstream owner/project;
+- source URL/reference;
+- version/commit;
+- upstream license;
+- required notice text or attribution reference;
+- local path(s) consuming the material.
+
+KPGS provenance manifests remain required even when the upstream license does not mandate a NOTICE file.
+
+## 7. Generated code and assets
+
+Generated material must record, when applicable:
+
+- generating tool/provider;
+- human reviewer;
+- prompt/specification or governing task reference;
+- source inputs/assets used;
+- known third-party dependencies or source lineage;
+- rights/license status for incorporated source material;
+- evidence that the generated artifact does not merely reproduce restricted material.
+
+Generation does not erase copyright, license, privacy or attribution constraints inherited from its inputs.
+
+## 8. KPGS skill promotion gate
+
+A skill manifest may move to `license_status: verified-compatible` only when all of the following are true:
+
+1. its origin/source lineage is explicit;
+2. the relevant source and target license states are known;
+3. compatibility has been evaluated;
+4. required attribution/NOTICE is present;
+5. no conflicting upstream restriction is hidden;
+6. the repository/path license decision is human-authorized where required.
+
+If any element is unknown, the skill remains `pending` or `unknown` and cannot be promoted to `validated` / `approved` solely on functional CI success.
+
+## 9. Recommendation currently on record
+
+`MIT` is recorded as the current **recommendation**, based on existing MIT-licensed skill packaging already present elsewhere in the governed ecosystem. This is evidence of an ecosystem pattern, not a license grant for this repository.
+
+Canonical license state remains `AWAITING_HUMAN_DECISION` until the owner explicitly authorizes a policy.

--- a/governance/kpgs-vnext/licensing/license-decision.json
+++ b/governance/kpgs-vnext/licensing/license-decision.json
@@ -1,0 +1,32 @@
+{
+  "schema_version": "1.0",
+  "repository": "RobynAwesome/Introduction-to-MCP",
+  "issue": 47,
+  "decision_status": "AWAITING_HUMAN_DECISION",
+  "current_repository_state": {
+    "root_license_file_present": false,
+    "canonical_spdx": null,
+    "repository_wide_license_claim_allowed": false
+  },
+  "recommendation": {
+    "spdx": "MIT",
+    "status": "RECOMMENDED_NOT_AUTHORIZED",
+    "basis": [
+      "Existing FivesArena skill packaging in the user's governed ecosystem declares MIT.",
+      "Existing KRRababalela skill packaging in the user's governed ecosystem declares MIT.",
+      "A permissive single SPDX identifier would simplify KPGS skill/package compatibility checks if the human owner chooses it."
+    ],
+    "non_claim": "This recommendation does not license this repository and must not be treated as owner consent."
+  },
+  "allowed_human_decisions": [
+    "MIT",
+    "Apache-2.0",
+    "PROPRIETARY",
+    "UNLICENSED",
+    "PATH_SPECIFIC"
+  ],
+  "promotion_rule": "No repository-authored artifact may move from license_status unknown/pending to verified-compatible solely from this recommendation. A current human-approved decision and corresponding repository/path license evidence are required.",
+  "third_party_rule": "Existing or imported third-party licenses must be preserved exactly and may never be overwritten by a repository-wide declaration.",
+  "generated_material_rule": "Generated code, documentation and assets require provenance and human review; generation does not erase upstream rights, attribution duties or source-license constraints.",
+  "updated_at": "2026-08-17T15:47:00+02:00"
+}

--- a/governance/kpgs-vnext/licensing/validate_license_policy.py
+++ b/governance/kpgs-vnext/licensing/validate_license_policy.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Structural governance gate for KPGS repository licensing and provenance policy."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO = HERE.parents[2]
+DECISION = HERE / "license-decision.json"
+POLICY = HERE / "PROVENANCE_AND_LICENSE_POLICY.md"
+CONTRIBUTING = REPO / "CONTRIBUTING.md"
+NOTICES = REPO / "THIRD_PARTY_NOTICES.md"
+LICENSE = REPO / "LICENSE"
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise SystemExit(f"KPGS-LICENSE FAIL: {message}")
+
+
+def main() -> None:
+    decision = json.loads(DECISION.read_text(encoding="utf-8"))
+
+    require(decision.get("repository") == "RobynAwesome/Introduction-to-MCP", "decision must bind to the canonical repository")
+    require(decision.get("issue") == 47, "decision must bind to governance issue #47")
+    require(POLICY.is_file(), "provenance/license policy document is missing")
+    require(CONTRIBUTING.is_file(), "CONTRIBUTING.md is missing")
+    require(NOTICES.is_file(), "THIRD_PARTY_NOTICES.md is missing")
+
+    status = decision.get("decision_status")
+    require(status in {"AWAITING_HUMAN_DECISION", "HUMAN_APPROVED"}, "unsupported decision_status")
+
+    current = decision.get("current_repository_state", {})
+    recommendation = decision.get("recommendation", {})
+    promotion_rule = decision.get("promotion_rule", "")
+    third_party_rule = decision.get("third_party_rule", "")
+
+    require("human" in promotion_rule.lower(), "promotion rule must require human authorization")
+    require("third-party" in third_party_rule.lower() or "third party" in third_party_rule.lower(), "third-party preservation rule is missing")
+
+    if status == "AWAITING_HUMAN_DECISION":
+        require(current.get("canonical_spdx") is None, "pending state cannot claim a canonical SPDX license")
+        require(current.get("repository_wide_license_claim_allowed") is False, "pending state cannot allow repository-wide licensing claims")
+        require(recommendation.get("status") == "RECOMMENDED_NOT_AUTHORIZED", "recommendation must remain non-authoritative while pending")
+        require(not LICENSE.exists(), "root LICENSE appeared while decision record still says awaiting human decision")
+    else:
+        require(recommendation.get("status") != "RECOMMENDED_NOT_AUTHORIZED" or current.get("canonical_spdx") is not None, "human-approved state must carry an explicit legal outcome")
+        require(current.get("repository_wide_license_claim_allowed") in {True, False}, "approved state must explicitly declare repository-wide claim authority")
+        if current.get("canonical_spdx") in {"MIT", "Apache-2.0"}:
+            require(LICENSE.is_file(), "approved open-source SPDX state requires a root LICENSE file")
+
+    contributing = CONTRIBUTING.read_text(encoding="utf-8")
+    require("provenance" in contributing.lower(), "contribution policy must preserve provenance")
+    require("license" in contributing.lower(), "contribution policy must state license handling")
+
+    policy = POLICY.read_text(encoding="utf-8")
+    for phrase in ("Existing third-party material", "Generated code and assets", "KPGS skill promotion gate"):
+        require(phrase in policy, f"policy missing required section: {phrase}")
+
+    print("KPGS-LICENSE PASS: repository license state is explicit and provenance promotion rules are structurally governed.")
+    print(f"Decision status: {status}; recommendation: {recommendation.get('spdx')} ({recommendation.get('status')}).")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Implements the non-destructive engineering portion of #47 without silently choosing a repository license for the human owner.

## Current decision state

`AWAITING_HUMAN_DECISION`

The repo still has no root `LICENSE`; this PR does **not** create one and does not claim a canonical SPDX identifier.

## Recommendation recorded, not authorized

`MIT` is recorded as `RECOMMENDED_NOT_AUTHORIZED`, based on existing MIT-licensed skill packaging already used in the governed FivesArena/KRR ecosystem. That precedent is useful evidence, but it is not authority to license this entire repository.

## Added governance

- `governance/kpgs-vnext/licensing/license-decision.json`
  - explicit legal state
  - allowed human decision states
  - recommendation vs authorization separation
  - promotion block while undecided
- `governance/kpgs-vnext/licensing/PROVENANCE_AND_LICENSE_POLICY.md`
  - reference/adaptation/import/vendor rules
  - path-specific licensing rules
  - third-party license preservation
  - NOTICE/attribution requirements
  - generated material provenance
  - KPGS skill promotion gate
- `CONTRIBUTING.md`
  - provenance requirements for original, adapted, imported, generated and fork-derived contributions
- `THIRD_PARTY_NOTICES.md`
  - attribution registry/template
- `governance/kpgs-vnext/licensing/validate_license_policy.py`
  - blocks repository-wide SPDX claims while human decision is pending
  - detects inconsistent root LICENSE state
  - requires root LICENSE evidence when an approved MIT/Apache state is later declared
  - validates provenance/NOTICE policy presence
- KPGS vNext workflow now executes and compiles the licensing validator.

## Human decision still required

This PR deliberately does not close #47. The owner must explicitly choose the canonical legal model (`MIT`, `Apache-2.0`, `PROPRIETARY`, `UNLICENSED`, or `PATH_SPECIFIC`) before the decision record can move to `HUMAN_APPROVED` and repository-authored skill manifests can claim verified compatibility on that basis.

## Safety invariant

**Recommendation != authorization. CI success != legal consent. Third-party licenses are never overwritten by a later repository-wide declaration.**