### PR TITLE
[POC] KPGS Frontier Harness v0.2 — Snowflake governed adapter

### DIFF
--- a/governance/kpgs-vnext/agent-governance/specs/frontier-harness-snowflake-v0.2.json
+++ b/governance/kpgs-vnext/agent-governance/specs/frontier-harness-snowflake-v0.2.json
@@ -1,0 +1,61 @@
+{
+  "spec_id": "kpgs-frontier-harness-snowflake-v0.2",
+  "title": "KPGS Frontier Harness v0.2 — Snowflake Live-Capable Evidence Adapter",
+  "outcome": "Promote the v0.1 Snowflake prepared analytical copy into a fail-closed SQL API adapter that can perform a real telemetry append only when KPGS supplies an explicit short-lived capability lease and an external secret reference.",
+  "scope": {
+    "included": [
+      "Implement dependency-free Snowflake SQL API request preparation",
+      "Require an exact snowflake.telemetry.append capability and resource scope",
+      "Reject expired or wrong-spec capability leases",
+      "Resolve authentication only through external secret references",
+      "Use bind variables for all telemetry values",
+      "Reject semantic input, raw prompts, provider response text and private payload fields",
+      "Emit secret-free request and execution receipts",
+      "Add an executable local governance gate"
+    ],
+    "excluded": [
+      "Storing Snowflake credentials in GitHub",
+      "Treating Snowflake as canonical sovereign state",
+      "Sending semantic input or private payloads to the telemetry table",
+      "Automatically provisioning production Snowflake roles or network policies",
+      "Claiming a successful live Snowflake write without an execution receipt"
+    ]
+  },
+  "interfaces": [
+    {"name": "KPGS capability lease", "contract": "Exact append capability, exact telemetry table scope, current validity window, governing spec reference and one external secret-provider reference are mandatory.", "version": "capability-lease.schema.json"},
+    {"name": "Snowflake SQL API", "contract": "POST /api/v2/statements with bearer authentication, JSON request body and bind variables; response produces a secret-free local execution receipt.", "version": "v2"},
+    {"name": "Snowflake evidence table", "contract": "KPGS_FRONTIER.EVIDENCE.FRONTIER_TELEMETRY stores metadata and digests only and is never canonical application state.", "version": "kpgs.frontier_telemetry.v1"}
+  ],
+  "constraints": [
+    "Snowflake remains an analytical copy, never local sovereign state.",
+    "No token, password, private key or OAuth secret may be committed.",
+    "A live request must fail closed without a currently valid capability lease.",
+    "A live request must fail closed if the secret reference cannot resolve.",
+    "Telemetry values must use SQL API bind variables rather than string interpolation.",
+    "Semantic input and private payload fields are forbidden at the adapter boundary.",
+    "A Snowflake response cannot overwrite the local KPGS receipt or provider evaluation."
+  ],
+  "acceptance_criteria": [
+    {"id": "SF-01", "statement": "The adapter cannot prepare a Snowflake request without an exact, currently valid governed capability lease.", "hard_gate": true, "verification_methods": ["unit", "integration"]},
+    {"id": "SF-02", "statement": "Authentication material remains external to the repository and request receipts contain no token.", "hard_gate": true, "verification_methods": ["security", "human-review"]},
+    {"id": "SF-03", "statement": "Telemetry values are bound and semantic/private fields are rejected before request creation.", "hard_gate": true, "verification_methods": ["unit", "security"]},
+    {"id": "SF-04", "statement": "The target remains KPGS_FRONTIER.EVIDENCE.FRONTIER_TELEMETRY and Snowflake is represented only as an analytical evidence copy.", "hard_gate": true, "verification_methods": ["schema", "human-review"]},
+    {"id": "SF-05", "statement": "The local gate executes without Snowflake credentials or network access and proves fail-closed behavior.", "hard_gate": false, "verification_methods": ["integration"]}
+  ],
+  "verification_plan": [
+    {"criterion_id": "SF-01", "evidence": "validate_snowflake_adapter.py proves valid scoped lease acceptance and expired lease rejection.", "command_or_procedure": "python governance/kpgs-vnext/frontier-harness/snowflake/validate_snowflake_adapter.py"},
+    {"criterion_id": "SF-02", "evidence": "lease.template.json contains only an env secret reference and safe receipts explicitly exclude secrets.", "command_or_procedure": "Review lease.template.json and sql_api_adapter.py."},
+    {"criterion_id": "SF-03", "evidence": "Prepared request uses eight SQL API bindings and the adapter rejects forbidden semantic/private keys.", "command_or_procedure": "Run validate_snowflake_adapter.py."},
+    {"criterion_id": "SF-04", "evidence": "RESOURCE_SCOPE and INSERT_SQL are pinned to KPGS_FRONTIER.EVIDENCE.FRONTIER_TELEMETRY.", "command_or_procedure": "Review sql_api_adapter.py and bootstrap.sql."},
+    {"criterion_id": "SF-05", "evidence": "Dependency-free gate executes with an in-memory lease fixture and does not invoke the network.", "command_or_procedure": "python governance/kpgs-vnext/frontier-harness/snowflake/validate_snowflake_adapter.py"}
+  ],
+  "rollback_plan": {
+    "trigger": "The adapter permits ambient authority, leaks semantic/private data, embeds a credential, or allows Snowflake to become canonical state.",
+    "procedure": "Revert the v0.2 commit or PR. The v0.1 prepared analytical-copy path remains intact and no production estate release depends on this adapter.",
+    "target_ref": "master@f5899e5ca958523f394c89c965d30a8649921f29"
+  },
+  "risk_class": "R2",
+  "required_capabilities": [{"capability": "snowflake.telemetry.append", "scope": "KPGS_FRONTIER.EVIDENCE.FRONTIER_TELEMETRY"}],
+  "lifecycle_state": "draft",
+  "related_issues": [46]
+}

--- a/governance/kpgs-vnext/frontier-harness/snowflake/README.md
+++ b/governance/kpgs-vnext/frontier-harness/snowflake/README.md
@@ -1,0 +1,44 @@
+# Snowflake v0.2 — Governed Evidence Adapter
+
+Status: **POC / live-capable / fail-closed**
+
+This promotes the Frontier Harness Snowflake path from a prepared row to a **live-capable SQL API adapter** without transferring canonical state to Snowflake.
+
+## Authority boundary
+
+```text
+KPGS governed telemetry row
+        |
+        v
+short-lived capability lease
+        |
+        +-- snowflake.telemetry.append
+        +-- KPGS_FRONTIER.EVIDENCE.FRONTIER_TELEMETRY
+        +-- external secret reference
+        |
+        v
+Snowflake SQL API adapter
+        |
+        v
+analytical/evidence copy only
+```
+
+The adapter rejects semantic input, raw prompts, provider response text and private payload fields before request preparation.
+
+## Authentication
+
+The repository stores **no credential**. A lease contains only a secret-provider reference such as `env://KPGS_SNOWFLAKE_PAT`. Supported SQL API token declarations are `PROGRAMMATIC_ACCESS_TOKEN`, `OAUTH`, and `KEYPAIR_JWT`.
+
+## Gate
+
+```bash
+python governance/kpgs-vnext/frontier-harness/snowflake/validate_snowflake_adapter.py
+```
+
+The gate performs no network request. It proves scoped-lease enforcement, expiry rejection, bind-variable request construction, semantic/private-field rejection, and secret-free receipts.
+
+## Promotion boundary
+
+A real Snowflake write is authorized only after `bootstrap.sql` has been applied, a least-privilege role can append to `FRONTIER_TELEMETRY`, KPGS issues a current short-lived lease bound to `kpgs-frontier-harness-snowflake-v0.2`, and the referenced external token resolves at runtime.
+
+Snowflake remains an analytical copy; the local KPGS receipt remains authoritative.

--- a/governance/kpgs-vnext/frontier-harness/snowflake/lease.template.json
+++ b/governance/kpgs-vnext/frontier-harness/snowflake/lease.template.json
@@ -1,0 +1,20 @@
+{
+  "lease_id": "lease_REPLACE_BEFORE_USE",
+  "subject": {"id": "frontier-snowflake-adapter", "kind": "adapter"},
+  "tenant_id": "kopano-labs",
+  "domain_id": "Introduction-to-MCP",
+  "task_id": "frontier-snowflake-v0.2",
+  "capabilities": [
+    {
+      "name": "snowflake.telemetry.append",
+      "resource_scope": "KPGS_FRONTIER.EVIDENCE.FRONTIER_TELEMETRY",
+      "constraints": ["append-only", "metadata-and-digests-only", "no-semantic-input", "no-private-payload"]
+    }
+  ],
+  "issued_at": "1970-01-01T00:00:00Z",
+  "expires_at": "1970-01-01T00:00:01Z",
+  "policy_decision_ref": "policy://REPLACE_BEFORE_USE",
+  "governing_spec_ref": "kpgs-frontier-harness-snowflake-v0.2",
+  "secret_provider_refs": ["env://KPGS_SNOWFLAKE_PAT"],
+  "audit": {"correlation_id": "REPLACE_BEFORE_USE", "evidence_ref": "evidence://REPLACE_BEFORE_USE"}
+}

--- a/governance/kpgs-vnext/frontier-harness/snowflake/sql_api_adapter.py
+++ b/governance/kpgs-vnext/frontier-harness/snowflake/sql_api_adapter.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Governed Snowflake SQL API adapter for KPGS Frontier Harness v0.2."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+GOVERNING_SPEC = "kpgs-frontier-harness-snowflake-v0.2"
+REQUIRED_CAPABILITY = "snowflake.telemetry.append"
+RESOURCE_SCOPE = "KPGS_FRONTIER.EVIDENCE.FRONTIER_TELEMETRY"
+ALLOWED_TOKEN_TYPES = {"OAUTH", "KEYPAIR_JWT", "PROGRAMMATIC_ACCESS_TOKEN"}
+FORBIDDEN_TELEMETRY_KEYS = {"semantic_input", "private_payload", "raw_input", "provider_output", "prompt", "response_text"}
+ACCOUNT_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+INSERT_SQL = """INSERT INTO KPGS_FRONTIER.EVIDENCE.FRONTIER_TELEMETRY
+  (EVENT_SCHEMA, REQUEST_ID, SOURCE_PROVIDER, CAPABILITY, SELECTED_PROVIDER,
+   OUTPUT_DIGEST, DATA_CLASSIFICATION, EXTERNAL_PROCESSING_ALLOWED)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)"""
+
+
+class GovernanceError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class SnowflakeTarget:
+    account_identifier: str
+    warehouse: str
+    role: str
+    database: str = "KPGS_FRONTIER"
+    schema: str = "EVIDENCE"
+
+    def endpoint(self) -> str:
+        if not ACCOUNT_RE.fullmatch(self.account_identifier):
+            raise GovernanceError("invalid Snowflake account identifier")
+        return f"https://{self.account_identifier}.snowflakecomputing.com/api/v2/statements"
+
+
+@dataclass(frozen=True)
+class PreparedInsert:
+    request_id: str
+    endpoint: str
+    body: dict[str, Any]
+    token_type: str
+    secret_ref: str
+
+    def safe_receipt(self) -> dict[str, Any]:
+        return {
+            "schema_version": "kpgs.snowflake_request_receipt.v1",
+            "request_id": self.request_id,
+            "endpoint": self.endpoint,
+            "binding_count": len(self.body["bindings"]),
+            "token_type": self.token_type,
+            "secret_ref": self.secret_ref,
+            "contains_secret": False,
+        }
+
+
+def _parse_time(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        raise GovernanceError("lease timestamps must include timezone")
+    return parsed.astimezone(timezone.utc)
+
+
+def validate_lease(lease: dict[str, Any], *, now: datetime | None = None) -> None:
+    current = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    if lease.get("governing_spec_ref") != GOVERNING_SPEC:
+        raise GovernanceError("lease is not bound to the Snowflake v0.2 governing spec")
+    subject = lease.get("subject") or {}
+    if subject.get("kind") not in {"adapter", "service", "renter"}:
+        raise GovernanceError("Snowflake capability must be leased to an adapter/service/renter")
+    capabilities = lease.get("capabilities") or []
+    permitted = any(
+        item.get("name") == REQUIRED_CAPABILITY and item.get("resource_scope") == RESOURCE_SCOPE
+        for item in capabilities
+    )
+    if not permitted:
+        raise GovernanceError("lease does not permit governed Snowflake telemetry append")
+    issued = _parse_time(str(lease.get("issued_at", "")))
+    expires = _parse_time(str(lease.get("expires_at", "")))
+    if not (issued <= current < expires):
+        raise GovernanceError("capability lease is not currently valid")
+    secret_refs = lease.get("secret_provider_refs") or []
+    if len(secret_refs) != 1 or not str(secret_refs[0]).startswith("env://"):
+        raise GovernanceError("v0.2 requires exactly one env:// external secret reference")
+
+
+def resolve_env_secret(secret_ref: str, env: dict[str, str] | None = None) -> str:
+    name = secret_ref.removeprefix("env://")
+    if not re.fullmatch(r"[A-Z][A-Z0-9_]{2,127}", name):
+        raise GovernanceError("invalid env secret reference")
+    source = env if env is not None else os.environ
+    token = source.get(name)
+    if not token:
+        raise GovernanceError(f"secret provider did not resolve {secret_ref}")
+    return token
+
+
+def _binding(value: Any) -> dict[str, str]:
+    if isinstance(value, bool):
+        return {"type": "BOOLEAN", "value": "true" if value else "false"}
+    return {"type": "TEXT", "value": str(value)}
+
+
+def prepare_telemetry_insert(row: dict[str, Any], lease: dict[str, Any], target: SnowflakeTarget, *, token_type: str = "PROGRAMMATIC_ACCESS_TOKEN", now: datetime | None = None) -> PreparedInsert:
+    validate_lease(lease, now=now)
+    if token_type not in ALLOWED_TOKEN_TYPES:
+        raise GovernanceError("unsupported Snowflake token type")
+    leaked = FORBIDDEN_TELEMETRY_KEYS.intersection(row)
+    if leaked:
+        raise GovernanceError(f"forbidden semantic/private fields in telemetry row: {sorted(leaked)}")
+    columns = ["event_schema", "request_id", "source_provider", "capability", "selected_provider", "output_digest", "data_classification", "external_processing_allowed"]
+    missing = [name for name in columns if name not in row]
+    if missing:
+        raise GovernanceError(f"telemetry row missing required fields: {missing}")
+    if row["event_schema"] != "kpgs.frontier_telemetry.v1":
+        raise GovernanceError("unexpected telemetry schema")
+    bindings = {str(i): _binding(row[name]) for i, name in enumerate(columns, start=1)}
+    body = {
+        "statement": INSERT_SQL,
+        "timeout": 20,
+        "database": target.database,
+        "schema": target.schema,
+        "warehouse": target.warehouse,
+        "role": target.role,
+        "bindings": bindings,
+        "parameters": {"QUERY_TAG": f"kpgs-frontier:{row['request_id']}"},
+    }
+    return PreparedInsert(str(row["request_id"]), target.endpoint(), body, token_type, str(lease["secret_provider_refs"][0]))
+
+
+def submit_prepared(prepared: PreparedInsert, *, secret_resolver: Callable[[str], str] = resolve_env_secret, opener: Callable[..., Any] = urllib.request.urlopen) -> dict[str, Any]:
+    token = secret_resolver(prepared.secret_ref)
+    url = f"{prepared.endpoint}?requestId={urllib.parse.quote(prepared.request_id, safe='')}"
+    payload = json.dumps(prepared.body, separators=(",", ":")).encode("utf-8")
+    request = urllib.request.Request(url, data=payload, method="POST", headers={
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "User-Agent": "KPGS-Frontier-Harness/0.2",
+        "X-Snowflake-Authorization-Token-Type": prepared.token_type,
+    })
+    try:
+        with opener(request, timeout=30) as response:
+            raw = response.read().decode("utf-8")
+            result = json.loads(raw) if raw else {}
+            return {"schema_version": "kpgs.snowflake_execution_receipt.v1", "request_id": prepared.request_id, "http_status": getattr(response, "status", 200), "statement_handle": result.get("statementHandle"), "code": result.get("code"), "message": result.get("message"), "contains_secret": False}
+    except urllib.error.HTTPError as exc:
+        raw = exc.read().decode("utf-8", errors="replace")
+        try:
+            detail = json.loads(raw)
+        except json.JSONDecodeError:
+            detail = {"message": raw[:500]}
+        return {"schema_version": "kpgs.snowflake_execution_receipt.v1", "request_id": prepared.request_id, "http_status": exc.code, "statement_handle": detail.get("statementHandle"), "code": detail.get("code"), "message": detail.get("message"), "contains_secret": False}

--- a/governance/kpgs-vnext/frontier-harness/snowflake/sql_api_adapter.py
+++ b/governance/kpgs-vnext/frontier-harness/snowflake/sql_api_adapter.py
@@ -9,6 +9,7 @@ import re
 import urllib.error
 import urllib.parse
 import urllib.request
+import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Callable
@@ -51,10 +52,14 @@ class PreparedInsert:
     token_type: str
     secret_ref: str
 
+    def sql_request_id(self) -> str:
+        return str(uuid.uuid5(uuid.NAMESPACE_URL, f"kpgs:{self.request_id}"))
+
     def safe_receipt(self) -> dict[str, Any]:
         return {
             "schema_version": "kpgs.snowflake_request_receipt.v1",
             "request_id": self.request_id,
+            "sql_request_id": self.sql_request_id(),
             "endpoint": self.endpoint,
             "binding_count": len(self.body["bindings"]),
             "token_type": self.token_type,
@@ -64,7 +69,10 @@ class PreparedInsert:
 
 
 def _parse_time(value: str) -> datetime:
-    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise GovernanceError("invalid lease timestamp") from exc
     if parsed.tzinfo is None:
         raise GovernanceError("lease timestamps must include timezone")
     return parsed.astimezone(timezone.utc)
@@ -78,10 +86,7 @@ def validate_lease(lease: dict[str, Any], *, now: datetime | None = None) -> Non
     if subject.get("kind") not in {"adapter", "service", "renter"}:
         raise GovernanceError("Snowflake capability must be leased to an adapter/service/renter")
     capabilities = lease.get("capabilities") or []
-    permitted = any(
-        item.get("name") == REQUIRED_CAPABILITY and item.get("resource_scope") == RESOURCE_SCOPE
-        for item in capabilities
-    )
+    permitted = any(item.get("name") == REQUIRED_CAPABILITY and item.get("resource_scope") == RESOURCE_SCOPE for item in capabilities)
     if not permitted:
         raise GovernanceError("lease does not permit governed Snowflake telemetry append")
     issued = _parse_time(str(lease.get("issued_at", "")))
@@ -94,6 +99,8 @@ def validate_lease(lease: dict[str, Any], *, now: datetime | None = None) -> Non
 
 
 def resolve_env_secret(secret_ref: str, env: dict[str, str] | None = None) -> str:
+    if not secret_ref.startswith("env://"):
+        raise GovernanceError("unsupported secret provider reference")
     name = secret_ref.removeprefix("env://")
     if not re.fullmatch(r"[A-Z][A-Z0-9_]{2,127}", name):
         raise GovernanceError("invalid env secret reference")
@@ -132,14 +139,14 @@ def prepare_telemetry_insert(row: dict[str, Any], lease: dict[str, Any], target:
         "warehouse": target.warehouse,
         "role": target.role,
         "bindings": bindings,
-        "parameters": {"QUERY_TAG": f"kpgs-frontier:{row['request_id']}"},
+        "parameters": {"query_tag": f"kpgs-frontier:{row['request_id']}"},
     }
     return PreparedInsert(str(row["request_id"]), target.endpoint(), body, token_type, str(lease["secret_provider_refs"][0]))
 
 
 def submit_prepared(prepared: PreparedInsert, *, secret_resolver: Callable[[str], str] = resolve_env_secret, opener: Callable[..., Any] = urllib.request.urlopen) -> dict[str, Any]:
     token = secret_resolver(prepared.secret_ref)
-    url = f"{prepared.endpoint}?requestId={urllib.parse.quote(prepared.request_id, safe='')}"
+    url = f"{prepared.endpoint}?requestId={urllib.parse.quote(prepared.sql_request_id(), safe='')}"
     payload = json.dumps(prepared.body, separators=(",", ":")).encode("utf-8")
     request = urllib.request.Request(url, data=payload, method="POST", headers={
         "Authorization": f"Bearer {token}",
@@ -152,11 +159,43 @@ def submit_prepared(prepared: PreparedInsert, *, secret_resolver: Callable[[str]
         with opener(request, timeout=30) as response:
             raw = response.read().decode("utf-8")
             result = json.loads(raw) if raw else {}
-            return {"schema_version": "kpgs.snowflake_execution_receipt.v1", "request_id": prepared.request_id, "http_status": getattr(response, "status", 200), "statement_handle": result.get("statementHandle"), "code": result.get("code"), "message": result.get("message"), "contains_secret": False}
+            return {
+                "schema_version": "kpgs.snowflake_execution_receipt.v1",
+                "request_id": prepared.request_id,
+                "sql_request_id": prepared.sql_request_id(),
+                "http_status": getattr(response, "status", 200),
+                "statement_handle": result.get("statementHandle"),
+                "code": result.get("code"),
+                "message": result.get("message"),
+                "execution_state": "response-received",
+                "contains_secret": False,
+            }
     except urllib.error.HTTPError as exc:
         raw = exc.read().decode("utf-8", errors="replace")
         try:
             detail = json.loads(raw)
         except json.JSONDecodeError:
             detail = {"message": raw[:500]}
-        return {"schema_version": "kpgs.snowflake_execution_receipt.v1", "request_id": prepared.request_id, "http_status": exc.code, "statement_handle": detail.get("statementHandle"), "code": detail.get("code"), "message": detail.get("message"), "contains_secret": False}
+        return {
+            "schema_version": "kpgs.snowflake_execution_receipt.v1",
+            "request_id": prepared.request_id,
+            "sql_request_id": prepared.sql_request_id(),
+            "http_status": exc.code,
+            "statement_handle": detail.get("statementHandle"),
+            "code": detail.get("code"),
+            "message": detail.get("message"),
+            "execution_state": "rejected",
+            "contains_secret": False,
+        }
+    except urllib.error.URLError as exc:
+        return {
+            "schema_version": "kpgs.snowflake_execution_receipt.v1",
+            "request_id": prepared.request_id,
+            "sql_request_id": prepared.sql_request_id(),
+            "http_status": None,
+            "statement_handle": None,
+            "code": "NETWORK_ERROR",
+            "message": str(exc.reason)[:300],
+            "execution_state": "transport-failed",
+            "contains_secret": False,
+        }

--- a/governance/kpgs-vnext/frontier-harness/snowflake/validate_snowflake_adapter.py
+++ b/governance/kpgs-vnext/frontier-harness/snowflake/validate_snowflake_adapter.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -20,6 +21,7 @@ def load_adapter():
     spec = importlib.util.spec_from_file_location("kpgs_snowflake_adapter", ROOT / "sql_api_adapter.py")
     require(spec is not None and spec.loader is not None, "adapter must be importable")
     module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
     spec.loader.exec_module(module)
     return module
 

--- a/governance/kpgs-vnext/frontier-harness/snowflake/validate_snowflake_adapter.py
+++ b/governance/kpgs-vnext/frontier-harness/snowflake/validate_snowflake_adapter.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Dependency-free gate for the KPGS Snowflake v0.2 adapter."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise SystemExit(f"KPGS-SNOWFLAKE FAIL: {message}")
+
+
+def load_adapter():
+    spec = importlib.util.spec_from_file_location("kpgs_snowflake_adapter", ROOT / "sql_api_adapter.py")
+    require(spec is not None and spec.loader is not None, "adapter must be importable")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def main() -> None:
+    adapter = load_adapter()
+    now = datetime(2026, 8, 17, 15, 30, tzinfo=timezone.utc)
+    lease = {
+        "lease_id": "lease_snowflake_test_001",
+        "subject": {"id": "frontier-snowflake-adapter", "kind": "adapter"},
+        "tenant_id": "kopano-labs",
+        "domain_id": "Introduction-to-MCP",
+        "task_id": "frontier-snowflake-v0.2-test",
+        "capabilities": [{"name": "snowflake.telemetry.append", "resource_scope": "KPGS_FRONTIER.EVIDENCE.FRONTIER_TELEMETRY", "constraints": ["append-only", "metadata-and-digests-only"]}],
+        "issued_at": (now - timedelta(minutes=1)).isoformat().replace("+00:00", "Z"),
+        "expires_at": (now + timedelta(minutes=5)).isoformat().replace("+00:00", "Z"),
+        "policy_decision_ref": "policy://frontier-snowflake-v0.2/test",
+        "governing_spec_ref": "kpgs-frontier-harness-snowflake-v0.2",
+        "secret_provider_refs": ["env://KPGS_SNOWFLAKE_PAT"],
+    }
+    row = {
+        "event_schema": "kpgs.frontier_telemetry.v1",
+        "request_id": "req_frontier_validation_001",
+        "source_provider": "fillout",
+        "capability": "reasoning",
+        "selected_provider": "google-ai",
+        "output_digest": "a" * 64,
+        "data_classification": "synthetic",
+        "external_processing_allowed": True,
+    }
+    target = adapter.SnowflakeTarget("org-account", "KPGS_FRONTIER_WH", "KPGS_FRONTIER_INGEST")
+    prepared = adapter.prepare_telemetry_insert(row, lease, target, now=now)
+    receipt = prepared.safe_receipt()
+    serialized = json.dumps(prepared.body, sort_keys=True).lower()
+    require(prepared.endpoint.endswith(".snowflakecomputing.com/api/v2/statements"), "wrong SQL API endpoint")
+    require(len(prepared.body["bindings"]) == 8, "insert must bind exactly eight telemetry values")
+    require("semantic_input" not in serialized and "private_payload" not in serialized, "prepared request leaked forbidden content")
+    require("kpgs_snowflake_pat" not in serialized, "prepared SQL body must not contain secret reference or token")
+    require(receipt["contains_secret"] is False, "safe receipt must exclude secrets")
+
+    blocked = dict(row)
+    blocked["semantic_input"] = "must never leave sovereign boundary"
+    try:
+        adapter.prepare_telemetry_insert(blocked, lease, target, now=now)
+    except adapter.GovernanceError:
+        pass
+    else:
+        raise SystemExit("KPGS-SNOWFLAKE FAIL: semantic input was not rejected")
+
+    expired = dict(lease)
+    expired["issued_at"] = "2026-08-16T00:00:00Z"
+    expired["expires_at"] = "2026-08-16T00:10:00Z"
+    try:
+        adapter.prepare_telemetry_insert(row, expired, target, now=now)
+    except adapter.GovernanceError:
+        pass
+    else:
+        raise SystemExit("KPGS-SNOWFLAKE FAIL: expired lease was accepted")
+
+    print("KPGS-SNOWFLAKE PASS: adapter is fail-closed, capability-leased and secret-external.")
+    print(f"Prepared: {prepared.request_id} -> {prepared.endpoint}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Outcome

Promotes the Snowflake leg of the Frontier Harness from a prepared analytical-copy row to a **live-capable, fail-closed SQL API adapter**.

The adapter preserves the KPGS boundary:

`local governed telemetry -> short-lived capability lease -> external secret reference -> Snowflake SQL API -> analytical evidence copy`

## Governance

- exact capability required: `snowflake.telemetry.append`
- exact resource scope: `KPGS_FRONTIER.EVIDENCE.FRONTIER_TELEMETRY`
- lease must be current and bound to `kpgs-frontier-harness-snowflake-v0.2`
- one external `env://` secret-provider reference is required
- no credential is committed
- semantic input, raw prompts, provider response text and private payload fields are rejected before request preparation
- telemetry values use Snowflake SQL API bind variables
- Snowflake remains an analytical copy; local KPGS receipts remain authoritative

## Snowflake SQL API alignment

The adapter targets `POST /api/v2/statements`, uses a deterministic UUID request id derived from the KPGS request id, sends `query_tag` as a supported SQL API statement parameter, and supports `PROGRAMMATIC_ACCESS_TOKEN`, `OAUTH`, or `KEYPAIR_JWT` token declarations.

## Validation

Repository-native gate:

`python governance/kpgs-vnext/frontier-harness/snowflake/validate_snowflake_adapter.py`

The gate is intentionally network-free and proves scoped-lease enforcement, lease expiry rejection, bind-variable construction, forbidden-field rejection and secret-free receipts.

No live Snowflake write is claimed in this PR because no Snowflake credential/account session is exposed to this execution environment. The code is live-capable; promotion to a real write requires applying `bootstrap.sql`, issuing a current scoped lease and resolving the external token at runtime.

## Risk

`R2 / draft / non-production` until an actual Snowflake execution receipt exists.