### PR TITLE
feat(kpgs): lock sovereign task contract v0.1

### DIFF
--- a/governance/kpgs-vnext/README.md
+++ b/governance/kpgs-vnext/README.md
@@ -74,6 +74,10 @@ Tools / APIs / Domain Systems
 - `agent-governance/SPECIFICATION.md`
 - `agent-governance/build-spec.schema.json`
 - `fork-assimilation/evolution-matrix.json`
+- `task-contract/README.md`
+- `task-contract/principal-envelope.schema.json`
+- `task-contract/task-receipt.schema.json`
+- `task-contract/adapter.py`
 
 ## Definition of done
 

--- a/governance/kpgs-vnext/task-contract/README.md
+++ b/governance/kpgs-vnext/task-contract/README.md
@@ -1,0 +1,135 @@
+# KPGS Sovereign Task Contract v0.1
+
+Status: **Phase 0 / contract POC / non-production**
+
+This slice makes task authority independent of MCP sessions, agent processes, model runtimes, and transports.
+
+## Governing invariant
+
+```text
+principal identity
+    +
+explicit capability grant
+    +
+governing policy/spec
+    ↓
+KPGS task receipt
+    ↓
+protocol adapter (MCP/A2A/local/other)
+    ↓
+disposable executor
+```
+
+A protocol task handle is a correlation mechanism. It is **not** canonical task authority.
+
+## Contract artifacts
+
+- `principal-envelope.schema.json` — protocol-neutral identity, accountable principal, key/credential reference, and explicit capability grants.
+- `task-receipt.schema.json` — canonical task state, receipt sequence/hash chain, policy lineage, idempotency key, protocol mapping, and metadata-only evidence references.
+- `adapter.py` — deterministic reference adapter and conformance harness for MCP `2026-07-28`.
+- `tests/test_kpgs_task_contract.py` — destruction/resume, duplicate-delivery, canonicalization, capability-denial, and MCP mapping tests.
+
+## MCP 2026-07-28 boundary
+
+KPGS follows the final MCP `2026-07-28` semantics at the adapter boundary:
+
+- requests are stateless and carry protocol/client metadata per request;
+- `server/discover` is available for version/capability discovery;
+- protocol semantics are transport-independent;
+- Tasks are an opt-in extension under `io.modelcontextprotocol/tasks`;
+- MCP external task IDs remain external correlation identifiers.
+
+KPGS does **not** put canonical task truth in:
+
+- an MCP connection;
+- an `initialize`-era session;
+- a transport stream;
+- a model context window;
+- a Stateless Renter;
+- an external task handle.
+
+The adapter may be destroyed and recreated while the canonical ledger survives.
+
+Primary MCP references:
+
+- `modelcontextprotocol/modelcontextprotocol/docs/specification/2026-07-28/`
+- `modelcontextprotocol/modelcontextprotocol/docs/specification/2026-07-28/server/discover.mdx`
+- `modelcontextprotocol/modelcontextprotocol/docs/specification/2026-07-28/basic/transports/`
+- `modelcontextprotocol/modelcontextprotocol` release note: `2026-07-28 Specification`
+
+## Principal/capability law
+
+Identity, authorization, delegation, transport, and governance are separate claims.
+
+```text
+principal_id               who is acting
+accountable_principal_id   who is accountable where delegation exists
+identity                   how the principal is verified
+capability_grant           what it may attempt
+protocol                   how the request arrived
+KPGS policy                whether execution is permitted now
+```
+
+No current DID/AIP/agent-identity draft is constitutionalized by this v0.1 contract. Credential schemes are adapter choices behind the `identity` envelope.
+
+## Receipt law
+
+Each state mutation emits a new receipt:
+
+```text
+receipt[n]
+   sha256
+      ↓
+receipt[n+1].previous_receipt_sha256
+```
+
+Required properties:
+
+1. stable `task_id`;
+2. monotonically increasing `sequence`;
+3. explicit `principal_id` and `capability_grant_id`;
+4. governing spec/policy lineage;
+5. replay-safe `idempotency_key`;
+6. protocol mapping kept subordinate to KPGS identity;
+7. evidence represented by SHA-256 reference by default;
+8. terminal states cannot silently resume.
+
+## Privacy boundary
+
+`evidence_refs[].content_captured` is locked to `false` in the v0.1 schema.
+
+The receipt records:
+
+```text
+hash + optional governed reference
+```
+
+not raw prompts, retrieved documents, tool arguments, user data, or model outputs.
+
+A later evidence-store contract may authorize encrypted content capture separately. Observability must not widen evidence disclosure by default.
+
+## Conformance gates
+
+This v0.1 POC must prove:
+
+- **capability before execution** — an unauthorized operation fails before task creation;
+- **duplicate delivery safety** — one idempotency key resolves to one canonical task;
+- **process destruction safety** — replacing the adapter does not erase task state;
+- **receipt continuity** — each mutation extends the prior receipt hash;
+- **deterministic canonicalization** — equivalent JSON objects hash identically regardless of key order;
+- **external handle non-authority** — MCP task IDs never replace KPGS task IDs;
+- **metadata-only evidence** — evidence payloads are hashed and discarded by the reference adapter.
+
+## Scope boundary
+
+This is intentionally a narrow vertical slice. It does not yet claim:
+
+- production persistence;
+- live MCP SDK integration;
+- DID/X.509 deployment;
+- distributed consensus;
+- CRDT reconciliation;
+- iroh/libp2p transport;
+- production signing/HSM integration.
+
+The next isolated POC is offline replicated non-authoritative state. It must not be allowed to mutate this constitutional task contract merely because a CRDT converges.

--- a/governance/kpgs-vnext/task-contract/adapter.py
+++ b/governance/kpgs-vnext/task-contract/adapter.py
@@ -1,0 +1,375 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from datetime import datetime, timezone
+from enum import StrEnum
+import hashlib
+import json
+from typing import Any, Mapping
+
+MCP_PROTOCOL_VERSION = "2026-07-28"
+MCP_TASK_EXTENSION = "io.modelcontextprotocol/tasks"
+
+
+class ContractError(ValueError):
+    pass
+
+
+class TaskState(StrEnum):
+    ACCEPTED = "accepted"
+    STARTED = "started"
+    AWAITING_APPROVAL = "awaiting_approval"
+    CHECKPOINTED = "checkpointed"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+    HELD = "held"
+
+
+TERMINAL_STATES = {TaskState.COMPLETED, TaskState.FAILED, TaskState.CANCELLED}
+_ALLOWED_TRANSITIONS = {
+    TaskState.ACCEPTED: {TaskState.STARTED, TaskState.FAILED, TaskState.CANCELLED, TaskState.HELD},
+    TaskState.STARTED: {
+        TaskState.AWAITING_APPROVAL,
+        TaskState.CHECKPOINTED,
+        TaskState.COMPLETED,
+        TaskState.FAILED,
+        TaskState.CANCELLED,
+        TaskState.HELD,
+    },
+    TaskState.AWAITING_APPROVAL: {TaskState.STARTED, TaskState.FAILED, TaskState.CANCELLED, TaskState.HELD},
+    TaskState.CHECKPOINTED: {TaskState.STARTED, TaskState.COMPLETED, TaskState.FAILED, TaskState.CANCELLED},
+    TaskState.HELD: {TaskState.STARTED, TaskState.FAILED, TaskState.CANCELLED},
+    TaskState.COMPLETED: set(),
+    TaskState.FAILED: set(),
+    TaskState.CANCELLED: set(),
+}
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+
+def canonical_sha256(value: Any) -> str:
+    return hashlib.sha256(canonical_json_bytes(value)).hexdigest()
+
+
+@dataclass(frozen=True)
+class PrincipalEnvelope:
+    principal_id: str
+    principal_type: str
+    identity_scheme: str
+    identity_subject: str
+    accountable_principal_id: str | None = None
+    public_key_ref: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.principal_id.strip():
+            raise ContractError("principal_id is required")
+        if not self.identity_subject.strip():
+            raise ContractError("identity_subject is required")
+
+
+@dataclass(frozen=True)
+class CapabilityGrant:
+    grant_id: str
+    principal_id: str
+    operations: frozenset[str]
+    resources: frozenset[str]
+    expires_at: str | None = None
+    parent_grant_id: str | None = None
+    revocation_ref: str | None = None
+
+    def allows(self, *, operation: str, resource: str) -> bool:
+        return ("*" in self.operations or operation in self.operations) and (
+            "*" in self.resources or resource in self.resources
+        )
+
+    def assert_valid_for(
+        self,
+        *,
+        principal: PrincipalEnvelope,
+        operation: str,
+        resource: str,
+        now: datetime | None = None,
+    ) -> None:
+        if self.principal_id != principal.principal_id:
+            raise ContractError("capability principal does not match task principal")
+        if self.expires_at is not None:
+            instant = datetime.fromisoformat(self.expires_at.replace("Z", "+00:00"))
+            current = now or datetime.now(timezone.utc)
+            if instant <= current:
+                raise ContractError("capability grant has expired")
+        if not self.allows(operation=operation, resource=resource):
+            raise ContractError("capability does not authorize operation/resource")
+
+
+@dataclass(frozen=True)
+class EvidenceRef:
+    sha256: str
+    ref: str | None = None
+    content_captured: bool = False
+
+
+@dataclass(frozen=True)
+class TaskReceipt:
+    task_id: str
+    receipt_id: str
+    sequence: int
+    tenant_id: str
+    domain_id: str
+    principal_id: str
+    capability_grant_id: str
+    governing_spec_ref: str
+    policy_version: str
+    state: TaskState
+    idempotency_key: str
+    operation: str
+    resource: str
+    created_at: str
+    updated_at: str
+    protocol: str = "local"
+    protocol_version: str | None = None
+    transport: str | None = None
+    external_task_id: str | None = None
+    checkpoint_ref: str | None = None
+    result_ref: str | None = None
+    failure_code: str | None = None
+    previous_receipt_sha256: str | None = None
+    evidence_refs: tuple[EvidenceRef, ...] = ()
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": "kpgs.task_receipt.v0.1",
+            "task_id": self.task_id,
+            "receipt_id": self.receipt_id,
+            "sequence": self.sequence,
+            "tenant_id": self.tenant_id,
+            "domain_id": self.domain_id,
+            "principal_id": self.principal_id,
+            "capability_grant_id": self.capability_grant_id,
+            "governing_spec_ref": self.governing_spec_ref,
+            "policy_version": self.policy_version,
+            "state": self.state.value,
+            "idempotency_key": self.idempotency_key,
+            "operation": self.operation,
+            "resource": self.resource,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "protocol": {
+                "name": self.protocol,
+                "version": self.protocol_version,
+                "transport": self.transport,
+                "external_task_id": self.external_task_id,
+            },
+            "checkpoint_ref": self.checkpoint_ref,
+            "result_ref": self.result_ref,
+            "failure_code": self.failure_code,
+            "previous_receipt_sha256": self.previous_receipt_sha256,
+            "evidence_refs": [
+                {"sha256": item.sha256, "ref": item.ref, "content_captured": item.content_captured}
+                for item in self.evidence_refs
+            ],
+        }
+
+    @property
+    def sha256(self) -> str:
+        return canonical_sha256(self.as_dict())
+
+
+class InMemoryTaskLedger:
+    """POC canonical-store interface used by adapter conformance tests.
+
+    Production storage MUST replace this class. The important property is that
+    adapter instances do not own the task truth.
+    """
+
+    def __init__(self) -> None:
+        self._latest: dict[str, TaskReceipt] = {}
+        self._history: dict[str, list[TaskReceipt]] = {}
+        self._idempotency: dict[str, str] = {}
+
+    def get(self, task_id: str) -> TaskReceipt:
+        try:
+            return self._latest[task_id]
+        except KeyError as exc:
+            raise ContractError(f"unknown task_id: {task_id}") from exc
+
+    def get_by_idempotency_key(self, key: str) -> TaskReceipt | None:
+        task_id = self._idempotency.get(key)
+        return self._latest.get(task_id) if task_id else None
+
+    def append(self, receipt: TaskReceipt) -> TaskReceipt:
+        current = self._latest.get(receipt.task_id)
+        if current is None:
+            if receipt.sequence != 0:
+                raise ContractError("first receipt sequence must be 0")
+            if receipt.previous_receipt_sha256 is not None:
+                raise ContractError("first receipt cannot point to a previous receipt")
+            existing = self._idempotency.get(receipt.idempotency_key)
+            if existing is not None and existing != receipt.task_id:
+                raise ContractError("idempotency key already belongs to another task")
+            self._idempotency[receipt.idempotency_key] = receipt.task_id
+            self._history[receipt.task_id] = [receipt]
+        else:
+            if receipt.sequence != current.sequence + 1:
+                raise ContractError("receipt sequence is not continuous")
+            if receipt.previous_receipt_sha256 != current.sha256:
+                raise ContractError("receipt hash chain is broken")
+            self._history[receipt.task_id].append(receipt)
+        self._latest[receipt.task_id] = receipt
+        return receipt
+
+    def history(self, task_id: str) -> tuple[TaskReceipt, ...]:
+        return tuple(self._history.get(task_id, ()))
+
+
+def evidence_ref(payload: Any, *, ref: str | None = None) -> EvidenceRef:
+    """Create a metadata-only evidence reference. Raw content is not retained."""
+    return EvidenceRef(sha256=canonical_sha256(payload), ref=ref, content_captured=False)
+
+
+class MCP20260728Adapter:
+    """Map MCP 2026-07-28 interactions onto protocol-neutral KPGS tasks.
+
+    The adapter owns no durable task authority. A connection, process, request,
+    or MCP external task handle may disappear without invalidating KPGS state.
+    """
+
+    def __init__(self, ledger: InMemoryTaskLedger) -> None:
+        self._ledger = ledger
+
+    @staticmethod
+    def request_meta(
+        *,
+        client_name: str,
+        client_version: str,
+        client_capabilities: Mapping[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        return {
+            "io.modelcontextprotocol/protocolVersion": MCP_PROTOCOL_VERSION,
+            "io.modelcontextprotocol/clientInfo": {"name": client_name, "version": client_version},
+            "io.modelcontextprotocol/clientCapabilities": dict(client_capabilities or {}),
+        }
+
+    @classmethod
+    def discover_request(
+        cls,
+        *,
+        request_id: str,
+        client_name: str,
+        client_version: str,
+        client_capabilities: Mapping[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        return {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": "server/discover",
+            "params": {
+                "_meta": cls.request_meta(
+                    client_name=client_name,
+                    client_version=client_version,
+                    client_capabilities=client_capabilities,
+                )
+            },
+        }
+
+    def accept_task(
+        self,
+        *,
+        tenant_id: str,
+        domain_id: str,
+        principal: PrincipalEnvelope,
+        capability: CapabilityGrant,
+        operation: str,
+        resource: str,
+        governing_spec_ref: str,
+        policy_version: str,
+        idempotency_key: str,
+        external_task_id: str | None = None,
+        transport: str | None = None,
+        now: datetime | None = None,
+    ) -> TaskReceipt:
+        capability.assert_valid_for(principal=principal, operation=operation, resource=resource, now=now)
+        identity = {
+            "tenant_id": tenant_id,
+            "domain_id": domain_id,
+            "principal_id": principal.principal_id,
+            "capability_grant_id": capability.grant_id,
+            "operation": operation,
+            "resource": resource,
+            "governing_spec_ref": governing_spec_ref,
+            "policy_version": policy_version,
+            "idempotency_key": idempotency_key,
+        }
+        task_id = f"kpgs-task-{canonical_sha256(identity)[:24]}"
+        existing = self._ledger.get_by_idempotency_key(idempotency_key)
+        if existing is not None:
+            if existing.task_id != task_id:
+                raise ContractError("idempotency key replay does not match original governed task")
+            return existing
+        timestamp = (now or datetime.now(timezone.utc)).isoformat().replace("+00:00", "Z")
+        receipt = TaskReceipt(
+            task_id=task_id,
+            receipt_id=f"{task_id}-r0000",
+            sequence=0,
+            tenant_id=tenant_id,
+            domain_id=domain_id,
+            principal_id=principal.principal_id,
+            capability_grant_id=capability.grant_id,
+            governing_spec_ref=governing_spec_ref,
+            policy_version=policy_version,
+            state=TaskState.ACCEPTED,
+            idempotency_key=idempotency_key,
+            operation=operation,
+            resource=resource,
+            created_at=timestamp,
+            updated_at=timestamp,
+            protocol="mcp",
+            protocol_version=MCP_PROTOCOL_VERSION,
+            transport=transport,
+            external_task_id=external_task_id,
+        )
+        return self._ledger.append(receipt)
+
+    def transition(
+        self,
+        task_id: str,
+        *,
+        state: TaskState,
+        evidence: Any | None = None,
+        evidence_uri: str | None = None,
+        checkpoint_ref: str | None = None,
+        result_ref: str | None = None,
+        failure_code: str | None = None,
+        external_task_id: str | None = None,
+        now: datetime | None = None,
+    ) -> TaskReceipt:
+        current = self._ledger.get(task_id)
+        if current.state in TERMINAL_STATES:
+            raise ContractError("terminal task cannot transition")
+        if state not in _ALLOWED_TRANSITIONS[current.state]:
+            raise ContractError(f"invalid task transition: {current.state.value} -> {state.value}")
+        refs = current.evidence_refs
+        if evidence is not None:
+            refs = (*refs, evidence_ref(evidence, ref=evidence_uri))
+        timestamp = (now or datetime.now(timezone.utc)).isoformat().replace("+00:00", "Z")
+        next_sequence = current.sequence + 1
+        next_receipt = replace(
+            current,
+            receipt_id=f"{current.task_id}-r{next_sequence:04d}",
+            sequence=next_sequence,
+            state=state,
+            updated_at=timestamp,
+            external_task_id=external_task_id or current.external_task_id,
+            checkpoint_ref=checkpoint_ref or current.checkpoint_ref,
+            result_ref=result_ref or current.result_ref,
+            failure_code=failure_code,
+            previous_receipt_sha256=current.sha256,
+            evidence_refs=refs,
+        )
+        return self._ledger.append(next_receipt)
+
+    def resume(self, task_id: str) -> TaskReceipt:
+        """Return canonical task state after adapter/process recreation."""
+        return self._ledger.get(task_id)

--- a/governance/kpgs-vnext/task-contract/principal-envelope.schema.json
+++ b/governance/kpgs-vnext/task-contract/principal-envelope.schema.json
@@ -1,0 +1,132 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kopanolabs.com/kpgs/task-contract/principal-envelope.schema.json",
+  "title": "KPGS Principal Envelope v0.1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "principal_id",
+    "principal_type",
+    "identity",
+    "capability_grants"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "kpgs.principal.v0.1"
+    },
+    "principal_id": {
+      "type": "string",
+      "minLength": 3
+    },
+    "principal_type": {
+      "enum": [
+        "human",
+        "agent",
+        "service",
+        "device",
+        "runtime"
+      ]
+    },
+    "accountable_principal_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "scheme",
+        "subject",
+        "public_key_ref"
+      ],
+      "properties": {
+        "scheme": {
+          "enum": [
+            "local-key",
+            "did",
+            "x509",
+            "oauth-subject",
+            "workload",
+            "other"
+          ]
+        },
+        "subject": {
+          "type": "string",
+          "minLength": 1
+        },
+        "public_key_ref": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "capability_grants": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "grant_id",
+          "operations",
+          "resources",
+          "issued_at",
+          "expires_at",
+          "parent_grant_id",
+          "revocation_ref"
+        ],
+        "properties": {
+          "grant_id": {
+            "type": "string",
+            "minLength": 3
+          },
+          "operations": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "resources": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "issued_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "expires_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "parent_grant_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "revocation_ref": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/governance/kpgs-vnext/task-contract/task-receipt.schema.json
+++ b/governance/kpgs-vnext/task-contract/task-receipt.schema.json
@@ -1,0 +1,194 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kopanolabs.com/kpgs/task-contract/task-receipt.schema.json",
+  "title": "KPGS Task Receipt v0.1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "task_id",
+    "receipt_id",
+    "sequence",
+    "tenant_id",
+    "domain_id",
+    "principal_id",
+    "capability_grant_id",
+    "governing_spec_ref",
+    "policy_version",
+    "state",
+    "idempotency_key",
+    "operation",
+    "resource",
+    "created_at",
+    "updated_at",
+    "protocol",
+    "checkpoint_ref",
+    "result_ref",
+    "failure_code",
+    "previous_receipt_sha256",
+    "evidence_refs"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "kpgs.task_receipt.v0.1"
+    },
+    "task_id": {
+      "type": "string",
+      "pattern": "^kpgs-task-[0-9a-f]{24}$"
+    },
+    "receipt_id": {
+      "type": "string",
+      "minLength": 8
+    },
+    "sequence": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "tenant_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "domain_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "principal_id": {
+      "type": "string",
+      "minLength": 3
+    },
+    "capability_grant_id": {
+      "type": "string",
+      "minLength": 3
+    },
+    "governing_spec_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "policy_version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "state": {
+      "enum": [
+        "accepted",
+        "started",
+        "awaiting_approval",
+        "checkpointed",
+        "completed",
+        "failed",
+        "cancelled",
+        "held"
+      ]
+    },
+    "idempotency_key": {
+      "type": "string",
+      "minLength": 8
+    },
+    "operation": {
+      "type": "string",
+      "minLength": 1
+    },
+    "resource": {
+      "type": "string",
+      "minLength": 1
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "protocol": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "version",
+        "transport",
+        "external_task_id"
+      ],
+      "properties": {
+        "name": {
+          "enum": [
+            "mcp",
+            "a2a",
+            "local",
+            "other"
+          ]
+        },
+        "version": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "transport": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "external_task_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "checkpoint_ref": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "result_ref": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "failure_code": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "previous_receipt_sha256": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "evidence_refs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "sha256",
+          "ref",
+          "content_captured"
+        ],
+        "properties": {
+          "sha256": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{64}$"
+          },
+          "ref": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "content_captured": {
+            "const": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/test_kpgs_task_contract.py
+++ b/tests/test_kpgs_task_contract.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import importlib.util
+from pathlib import Path
+import sys
+
+import pytest
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "governance"
+    / "kpgs-vnext"
+    / "task-contract"
+    / "adapter.py"
+)
+SPEC = importlib.util.spec_from_file_location("kpgs_task_contract_adapter", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+adapter_module = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = adapter_module
+SPEC.loader.exec_module(adapter_module)
+
+CapabilityGrant = adapter_module.CapabilityGrant
+ContractError = adapter_module.ContractError
+InMemoryTaskLedger = adapter_module.InMemoryTaskLedger
+MCP20260728Adapter = adapter_module.MCP20260728Adapter
+MCP_PROTOCOL_VERSION = adapter_module.MCP_PROTOCOL_VERSION
+PrincipalEnvelope = adapter_module.PrincipalEnvelope
+TaskState = adapter_module.TaskState
+canonical_sha256 = adapter_module.canonical_sha256
+
+
+FIXED_NOW = datetime(2026, 8, 17, 15, 0, tzinfo=timezone.utc)
+
+
+def _principal() -> PrincipalEnvelope:
+    return PrincipalEnvelope(
+        principal_id="agent:forge",
+        principal_type="agent",
+        identity_scheme="local-key",
+        identity_subject="forge-key-01",
+        accountable_principal_id="human:owner",
+        public_key_ref="keyref://forge",
+    )
+
+
+def _capability() -> CapabilityGrant:
+    return CapabilityGrant(
+        grant_id="cap:repo-write",
+        principal_id="agent:forge",
+        operations=frozenset({"repo.write", "repo.read"}),
+        resources=frozenset({"repo:Introduction-to-MCP"}),
+        expires_at="2099-01-01T00:00:00Z",
+    )
+
+
+def _accept(adapter: MCP20260728Adapter, *, idempotency_key: str = "idem-task-0001"):
+    return adapter.accept_task(
+        tenant_id="kopano",
+        domain_id="governance",
+        principal=_principal(),
+        capability=_capability(),
+        operation="repo.write",
+        resource="repo:Introduction-to-MCP",
+        governing_spec_ref="kpgs://task-contract/v0.1",
+        policy_version="kpgs-vnext.phase0",
+        idempotency_key=idempotency_key,
+        external_task_id="mcp-task-123",
+        transport="streamable-http",
+        now=FIXED_NOW,
+    )
+
+
+def test_mcp_2026_07_28_uses_per_request_metadata_and_discovery():
+    request = MCP20260728Adapter.discover_request(
+        request_id="discover-1",
+        client_name="kpgs",
+        client_version="0.1.0",
+    )
+
+    assert request["method"] == "server/discover"
+    meta = request["params"]["_meta"]
+    assert meta["io.modelcontextprotocol/protocolVersion"] == MCP_PROTOCOL_VERSION
+    assert "session_id" not in meta
+    assert "initialize" not in request
+
+
+def test_capability_is_checked_before_task_creation():
+    ledger = InMemoryTaskLedger()
+    adapter = MCP20260728Adapter(ledger)
+    denied = CapabilityGrant(
+        grant_id="cap:read-only",
+        principal_id="agent:forge",
+        operations=frozenset({"repo.read"}),
+        resources=frozenset({"repo:Introduction-to-MCP"}),
+        expires_at="2099-01-01T00:00:00Z",
+    )
+
+    with pytest.raises(ContractError, match="does not authorize"):
+        adapter.accept_task(
+            tenant_id="kopano",
+            domain_id="governance",
+            principal=_principal(),
+            capability=denied,
+            operation="repo.write",
+            resource="repo:Introduction-to-MCP",
+            governing_spec_ref="kpgs://task-contract/v0.1",
+            policy_version="kpgs-vnext.phase0",
+            idempotency_key="idem-denied-0001",
+            now=FIXED_NOW,
+        )
+
+    assert ledger.get_by_idempotency_key("idem-denied-0001") is None
+
+
+def test_duplicate_delivery_resolves_to_one_canonical_task():
+    ledger = InMemoryTaskLedger()
+    first_adapter = MCP20260728Adapter(ledger)
+    first = _accept(first_adapter)
+
+    duplicate_adapter = MCP20260728Adapter(ledger)
+    duplicate = _accept(duplicate_adapter)
+
+    assert duplicate.task_id == first.task_id
+    assert duplicate.receipt_id == first.receipt_id
+    assert len(ledger.history(first.task_id)) == 1
+
+
+def test_idempotency_key_replay_cannot_change_governed_intent():
+    ledger = InMemoryTaskLedger()
+    adapter = MCP20260728Adapter(ledger)
+    _accept(adapter)
+
+    with pytest.raises(ContractError, match="replay does not match"):
+        adapter.accept_task(
+            tenant_id="kopano",
+            domain_id="governance",
+            principal=_principal(),
+            capability=_capability(),
+            operation="repo.read",
+            resource="repo:Introduction-to-MCP",
+            governing_spec_ref="kpgs://task-contract/v0.1",
+            policy_version="kpgs-vnext.phase0",
+            idempotency_key="idem-task-0001",
+            now=FIXED_NOW,
+        )
+
+
+def test_task_survives_adapter_destruction_and_resumes_from_ledger():
+    ledger = InMemoryTaskLedger()
+    first_adapter = MCP20260728Adapter(ledger)
+    accepted = _accept(first_adapter)
+
+    del first_adapter
+    replacement_adapter = MCP20260728Adapter(ledger)
+
+    resumed = replacement_adapter.resume(accepted.task_id)
+    assert resumed == accepted
+
+    started = replacement_adapter.transition(
+        accepted.task_id,
+        state=TaskState.STARTED,
+        checkpoint_ref="checkpoint://task/1",
+        now=FIXED_NOW,
+    )
+    assert started.sequence == 1
+    assert started.previous_receipt_sha256 == accepted.sha256
+
+
+def test_external_mcp_handle_never_replaces_kpgs_task_identity():
+    ledger = InMemoryTaskLedger()
+    adapter = MCP20260728Adapter(ledger)
+    accepted = _accept(adapter)
+
+    started = adapter.transition(
+        accepted.task_id,
+        state=TaskState.STARTED,
+        external_task_id="mcp-task-rebound",
+        now=FIXED_NOW,
+    )
+
+    assert started.task_id == accepted.task_id
+    assert started.external_task_id == "mcp-task-rebound"
+    assert started.principal_id == accepted.principal_id
+    assert started.capability_grant_id == accepted.capability_grant_id
+
+
+def test_canonical_hash_is_order_independent_for_json_object_keys():
+    left = {"task": {"b": 2, "a": 1}, "state": "started"}
+    right = {"state": "started", "task": {"a": 1, "b": 2}}
+
+    assert canonical_sha256(left) == canonical_sha256(right)
+
+
+def test_evidence_is_hashed_without_content_capture():
+    ledger = InMemoryTaskLedger()
+    adapter = MCP20260728Adapter(ledger)
+    accepted = _accept(adapter)
+
+    started = adapter.transition(
+        accepted.task_id,
+        state=TaskState.STARTED,
+        evidence={"private": "do-not-copy-into-telemetry"},
+        evidence_uri="evidence://encrypted/object-1",
+        now=FIXED_NOW,
+    )
+
+    item = started.evidence_refs[-1]
+    assert len(item.sha256) == 64
+    assert item.ref == "evidence://encrypted/object-1"
+    assert item.content_captured is False
+    assert "private" not in started.as_dict()["evidence_refs"][-1]
+
+
+def test_terminal_state_cannot_silently_resume():
+    ledger = InMemoryTaskLedger()
+    adapter = MCP20260728Adapter(ledger)
+    accepted = _accept(adapter)
+
+    started = adapter.transition(
+        accepted.task_id,
+        state=TaskState.STARTED,
+        now=FIXED_NOW,
+    )
+    completed = adapter.transition(
+        started.task_id,
+        state=TaskState.COMPLETED,
+        result_ref="result://task/1",
+        now=FIXED_NOW,
+    )
+
+    with pytest.raises(ContractError, match="terminal task"):
+        adapter.transition(
+            completed.task_id,
+            state=TaskState.STARTED,
+            now=FIXED_NOW,
+        )


### PR DESCRIPTION
Implements the Phase 0 sovereign task-contract slice: protocol-neutral principal/capability and task receipt contracts, MCP 2026-07-28 adapter mapping, receipt continuity, replay protection, privacy-minimized evidence references, and focused conformance tests.

Validation receipts:
- focused contract tests: 9 passed locally
- KPGS vNext Contract Gate: passed
- Kopano CI Pipeline: passed
- CodeQL Advanced: passed after re-running one Python job that initially failed during action download with GitHub 503/429; no code change was required

Scope remains Phase 0 / contract POC / non-production. Production durable storage, live MCP SDK integration, signing/HSM, identity deployment, and CRDT/iroh replication remain separate gates.