### PR TITLE
[POC] KPGS Frontier Harness v0.3 — Google AI governed renter

### DIFF
--- a/governance/kpgs-vnext/agent-governance/specs/frontier-google-ai-v0.3.json
+++ b/governance/kpgs-vnext/agent-governance/specs/frontier-google-ai-v0.3.json
@@ -1,0 +1,152 @@
+{
+  "spec_id": "kpgs-frontier-harness-google-ai-v0.3",
+  "title": "KPGS Frontier Harness — Google AI Governed Renter v0.3",
+  "outcome": "Promote the Google AI leg from deterministic mock routing to a live-capable Gemini GenerateContent renter while preserving KPGS routing, policy, semantic authority, receipt authority, secret isolation, and rollback control.",
+  "scope": {
+    "included": [
+      "Add a dependency-free Gemini GenerateContent REST adapter",
+      "Require a current capability lease scoped to an exact Gemini model resource",
+      "Resolve the API key only from an external env:// secret reference",
+      "Allow only public or synthetic external processing in v0.3",
+      "Digest-bind input and provider output without storing either in execution receipts",
+      "Capture provider usage metadata and finish reasons for KPGS evaluation",
+      "Reject deprecated/non-allow-listed model identifiers",
+      "Provide a network-free executable governance gate"
+    ],
+    "excluded": [
+      "Committing or persisting a Google API key",
+      "Sending private, restricted, confidential, or autobiographical KPGS state to Google AI",
+      "Treating model output as canonical truth or human consent",
+      "Granting Gemini durable state authority",
+      "Using Google hosted agents as the KPGS landlord/control plane",
+      "Claiming a live Gemini execution receipt without a real credential-backed call"
+    ]
+  },
+  "interfaces": [
+    {
+      "name": "KPGS capability request",
+      "contract": "Input arrives through kpgs.capability_request.v1 and external processing must already be policy-authorized.",
+      "version": "kpgs.capability_request.v1"
+    },
+    {
+      "name": "Capability lease",
+      "contract": "google-ai.generate-content is leased to an adapter/service/renter and bound to an exact models/<model>:generateContent resource scope.",
+      "version": "capability-lease.schema.json"
+    },
+    {
+      "name": "Gemini GenerateContent",
+      "contract": "The adapter uses the Gemini REST GenerateContent endpoint and sends the runtime API key only in the x-goog-api-key header.",
+      "version": "v1beta"
+    },
+    {
+      "name": "KPGS provider receipt",
+      "contract": "Request/execution receipts contain digests and usage metadata but no raw prompt, raw model output, or API key; provider output remains non-canonical.",
+      "version": "kpgs.google_ai_execution_receipt.v1"
+    }
+  ],
+  "constraints": [
+    "Provider output != KPGS truth.",
+    "Model execution != semantic authority.",
+    "Only public or synthetic data may be sent to Google AI in v0.3.",
+    "Every live call requires a current capability lease and exactly one external env:// secret reference.",
+    "The model identifier must be in the governed allow-list.",
+    "Receipts may contain input/output digests and token usage but not raw semantic content.",
+    "No deprecated sampling controls are required for the adapter.",
+    "No live provider execution may be claimed without a credential-backed execution receipt."
+  ],
+  "acceptance_criteria": [
+    {
+      "id": "GA-01",
+      "statement": "Google AI execution requires a current lease scoped to google-ai.generate-content and the exact model resource.",
+      "hard_gate": true,
+      "verification_methods": ["unit", "security"]
+    },
+    {
+      "id": "GA-02",
+      "statement": "Only public or synthetic requests with allow_external_processing=true can reach request preparation.",
+      "hard_gate": true,
+      "verification_methods": ["unit", "security"]
+    },
+    {
+      "id": "GA-03",
+      "statement": "The API key remains external and is transmitted only through x-goog-api-key at execution time.",
+      "hard_gate": true,
+      "verification_methods": ["unit", "security"]
+    },
+    {
+      "id": "GA-04",
+      "statement": "The adapter permits current governed stable model identifiers and rejects deprecated/non-allow-listed identifiers.",
+      "hard_gate": true,
+      "verification_methods": ["unit", "human-review"]
+    },
+    {
+      "id": "GA-05",
+      "statement": "Provider output is digest-bound, non-canonical, and KPGS remains semantic authority.",
+      "hard_gate": true,
+      "verification_methods": ["unit", "schema"]
+    },
+    {
+      "id": "GA-06",
+      "statement": "Execution receipts exclude raw prompt, raw output, and secret while preserving model, finish, and usage evidence.",
+      "hard_gate": true,
+      "verification_methods": ["unit", "security"]
+    },
+    {
+      "id": "GA-07",
+      "statement": "The network-free validator proves the live-capable request/receipt path without claiming a real provider call.",
+      "hard_gate": false,
+      "verification_methods": ["integration"]
+    }
+  ],
+  "verification_plan": [
+    {
+      "criterion_id": "GA-01",
+      "evidence": "validate_google_ai_adapter.py constructs a scoped current lease and separately proves expired lease rejection.",
+      "command_or_procedure": "python governance/kpgs-vnext/frontier-harness/google-ai/validate_google_ai_adapter.py"
+    },
+    {
+      "criterion_id": "GA-02",
+      "evidence": "Validator proves private/non-external requests fail closed before provider request preparation.",
+      "command_or_procedure": "python governance/kpgs-vnext/frontier-harness/google-ai/validate_google_ai_adapter.py"
+    },
+    {
+      "criterion_id": "GA-03",
+      "evidence": "Request body is checked for credential absence and a fake opener verifies x-goog-api-key header injection only at submit time.",
+      "command_or_procedure": "python governance/kpgs-vnext/frontier-harness/google-ai/validate_google_ai_adapter.py"
+    },
+    {
+      "criterion_id": "GA-04",
+      "evidence": "Adapter allow-list contains gemini-3.6-flash and gemini-3.5-flash-lite; validator rejects gemini-2.0-flash.",
+      "command_or_procedure": "Review current Google AI model/deprecation documentation and run validator."
+    },
+    {
+      "criterion_id": "GA-05",
+      "evidence": "Safe request and fake execution receipts assert canonical=false and semantic_authority=kpgs.",
+      "command_or_procedure": "python governance/kpgs-vnext/frontier-harness/google-ai/validate_google_ai_adapter.py"
+    },
+    {
+      "criterion_id": "GA-06",
+      "evidence": "Fake execution captures token usage while receipts carry contains_input=false, contains_output=false, contains_secret=false and SHA-256 output digest.",
+      "command_or_procedure": "python governance/kpgs-vnext/frontier-harness/google-ai/validate_google_ai_adapter.py"
+    },
+    {
+      "criterion_id": "GA-07",
+      "evidence": "Dependency-free fake HTTP response exercises request and provider-response handling without network access.",
+      "command_or_procedure": "python governance/kpgs-vnext/frontier-harness/google-ai/validate_google_ai_adapter.py"
+    }
+  ],
+  "rollback_plan": {
+    "trigger": "Google AI gains hidden authority, a non-permitted classification can leave KPGS, credentials can enter repository/receipts, or model policy diverges from current provider support.",
+    "procedure": "Revert the Google AI v0.3 adapter commit/PR. The Frontier Harness falls back to the deterministic v0.1 mock/local path and no sovereign state depends on Gemini.",
+    "target_ref": "master@a441d61285fea9396eb0ed1e3c055bbe25675045"
+  },
+  "risk_class": "R2",
+  "required_capabilities": [
+    {
+      "capability": "google-ai.generate-content",
+      "scope": "models/gemini-3.6-flash:generateContent"
+    }
+  ],
+  "lifecycle_state": "draft",
+  "related_issues": [46]
+}

--- a/governance/kpgs-vnext/frontier-harness/README.md
+++ b/governance/kpgs-vnext/frontier-harness/README.md
@@ -1,8 +1,8 @@
-# KPGS Frontier Harness v0.1
+# KPGS Frontier Harness
 
-Status: **POC / non-production**
+Status: **POC / non-production / provider promotions in progress**
 
-The Frontier Harness proves that KPGS can consume rented external capabilities without transferring semantic authority, durable state, or governance ownership to the provider.
+The Frontier Harness proves that KPGS can consume rented external capabilities without transferring semantic authority, durable state, governance ownership, or secret custody to the provider.
 
 ## One Engine
 
@@ -15,12 +15,14 @@ kpgs.capability_request.v1
         v
 KPGS capability router
         |
-        +--> Google AI adapter (mock in v0.1)
+        +--> Google AI renter
+        |      `-- v0.3 live-capable / lease-scoped / non-canonical
         |
         v
 kpgs.capability_receipt.v1
         |
-        +--> Snowflake analytics copy (prepared row)
+        +--> Snowflake analytical copy
+        |      `-- v0.2 live-capable / fail-closed
         +--> local SHA-256 commitment
         +--> Solana anchor intent (not broadcast)
         |
@@ -41,35 +43,35 @@ kpgs.modality_contract.v1
 4. **Modality != semantic authority.**
 5. **External analytics != local sovereign state.**
 6. **Input != authority.**
-7. A provider adapter MUST be replaceable without changing the capability request or receipt schemas.
+7. **Secret reference != secret custody.**
+8. A provider adapter MUST be replaceable without changing the capability request/receipt authority model.
 
-## v0.1 provider roles
+## Provider promotion map
 
-| Provider | Governed role | v0.1 state |
+| Provider | Governed role | Current state |
 |---|---|---|
 | Fillout / Zite | structured intake / disposable frontier UI | synthetic fixture |
-| Google AI | rented model/multimodal capability | deterministic mock adapter |
-| Snowflake | analytical copy / evidence telemetry | SQL bootstrap + staged row |
+| Google AI | rented model/multimodal capability | v0.3 live-capable adapter; no live credential receipt yet |
+| Snowflake | analytical copy / evidence telemetry | v0.2 live-capable SQL API adapter; no live write receipt yet |
 | Solana | public commitment anchoring | devnet-ready intent only |
 | ElevenLabs | speech renderer | modality contract declaration only |
 
-No vendor credential is stored in this directory. Live provider execution is deliberately out of scope until a capability lease and secret-provider reference are supplied.
+No vendor credential is stored in this directory. Provider promotion requires a current capability lease plus an external secret-provider reference. A live-capable adapter does not become a claimed live integration until a credential-backed execution receipt exists.
 
-## Run the vertical slice
+## Run the governed gates
 
 ```bash
-python governance/kpgs-vnext/frontier-harness/frontier_harness.py
 python governance/kpgs-vnext/frontier-harness/validate.py
+python governance/kpgs-vnext/frontier-harness/snowflake/validate_snowflake_adapter.py
+python governance/kpgs-vnext/frontier-harness/google-ai/validate_google_ai_adapter.py
 ```
 
-`frontier_harness.py` uses only the Python standard library. It converts the synthetic Fillout-like event into a governed request, routes it through a deterministic Google-AI mock renter, emits a receipt, stages a Snowflake-compatible telemetry row, prepares a Solana devnet anchor intent, and emits a modality contract.
-
-`validate.py` is the dependency-free structural gate for the v0.1 schemas and dry-run invariants.
+The baseline v0.1 harness remains deterministic and provider-independent. Provider-specific promotion adapters sit behind the same KPGS authority boundary and can fail back to the local/mock path.
 
 ## Promotion boundary
 
-The harness is a POC. A provider may move from `mock`/`prepared` to `live` only when KPGS can prove:
+A provider may move from `mock`/`prepared` to a claimed `live` state only when KPGS can prove:
 
-`request -> governing spec -> capability lease -> provider execution -> receipt -> evaluation -> local checkpoint -> optional external copy/anchor -> rollback`
+`request -> governing spec -> capability lease -> external secret resolution -> provider execution -> receipt -> KPGS evaluation -> local checkpoint -> optional external copy/anchor -> rollback`
 
-The local receipt remains authoritative for the execution record. Snowflake is an analytical copy, Solana receives only a commitment, and renderers never receive semantic authority.
+The local KPGS receipt remains authoritative for the execution record. Snowflake is an analytical copy, Google AI is a rented capability, Solana receives only commitments, and renderers never receive semantic authority.

--- a/governance/kpgs-vnext/frontier-harness/google-ai/README.md
+++ b/governance/kpgs-vnext/frontier-harness/google-ai/README.md
@@ -1,0 +1,60 @@
+# Google AI v0.3 — Governed Renter Adapter
+
+Status: **POC / live-capable / fail-closed**
+
+This promotes the Frontier Harness Google AI leg from a deterministic mock to a live-capable Gemini GenerateContent renter while preserving KPGS authority.
+
+## Authority boundary
+
+```text
+KPGS capability request
+        |
+        v
+short-lived capability lease
+        |
+        +-- google-ai.generate-content
+        +-- exact model resource scope
+        +-- external env:// secret reference
+        |
+        v
+Gemini GenerateContent API
+        |
+        v
+non-canonical provider result
+        |
+        v
+KPGS evaluation + receipt
+```
+
+## Governing laws
+
+1. **Provider output != KPGS truth.**
+2. **Model execution != semantic authority.**
+3. **API key != repository state.**
+4. **Private/restricted input does not leave KPGS in v0.3.**
+5. **Model selection is allow-listed and lease-scoped.**
+6. **Receipts keep digests/usage metadata, not raw prompts or model output.**
+
+## Current model policy
+
+The default stable model is `gemini-3.6-flash`; `gemini-3.5-flash-lite` is permitted for high-throughput/low-cost work. Deprecated/shut-down Gemini 2.x identifiers are rejected. Model policy was checked against Google AI documentation on 2026-08-17.
+
+The adapter deliberately avoids deprecated sampling controls such as `temperature`, `top_p`, and `top_k`.
+
+## Authentication
+
+No Google API key is stored in the repository. The capability lease references `env://KPGS_GOOGLE_AI_API_KEY`; runtime resolution supplies the key only to the `x-goog-api-key` HTTP header.
+
+## Gate
+
+```bash
+python governance/kpgs-vnext/frontier-harness/google-ai/validate_google_ai_adapter.py
+```
+
+The gate is dependency-free and network-free. It proves lease enforcement, model allow-listing, private-input rejection, external secret isolation, request construction, response digesting, usage capture, and non-canonical provider output.
+
+## Promotion boundary
+
+A real Google AI call is authorized only when KPGS issues a current lease bound to `kpgs-frontier-harness-google-ai-v0.3`, the request is classified `public` or `synthetic`, `allow_external_processing=true`, and the external API key resolves at runtime.
+
+A successful provider response still remains non-canonical until KPGS evaluates it and emits the governing capability receipt.

--- a/governance/kpgs-vnext/frontier-harness/google-ai/generate_content_adapter.py
+++ b/governance/kpgs-vnext/frontier-harness/google-ai/generate_content_adapter.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Governed Gemini GenerateContent adapter for KPGS Frontier Harness v0.3."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+GOVERNING_SPEC = "kpgs-frontier-harness-google-ai-v0.3"
+REQUIRED_CAPABILITY = "google-ai.generate-content"
+ALLOWED_MODELS = {"gemini-3.6-flash", "gemini-3.5-flash-lite"}
+ALLOWED_CLASSIFICATIONS = {"public", "synthetic"}
+API_ROOT = "https://generativelanguage.googleapis.com/v1beta/models"
+FORBIDDEN_REQUEST_KEYS = {"api_key", "secret", "password", "private_payload"}
+MAX_INPUT_CHARS = 12000
+
+
+class GovernanceError(RuntimeError):
+    pass
+
+
+def _digest(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _parse_time(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        raise GovernanceError("lease timestamps must include timezone")
+    return parsed.astimezone(timezone.utc)
+
+
+@dataclass(frozen=True)
+class GeminiTarget:
+    model: str = "gemini-3.6-flash"
+
+    def endpoint(self) -> str:
+        if self.model not in ALLOWED_MODELS:
+            raise GovernanceError("model is not in the governed allow-list")
+        return f"{API_ROOT}/{self.model}:generateContent"
+
+
+@dataclass(frozen=True)
+class PreparedGeneration:
+    request_id: str
+    endpoint: str
+    body: dict[str, Any]
+    secret_ref: str
+    model: str
+    input_digest: str
+
+    def safe_receipt(self) -> dict[str, Any]:
+        return {
+            "schema_version": "kpgs.google_ai_request_receipt.v1",
+            "request_id": self.request_id,
+            "provider": "google-ai",
+            "model": self.model,
+            "endpoint": self.endpoint,
+            "input_digest": self.input_digest,
+            "contains_input": False,
+            "secret_ref": self.secret_ref,
+            "contains_secret": False,
+            "canonical": False,
+            "semantic_authority": "kpgs",
+        }
+
+
+def validate_lease(lease: dict[str, Any], target: GeminiTarget, *, now: datetime | None = None) -> None:
+    current = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    if lease.get("governing_spec_ref") != GOVERNING_SPEC:
+        raise GovernanceError("lease is not bound to the Google AI v0.3 governing spec")
+
+    subject = lease.get("subject") or {}
+    if subject.get("kind") not in {"adapter", "service", "renter"}:
+        raise GovernanceError("Google AI capability must be leased to an adapter/service/renter")
+
+    expected_scope = f"models/{target.model}:generateContent"
+    capabilities = lease.get("capabilities") or []
+    permitted = any(
+        item.get("name") == REQUIRED_CAPABILITY and item.get("resource_scope") == expected_scope
+        for item in capabilities
+    )
+    if not permitted:
+        raise GovernanceError("lease does not permit the requested Gemini model/resource")
+
+    issued = _parse_time(str(lease.get("issued_at", "")))
+    expires = _parse_time(str(lease.get("expires_at", "")))
+    if not (issued <= current < expires):
+        raise GovernanceError("capability lease is not currently valid")
+
+    secret_refs = lease.get("secret_provider_refs") or []
+    if len(secret_refs) != 1 or not str(secret_refs[0]).startswith("env://"):
+        raise GovernanceError("v0.3 requires exactly one env:// external secret reference")
+
+
+def resolve_env_secret(secret_ref: str, env: dict[str, str] | None = None) -> str:
+    name = secret_ref.removeprefix("env://")
+    if not name or not name.replace("_", "").isalnum() or not name.upper() == name:
+        raise GovernanceError("invalid env secret reference")
+    source = env if env is not None else os.environ
+    value = source.get(name)
+    if not value:
+        raise GovernanceError(f"secret provider did not resolve {secret_ref}")
+    return value
+
+
+def prepare_generation(request: dict[str, Any], lease: dict[str, Any], target: GeminiTarget, *, now: datetime | None = None) -> PreparedGeneration:
+    validate_lease(lease, target, now=now)
+    forbidden = FORBIDDEN_REQUEST_KEYS.intersection(request)
+    if forbidden:
+        raise GovernanceError(f"forbidden request fields: {sorted(forbidden)}")
+
+    policy = request.get("policy") or {}
+    classification = policy.get("data_classification")
+    if classification not in ALLOWED_CLASSIFICATIONS or policy.get("allow_external_processing") is not True:
+        raise GovernanceError("request policy does not authorize external Google AI processing")
+
+    text = request.get("semantic_input")
+    if not isinstance(text, str) or not text.strip():
+        raise GovernanceError("semantic_input must be non-empty text")
+    if len(text) > MAX_INPUT_CHARS:
+        raise GovernanceError("semantic_input exceeds governed v0.3 size limit")
+
+    request_id = str(request.get("request_id") or "")
+    if len(request_id) < 8:
+        raise GovernanceError("request_id is missing or too short")
+
+    body = {
+        "contents": [{"role": "user", "parts": [{"text": text}]}],
+        "systemInstruction": {
+            "parts": [{
+                "text": (
+                    "You are a rented capability inside KPGS. Return useful task output only. "
+                    "Do not claim canonical authority, user consent, policy authority, or durable state."
+                )
+            }]
+        },
+    }
+    serialized = json.dumps(body, sort_keys=True).lower()
+    if "api_key" in serialized or "x-goog-api-key" in serialized:
+        raise GovernanceError("request body must never contain credentials")
+
+    return PreparedGeneration(
+        request_id=request_id,
+        endpoint=target.endpoint(),
+        body=body,
+        secret_ref=str(lease["secret_provider_refs"][0]),
+        model=target.model,
+        input_digest=_digest(text),
+    )
+
+
+def _extract_text(payload: dict[str, Any]) -> str:
+    chunks: list[str] = []
+    for candidate in payload.get("candidates") or []:
+        content = candidate.get("content") or {}
+        for part in content.get("parts") or []:
+            text = part.get("text")
+            if isinstance(text, str):
+                chunks.append(text)
+    return "\n".join(chunks).strip()
+
+
+def submit_prepared(
+    prepared: PreparedGeneration,
+    *,
+    secret_resolver: Callable[[str], str] = resolve_env_secret,
+    opener: Callable[..., Any] = urllib.request.urlopen,
+) -> dict[str, Any]:
+    api_key = secret_resolver(prepared.secret_ref)
+    payload = json.dumps(prepared.body, separators=(",", ":")).encode("utf-8")
+    http_request = urllib.request.Request(
+        prepared.endpoint,
+        data=payload,
+        method="POST",
+        headers={
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "x-goog-api-key": api_key,
+            "User-Agent": "KPGS-Frontier-Harness/0.3",
+        },
+    )
+    try:
+        with opener(http_request, timeout=45) as response:
+            raw = response.read().decode("utf-8")
+            result = json.loads(raw) if raw else {}
+            output = _extract_text(result)
+            usage = result.get("usageMetadata") or {}
+            finish_reasons = [
+                candidate.get("finishReason")
+                for candidate in result.get("candidates") or []
+                if candidate.get("finishReason")
+            ]
+            return {
+                "schema_version": "kpgs.google_ai_execution_receipt.v1",
+                "request_id": prepared.request_id,
+                "provider": "google-ai",
+                "model": prepared.model,
+                "http_status": getattr(response, "status", 200),
+                "input_digest": prepared.input_digest,
+                "output_digest": _digest(output),
+                "output_ref": None,
+                "finish_reasons": finish_reasons,
+                "usage": {
+                    "prompt_tokens": usage.get("promptTokenCount"),
+                    "candidate_tokens": usage.get("candidatesTokenCount"),
+                    "total_tokens": usage.get("totalTokenCount"),
+                },
+                "contains_input": False,
+                "contains_output": False,
+                "contains_secret": False,
+                "canonical": False,
+                "semantic_authority": "kpgs",
+            }
+    except urllib.error.HTTPError as exc:
+        raw = exc.read().decode("utf-8", errors="replace")
+        try:
+            detail = json.loads(raw)
+        except json.JSONDecodeError:
+            detail = {}
+        error = detail.get("error") or {}
+        return {
+            "schema_version": "kpgs.google_ai_execution_receipt.v1",
+            "request_id": prepared.request_id,
+            "provider": "google-ai",
+            "model": prepared.model,
+            "http_status": exc.code,
+            "input_digest": prepared.input_digest,
+            "output_digest": None,
+            "output_ref": None,
+            "finish_reasons": [],
+            "usage": {"prompt_tokens": None, "candidate_tokens": None, "total_tokens": None},
+            "error_code": error.get("code"),
+            "error_status": error.get("status"),
+            "contains_input": False,
+            "contains_output": False,
+            "contains_secret": False,
+            "canonical": False,
+            "semantic_authority": "kpgs",
+        }

--- a/governance/kpgs-vnext/frontier-harness/google-ai/validate_google_ai_adapter.py
+++ b/governance/kpgs-vnext/frontier-harness/google-ai/validate_google_ai_adapter.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Dependency-free gate for the KPGS Google AI v0.3 adapter."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise SystemExit(f"KPGS-GOOGLE-AI FAIL: {message}")
+
+
+def load_adapter():
+    spec = importlib.util.spec_from_file_location("kpgs_google_ai_adapter", ROOT / "generate_content_adapter.py")
+    require(spec is not None and spec.loader is not None, "adapter must be importable")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeResponse:
+    status = 200
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self):
+        return json.dumps({
+            "candidates": [{
+                "content": {"parts": [{"text": "Provider result for KPGS evaluation."}]},
+                "finishReason": "STOP"
+            }],
+            "usageMetadata": {
+                "promptTokenCount": 22,
+                "candidatesTokenCount": 8,
+                "totalTokenCount": 30
+            }
+        }).encode("utf-8")
+
+
+def main() -> None:
+    adapter = load_adapter()
+    now = datetime(2026, 8, 17, 15, 50, tzinfo=timezone.utc)
+    target = adapter.GeminiTarget("gemini-3.6-flash")
+    lease = {
+        "lease_id": "lease_google_ai_test_001",
+        "subject": {"id": "frontier-google-ai-adapter", "kind": "adapter"},
+        "tenant_id": "kopano-labs",
+        "domain_id": "Introduction-to-MCP",
+        "task_id": "frontier-google-ai-v0.3-test",
+        "capabilities": [{
+            "name": "google-ai.generate-content",
+            "resource_scope": "models/gemini-3.6-flash:generateContent",
+            "constraints": ["public-or-synthetic-only", "non-canonical-output"]
+        }],
+        "issued_at": (now - timedelta(minutes=1)).isoformat().replace("+00:00", "Z"),
+        "expires_at": (now + timedelta(minutes=5)).isoformat().replace("+00:00", "Z"),
+        "policy_decision_ref": "policy://frontier-google-ai-v0.3/test",
+        "governing_spec_ref": "kpgs-frontier-harness-google-ai-v0.3",
+        "secret_provider_refs": ["env://KPGS_GOOGLE_AI_API_KEY"],
+    }
+    request = {
+        "schema_version": "kpgs.capability_request.v1",
+        "request_id": "req_google_ai_validation_001",
+        "created_at": now.isoformat().replace("+00:00", "Z"),
+        "source": {"provider": "fillout", "event_id": "evt_test", "trust": "untrusted-input"},
+        "capability": {
+            "name": "reasoning",
+            "purpose": "validate rented model boundary",
+            "preferred_provider": "google-ai",
+            "requested_modality": "text",
+        },
+        "policy": {
+            "data_classification": "synthetic",
+            "allow_external_processing": True,
+            "allow_public_anchor": True,
+            "governing_spec_ref": "kpgs-frontier-harness-v0.1",
+            "capability_lease_ref": "lease_google_ai_test_001",
+        },
+        "semantic_input": "Explain why a rented model must not become the canonical authority.",
+    }
+
+    prepared = adapter.prepare_generation(request, lease, target, now=now)
+    body_text = json.dumps(prepared.body, sort_keys=True).lower()
+    safe = prepared.safe_receipt()
+
+    require(prepared.endpoint.endswith("/v1beta/models/gemini-3.6-flash:generateContent"), "wrong Gemini endpoint")
+    require("x-goog-api-key" not in body_text and "api_key" not in body_text, "credential leaked into body")
+    require(safe["contains_input"] is False and safe["contains_secret"] is False, "safe request receipt leaked sensitive material")
+    require(safe["canonical"] is False and safe["semantic_authority"] == "kpgs", "authority boundary violated")
+
+    captured = {}
+
+    def fake_opener(http_request, timeout):
+        captured["headers"] = dict(http_request.header_items())
+        captured["timeout"] = timeout
+        return FakeResponse()
+
+    execution = adapter.submit_prepared(
+        prepared,
+        secret_resolver=lambda _ref: "test-api-key-not-a-real-secret",
+        opener=fake_opener,
+    )
+    headers = {k.lower(): v for k, v in captured["headers"].items()}
+    require(headers.get("x-goog-api-key") == "test-api-key-not-a-real-secret", "API key must be sent in x-goog-api-key header")
+    require(execution["http_status"] == 200, "fake execution should succeed")
+    require(execution["contains_output"] is False and execution["contains_secret"] is False, "execution receipt leaked content/secret")
+    require(execution["output_digest"] and len(execution["output_digest"]) == 64, "output must be digest-bound")
+    require(execution["canonical"] is False and execution["semantic_authority"] == "kpgs", "provider result self-canonicalized")
+    require(execution["usage"]["total_tokens"] == 30, "usage metadata was not captured")
+
+    private_request = json.loads(json.dumps(request))
+    private_request["policy"]["data_classification"] = "private"
+    private_request["policy"]["allow_external_processing"] = False
+    try:
+        adapter.prepare_generation(private_request, lease, target, now=now)
+    except adapter.GovernanceError:
+        pass
+    else:
+        raise SystemExit("KPGS-GOOGLE-AI FAIL: private request was allowed to leave KPGS")
+
+    expired = dict(lease)
+    expired["issued_at"] = "2026-08-16T00:00:00Z"
+    expired["expires_at"] = "2026-08-16T00:10:00Z"
+    try:
+        adapter.prepare_generation(request, expired, target, now=now)
+    except adapter.GovernanceError:
+        pass
+    else:
+        raise SystemExit("KPGS-GOOGLE-AI FAIL: expired capability lease was accepted")
+
+    try:
+        adapter.prepare_generation(request, lease, adapter.GeminiTarget("gemini-2.0-flash"), now=now)
+    except adapter.GovernanceError:
+        pass
+    else:
+        raise SystemExit("KPGS-GOOGLE-AI FAIL: deprecated/non-allow-listed model was accepted")
+
+    print("KPGS-GOOGLE-AI PASS: live-capable renter adapter is leased, fail-closed and non-canonical.")
+    print(f"Prepared: {prepared.request_id} -> {prepared.endpoint}")
+    print(f"Receipt digest: {execution['output_digest']}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Outcome

Promotes the Google AI leg of the Frontier Harness from the deterministic v0.1 mock to a **live-capable, fail-closed Gemini GenerateContent renter** while keeping KPGS as router, evaluator, receipt authority and semantic authority.

Control boundary:

`KPGS request -> current capability lease -> external API-key reference -> Gemini GenerateContent -> non-canonical provider result -> KPGS receipt/evaluation`

## Current provider alignment

Checked against Google AI documentation on 2026-08-17:
- REST endpoint: `POST https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent`
- authentication: `x-goog-api-key`
- default governed model: `gemini-3.6-flash`
- high-throughput alternate: `gemini-3.5-flash-lite`
- deprecated/shut-down `gemini-2.0-flash` is explicitly rejected
- deprecated sampling controls (`temperature`, `top_p`, `top_k`) are intentionally omitted

## Governance

- exact capability: `google-ai.generate-content`
- exact resource scope bound by lease: `models/<model>:generateContent`
- only `public` or `synthetic` input is allowed in v0.3
- `allow_external_processing=true` is mandatory
- API key is referenced as `env://KPGS_GOOGLE_AI_API_KEY` and injected only into the HTTP header at execution time
- request/execution receipts retain SHA-256 digests + usage metadata, not raw prompt/output or secrets
- provider result is always `canonical=false`
- semantic authority remains `kpgs`

## Manual validation receipt

The dependency-free, network-free gate was executed against the authored implementation and passed:

`KPGS-GOOGLE-AI PASS: live-capable renter adapter is leased, fail-closed and non-canonical.`

Prepared endpoint:
`https://generativelanguage.googleapis.com/v1beta/models/gemini-3.6-flash:generateContent`

Synthetic output digest:
`b23feda92d5649d01066c626a26af45897d70d178fa62581722d414a32cc7b6a`

The validator additionally proves private-input rejection, expired-lease rejection, deprecated-model rejection, x-goog-api-key header injection, usage capture, and secret/content-free receipts.

## Live boundary

No real Gemini execution is claimed: this environment does not have the user's Google AI API credential. v0.3 is **live-capable**, not yet credential-proven live. A claimed live state requires an actual external-key-backed execution receipt.

## Risk

`R2 / draft / non-production` until a real provider execution receipt exists.