### PR TITLE
[POC] KPGS Frontier Harness v0.4 — ElevenLabs governed speech modality

### DIFF
--- a/governance/kpgs-vnext/agent-governance/specs/frontier-elevenlabs-v0.4.json
+++ b/governance/kpgs-vnext/agent-governance/specs/frontier-elevenlabs-v0.4.json
@@ -1,0 +1,152 @@
+{
+  "spec_id": "kpgs-frontier-harness-elevenlabs-v0.4",
+  "title": "KPGS Frontier Harness — ElevenLabs Governed Speech Renderer v0.4",
+  "outcome": "Promote the ElevenLabs leg from a declared speech renderer to a live-capable text-to-speech modality adapter while preserving KPGS semantic authority, accessibility fallback, secret isolation, and provider replaceability.",
+  "scope": {
+    "included": [
+      "Add a dependency-free ElevenLabs text-to-speech REST adapter",
+      "Require a current capability lease scoped to an exact voice/model renderer",
+      "Require a kpgs.modality_contract.v1 selecting speech and elevenlabs-speech",
+      "Require native-text fallback and text-equivalent accessibility",
+      "Resolve the ElevenLabs API key only from an external env:// secret reference",
+      "Allow only public or synthetic external rendering in v0.4",
+      "Digest-bind semantic text and returned audio without storing either in execution receipts",
+      "Provide a network-free executable governance gate"
+    ],
+    "excluded": [
+      "Committing or persisting an ElevenLabs API key",
+      "Sending private or restricted KPGS semantic content to ElevenLabs",
+      "Treating generated audio as canonical meaning or consent",
+      "Giving a renderer authority to edit semantic content",
+      "Voice cloning or voice identity creation",
+      "Claiming a live ElevenLabs execution receipt without a real credential-backed call"
+    ]
+  },
+  "interfaces": [
+    {
+      "name": "KPGS modality contract",
+      "contract": "Speech rendering requires primary=speech, renderer=elevenlabs-speech, renderer_has_semantic_authority=false, and native-text fallback.",
+      "version": "kpgs.modality_contract.v1"
+    },
+    {
+      "name": "Capability lease",
+      "contract": "elevenlabs.tts.generate is leased to an adapter/service/renter and bound to an exact voice/<voice_id>/model/<model_id> scope.",
+      "version": "capability-lease.schema.json"
+    },
+    {
+      "name": "ElevenLabs Text to Speech",
+      "contract": "The adapter uses POST /v1/text-to-speech/{voice_id} and sends the runtime API key only in the xi-api-key header.",
+      "version": "v1"
+    },
+    {
+      "name": "KPGS renderer receipt",
+      "contract": "Execution receipts contain text/audio digests and metadata but no raw semantic text, audio bytes, or API key; renderer semantic authority remains false.",
+      "version": "kpgs.elevenlabs_execution_receipt.v1"
+    }
+  ],
+  "constraints": [
+    "Modality != semantic authority.",
+    "Speech renderer != human consent.",
+    "Every speech path must preserve a native text equivalent in v0.4.",
+    "Only public or synthetic data may be sent to ElevenLabs in v0.4.",
+    "Every live call requires a current capability lease and exactly one external env:// secret reference.",
+    "Voice/model selection must be lease-scoped.",
+    "Receipts may contain text/audio digests and byte counts but not raw text or audio.",
+    "No live provider execution may be claimed without a credential-backed execution receipt."
+  ],
+  "acceptance_criteria": [
+    {
+      "id": "EL-01",
+      "statement": "ElevenLabs execution requires a current lease scoped to elevenlabs.tts.generate and the exact voice/model renderer.",
+      "hard_gate": true,
+      "verification_methods": ["unit", "security"]
+    },
+    {
+      "id": "EL-02",
+      "statement": "Speech rendering requires a valid modality contract with renderer_has_semantic_authority=false and native-text fallback.",
+      "hard_gate": true,
+      "verification_methods": ["unit", "accessibility"]
+    },
+    {
+      "id": "EL-03",
+      "statement": "Only public or synthetic requests with allow_external_processing=true can reach TTS request preparation.",
+      "hard_gate": true,
+      "verification_methods": ["unit", "security"]
+    },
+    {
+      "id": "EL-04",
+      "statement": "The API key remains external and is transmitted only through xi-api-key at execution time.",
+      "hard_gate": true,
+      "verification_methods": ["unit", "security"]
+    },
+    {
+      "id": "EL-05",
+      "statement": "The governed model allow-list contains current TTS models and excludes deprecated Turbo identifiers.",
+      "hard_gate": true,
+      "verification_methods": ["unit", "human-review"]
+    },
+    {
+      "id": "EL-06",
+      "statement": "Execution receipts exclude raw text, raw audio, and secret while preserving digests, model, voice, byte count, and HTTP evidence.",
+      "hard_gate": true,
+      "verification_methods": ["unit", "security"]
+    },
+    {
+      "id": "EL-07",
+      "statement": "The network-free validator proves the live-capable speech path without claiming a real provider call.",
+      "hard_gate": false,
+      "verification_methods": ["integration"]
+    }
+  ],
+  "verification_plan": [
+    {
+      "criterion_id": "EL-01",
+      "evidence": "validate_elevenlabs_adapter.py proves valid scoped lease acceptance and expired lease rejection.",
+      "command_or_procedure": "python governance/kpgs-vnext/frontier-harness/elevenlabs/validate_elevenlabs_adapter.py"
+    },
+    {
+      "criterion_id": "EL-02",
+      "evidence": "Validator requires speech + elevenlabs-speech + native-text fallback and separately proves missing fallback rejection.",
+      "command_or_procedure": "python governance/kpgs-vnext/frontier-harness/elevenlabs/validate_elevenlabs_adapter.py"
+    },
+    {
+      "criterion_id": "EL-03",
+      "evidence": "Validator proves private/non-external requests fail closed before renderer request preparation.",
+      "command_or_procedure": "python governance/kpgs-vnext/frontier-harness/elevenlabs/validate_elevenlabs_adapter.py"
+    },
+    {
+      "criterion_id": "EL-04",
+      "evidence": "Request body is credential-free and a fake opener verifies xi-api-key header injection only at submit time.",
+      "command_or_procedure": "python governance/kpgs-vnext/frontier-harness/elevenlabs/validate_elevenlabs_adapter.py"
+    },
+    {
+      "criterion_id": "EL-05",
+      "evidence": "Adapter allow-list contains eleven_flash_v2_5, eleven_multilingual_v2 and eleven_v3; deprecated Turbo IDs are absent.",
+      "command_or_procedure": "Review current ElevenLabs model documentation and run validator."
+    },
+    {
+      "criterion_id": "EL-06",
+      "evidence": "Fake execution creates SHA-256 audio digest and byte count while contains_text=false, contains_audio=false, contains_secret=false.",
+      "command_or_procedure": "python governance/kpgs-vnext/frontier-harness/elevenlabs/validate_elevenlabs_adapter.py"
+    },
+    {
+      "criterion_id": "EL-07",
+      "evidence": "Dependency-free fake audio response exercises request and response handling without network access.",
+      "command_or_procedure": "python governance/kpgs-vnext/frontier-harness/elevenlabs/validate_elevenlabs_adapter.py"
+    }
+  ],
+  "rollback_plan": {
+    "trigger": "The renderer gains semantic authority, a speech path can omit its text fallback, private data can leave KPGS, or credentials can enter repository/receipts.",
+    "procedure": "Revert the ElevenLabs v0.4 adapter commit/PR. The modality contract falls back to native-text and no sovereign state depends on ElevenLabs.",
+    "target_ref": "master@0b42221b177fee5fc770c5d898ee410d2352c11e"
+  },
+  "risk_class": "R2",
+  "required_capabilities": [
+    {
+      "capability": "elevenlabs.tts.generate",
+      "scope": "voice/<voice_id>/model/eleven_flash_v2_5"
+    }
+  ],
+  "lifecycle_state": "draft",
+  "related_issues": [46]
+}

--- a/governance/kpgs-vnext/frontier-harness/README.md
+++ b/governance/kpgs-vnext/frontier-harness/README.md
@@ -31,7 +31,7 @@ kpgs.modality_contract.v1
         |
         +--> text
         +--> visual
-        +--> speech
+        +--> speech --> ElevenLabs v0.4 live-capable renderer
         `--> haptic/event
 ```
 
@@ -44,7 +44,8 @@ kpgs.modality_contract.v1
 5. **External analytics != local sovereign state.**
 6. **Input != authority.**
 7. **Secret reference != secret custody.**
-8. A provider adapter MUST be replaceable without changing the capability request/receipt authority model.
+8. **Speech output != canonical meaning.**
+9. A provider adapter MUST be replaceable without changing the capability request/receipt authority model.
 
 ## Provider promotion map
 
@@ -54,7 +55,7 @@ kpgs.modality_contract.v1
 | Google AI | rented model/multimodal capability | v0.3 live-capable adapter; no live credential receipt yet |
 | Snowflake | analytical copy / evidence telemetry | v0.2 live-capable SQL API adapter; no live write receipt yet |
 | Solana | public commitment anchoring | devnet-ready intent only |
-| ElevenLabs | speech renderer | modality contract declaration only |
+| ElevenLabs | speech renderer | v0.4 live-capable renderer; native-text fallback mandatory; no live credential receipt yet |
 
 No vendor credential is stored in this directory. Provider promotion requires a current capability lease plus an external secret-provider reference. A live-capable adapter does not become a claimed live integration until a credential-backed execution receipt exists.
 
@@ -64,9 +65,10 @@ No vendor credential is stored in this directory. Provider promotion requires a 
 python governance/kpgs-vnext/frontier-harness/validate.py
 python governance/kpgs-vnext/frontier-harness/snowflake/validate_snowflake_adapter.py
 python governance/kpgs-vnext/frontier-harness/google-ai/validate_google_ai_adapter.py
+python governance/kpgs-vnext/frontier-harness/elevenlabs/validate_elevenlabs_adapter.py
 ```
 
-The baseline v0.1 harness remains deterministic and provider-independent. Provider-specific promotion adapters sit behind the same KPGS authority boundary and can fail back to the local/mock path.
+The baseline v0.1 harness remains deterministic and provider-independent. Provider-specific promotion adapters sit behind the same KPGS authority boundary and can fail back to local/mock or native rendering paths.
 
 ## Promotion boundary
 
@@ -74,4 +76,8 @@ A provider may move from `mock`/`prepared` to a claimed `live` state only when K
 
 `request -> governing spec -> capability lease -> external secret resolution -> provider execution -> receipt -> KPGS evaluation -> local checkpoint -> optional external copy/anchor -> rollback`
 
-The local KPGS receipt remains authoritative for the execution record. Snowflake is an analytical copy, Google AI is a rented capability, Solana receives only commitments, and renderers never receive semantic authority.
+For renderers the chain additionally requires:
+
+`evaluated semantic output -> modality contract -> accessibility fallback -> renderer execution -> digest receipt`
+
+The local KPGS receipt remains authoritative for the execution record. Snowflake is an analytical copy, Google AI is a rented capability, Solana receives only commitments, and ElevenLabs renders speech without receiving semantic authority.

--- a/governance/kpgs-vnext/frontier-harness/elevenlabs/README.md
+++ b/governance/kpgs-vnext/frontier-harness/elevenlabs/README.md
@@ -1,0 +1,57 @@
+# ElevenLabs v0.4 — Governed Speech Modality Adapter
+
+Status: **POC / live-capable / renderer-only**
+
+This promotes the ElevenLabs leg of the Frontier Harness from a modality declaration to a live-capable text-to-speech renderer while preserving the KPGS semantic boundary.
+
+## Authority boundary
+
+```text
+KPGS evaluated semantic output
+        |
+        v
+kpgs.modality_contract.v1
+        |
+        +-- primary = speech
+        +-- renderer = elevenlabs-speech
+        +-- fallback = native-text
+        +-- renderer_has_semantic_authority = false
+        |
+        v
+short-lived capability lease
+        |
+        v
+ElevenLabs TTS API
+        |
+        v
+audio digest receipt
+```
+
+## Governing laws
+
+1. **Modality != semantic authority.**
+2. **Speech renderer != user consent.**
+3. **Audio generation != canonical meaning.**
+4. **A speech path must preserve a native text equivalent.**
+5. **Private/restricted semantic text does not leave KPGS in v0.4.**
+6. **API credentials remain external to repository and receipts.**
+
+## Current provider policy
+
+The balanced/low-latency default is `eleven_flash_v2_5`. `eleven_multilingual_v2` and `eleven_v3` are permitted alternatives for quality/expressiveness. Deprecated Turbo identifiers are not allow-listed.
+
+The adapter uses `POST /v1/text-to-speech/{voice_id}` and injects the runtime API key only through the `xi-api-key` header.
+
+## Gate
+
+```bash
+python governance/kpgs-vnext/frontier-harness/elevenlabs/validate_elevenlabs_adapter.py
+```
+
+The network-free validator proves exact lease scope, speech-only modality selection, required native-text fallback, external secret isolation, private-input rejection, audio digesting, and `renderer_has_semantic_authority=false`.
+
+## Promotion boundary
+
+A real speech generation is authorized only when KPGS has already evaluated the semantic content, the modality contract explicitly selects speech, a native-text fallback exists, the request is public/synthetic and externally shareable, a current scoped lease exists, and the external API key resolves at runtime.
+
+The execution receipt records hashes and metadata, not raw text, audio, or credentials.

--- a/governance/kpgs-vnext/frontier-harness/elevenlabs/tts_adapter.py
+++ b/governance/kpgs-vnext/frontier-harness/elevenlabs/tts_adapter.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Governed ElevenLabs text-to-speech renderer for KPGS Frontier Harness v0.4."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+GOVERNING_SPEC = "kpgs-frontier-harness-elevenlabs-v0.4"
+REQUIRED_CAPABILITY = "elevenlabs.tts.generate"
+ALLOWED_MODELS = {"eleven_flash_v2_5", "eleven_multilingual_v2", "eleven_v3"}
+ALLOWED_CLASSIFICATIONS = {"public", "synthetic"}
+API_ROOT = "https://api.elevenlabs.io/v1/text-to-speech"
+VOICE_ID_RE = re.compile(r"^[A-Za-z0-9_-]{8,64}$")
+MAX_TEXT_CHARS = 5000
+
+
+class GovernanceError(RuntimeError):
+    pass
+
+
+def digest_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def digest_text(value: str) -> str:
+    return digest_bytes(value.encode("utf-8"))
+
+
+def _parse_time(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        raise GovernanceError("lease timestamps must include timezone")
+    return parsed.astimezone(timezone.utc)
+
+
+@dataclass(frozen=True)
+class ElevenLabsTarget:
+    voice_id: str
+    model: str = "eleven_flash_v2_5"
+    output_format: str = "mp3_44100_128"
+
+    def endpoint(self) -> str:
+        if not VOICE_ID_RE.fullmatch(self.voice_id):
+            raise GovernanceError("invalid ElevenLabs voice id")
+        if self.model not in ALLOWED_MODELS:
+            raise GovernanceError("model is not in the governed allow-list")
+        return f"{API_ROOT}/{self.voice_id}?output_format={urllib.parse.quote(self.output_format, safe='')}"
+
+
+@dataclass(frozen=True)
+class PreparedSpeech:
+    request_id: str
+    endpoint: str
+    body: dict[str, Any]
+    secret_ref: str
+    voice_id: str
+    model: str
+    text_digest: str
+
+    def safe_receipt(self) -> dict[str, Any]:
+        return {
+            "schema_version": "kpgs.elevenlabs_request_receipt.v1",
+            "request_id": self.request_id,
+            "provider": "elevenlabs",
+            "voice_id": self.voice_id,
+            "model": self.model,
+            "text_digest": self.text_digest,
+            "contains_text": False,
+            "contains_secret": False,
+            "renderer_has_semantic_authority": False,
+            "semantic_authority": "kpgs",
+        }
+
+
+def validate_lease(lease: dict[str, Any], target: ElevenLabsTarget, *, now: datetime | None = None) -> None:
+    current = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    if lease.get("governing_spec_ref") != GOVERNING_SPEC:
+        raise GovernanceError("lease is not bound to the ElevenLabs v0.4 governing spec")
+    subject = lease.get("subject") or {}
+    if subject.get("kind") not in {"adapter", "service", "renter"}:
+        raise GovernanceError("ElevenLabs capability must be leased to an adapter/service/renter")
+    expected_scope = f"voice/{target.voice_id}/model/{target.model}"
+    capabilities = lease.get("capabilities") or []
+    permitted = any(
+        item.get("name") == REQUIRED_CAPABILITY and item.get("resource_scope") == expected_scope
+        for item in capabilities
+    )
+    if not permitted:
+        raise GovernanceError("lease does not permit this voice/model renderer scope")
+    issued = _parse_time(str(lease.get("issued_at", "")))
+    expires = _parse_time(str(lease.get("expires_at", "")))
+    if not (issued <= current < expires):
+        raise GovernanceError("capability lease is not currently valid")
+    refs = lease.get("secret_provider_refs") or []
+    if len(refs) != 1 or not str(refs[0]).startswith("env://"):
+        raise GovernanceError("v0.4 requires exactly one env:// external secret reference")
+
+
+def resolve_env_secret(secret_ref: str, env: dict[str, str] | None = None) -> str:
+    name = secret_ref.removeprefix("env://")
+    if not name or not name.replace("_", "").isalnum() or name.upper() != name:
+        raise GovernanceError("invalid env secret reference")
+    source = env if env is not None else os.environ
+    value = source.get(name)
+    if not value:
+        raise GovernanceError(f"secret provider did not resolve {secret_ref}")
+    return value
+
+
+def validate_modality_contract(contract: dict[str, Any]) -> None:
+    if contract.get("schema_version") != "kpgs.modality_contract.v1":
+        raise GovernanceError("unexpected modality contract")
+    if contract.get("primary") != "speech":
+        raise GovernanceError("ElevenLabs renderer requires primary=speech")
+    if "elevenlabs-speech" not in (contract.get("renderers") or []):
+        raise GovernanceError("modality contract does not select ElevenLabs speech")
+    if contract.get("renderer_has_semantic_authority") is not False:
+        raise GovernanceError("renderer cannot receive semantic authority")
+    if "native-text" not in (contract.get("fallbacks") or []):
+        raise GovernanceError("speech modality must retain native-text fallback")
+    accessibility = contract.get("accessibility") or {}
+    if accessibility.get("text_equivalent_required") is not True:
+        raise GovernanceError("speech modality requires a text equivalent")
+
+
+def prepare_speech(
+    semantic_text: str,
+    request: dict[str, Any],
+    modality_contract: dict[str, Any],
+    lease: dict[str, Any],
+    target: ElevenLabsTarget,
+    *,
+    now: datetime | None = None,
+) -> PreparedSpeech:
+    validate_lease(lease, target, now=now)
+    validate_modality_contract(modality_contract)
+    policy = request.get("policy") or {}
+    if policy.get("data_classification") not in ALLOWED_CLASSIFICATIONS or policy.get("allow_external_processing") is not True:
+        raise GovernanceError("request policy does not authorize external speech rendering")
+    if not isinstance(semantic_text, str) or not semantic_text.strip():
+        raise GovernanceError("semantic text must be non-empty")
+    if len(semantic_text) > MAX_TEXT_CHARS:
+        raise GovernanceError("semantic text exceeds governed v0.4 renderer limit")
+    request_id = str(request.get("request_id") or "")
+    if len(request_id) < 8 or modality_contract.get("request_id") != request_id:
+        raise GovernanceError("request/modality correlation mismatch")
+    body = {"text": semantic_text, "model_id": target.model}
+    return PreparedSpeech(
+        request_id=request_id,
+        endpoint=target.endpoint(),
+        body=body,
+        secret_ref=str(lease["secret_provider_refs"][0]),
+        voice_id=target.voice_id,
+        model=target.model,
+        text_digest=digest_text(semantic_text),
+    )
+
+
+def submit_prepared(
+    prepared: PreparedSpeech,
+    *,
+    secret_resolver: Callable[[str], str] = resolve_env_secret,
+    opener: Callable[..., Any] = urllib.request.urlopen,
+) -> dict[str, Any]:
+    api_key = secret_resolver(prepared.secret_ref)
+    payload = json.dumps(prepared.body, separators=(",", ":")).encode("utf-8")
+    request = urllib.request.Request(
+        prepared.endpoint,
+        data=payload,
+        method="POST",
+        headers={
+            "Content-Type": "application/json",
+            "Accept": "audio/mpeg",
+            "xi-api-key": api_key,
+            "User-Agent": "KPGS-Frontier-Harness/0.4",
+        },
+    )
+    try:
+        with opener(request, timeout=45) as response:
+            audio = response.read()
+            return {
+                "schema_version": "kpgs.elevenlabs_execution_receipt.v1",
+                "request_id": prepared.request_id,
+                "provider": "elevenlabs",
+                "voice_id": prepared.voice_id,
+                "model": prepared.model,
+                "http_status": getattr(response, "status", 200),
+                "content_type": response.headers.get("Content-Type") if getattr(response, "headers", None) else None,
+                "text_digest": prepared.text_digest,
+                "audio_digest": digest_bytes(audio),
+                "audio_bytes": len(audio),
+                "contains_text": False,
+                "contains_audio": False,
+                "contains_secret": False,
+                "renderer_has_semantic_authority": False,
+                "semantic_authority": "kpgs",
+            }
+    except urllib.error.HTTPError as exc:
+        return {
+            "schema_version": "kpgs.elevenlabs_execution_receipt.v1",
+            "request_id": prepared.request_id,
+            "provider": "elevenlabs",
+            "voice_id": prepared.voice_id,
+            "model": prepared.model,
+            "http_status": exc.code,
+            "text_digest": prepared.text_digest,
+            "audio_digest": None,
+            "audio_bytes": 0,
+            "contains_text": False,
+            "contains_audio": False,
+            "contains_secret": False,
+            "renderer_has_semantic_authority": False,
+            "semantic_authority": "kpgs",
+        }

--- a/governance/kpgs-vnext/frontier-harness/elevenlabs/validate_elevenlabs_adapter.py
+++ b/governance/kpgs-vnext/frontier-harness/elevenlabs/validate_elevenlabs_adapter.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Dependency-free gate for KPGS ElevenLabs modality v0.4."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise SystemExit(f"KPGS-ELEVENLABS FAIL: {message}")
+
+
+def load_adapter():
+    spec = importlib.util.spec_from_file_location("kpgs_elevenlabs_adapter", ROOT / "tts_adapter.py")
+    require(spec is not None and spec.loader is not None, "adapter must be importable")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeHeaders:
+    def get(self, name, default=None):
+        return "audio/mpeg" if name.lower() == "content-type" else default
+
+
+class FakeResponse:
+    status = 200
+    headers = FakeHeaders()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self):
+        return b"ID3FAKE-MP3-KPGS-AUDIO"
+
+
+def main() -> None:
+    adapter = load_adapter()
+    now = datetime(2026, 8, 17, 16, 0, tzinfo=timezone.utc)
+    voice_id = "JBFqnCBsd6RMkjVDRZzb"
+    target = adapter.ElevenLabsTarget(voice_id, "eleven_flash_v2_5")
+    lease = {
+        "lease_id": "lease_elevenlabs_test_001",
+        "subject": {"id": "frontier-elevenlabs-renderer", "kind": "adapter"},
+        "tenant_id": "kopano-labs",
+        "domain_id": "Introduction-to-MCP",
+        "task_id": "frontier-elevenlabs-v0.4-test",
+        "capabilities": [{
+            "name": "elevenlabs.tts.generate",
+            "resource_scope": f"voice/{voice_id}/model/eleven_flash_v2_5",
+            "constraints": ["renderer-only", "text-equivalent-required"]
+        }],
+        "issued_at": (now - timedelta(minutes=1)).isoformat().replace("+00:00", "Z"),
+        "expires_at": (now + timedelta(minutes=5)).isoformat().replace("+00:00", "Z"),
+        "policy_decision_ref": "policy://frontier-elevenlabs-v0.4/test",
+        "governing_spec_ref": "kpgs-frontier-harness-elevenlabs-v0.4",
+        "secret_provider_refs": ["env://KPGS_ELEVENLABS_API_KEY"],
+    }
+    request = {
+        "schema_version": "kpgs.capability_request.v1",
+        "request_id": "req_elevenlabs_validation_001",
+        "policy": {"data_classification": "synthetic", "allow_external_processing": True},
+    }
+    modality = {
+        "schema_version": "kpgs.modality_contract.v1",
+        "contract_id": "modality_test_001",
+        "request_id": request["request_id"],
+        "semantic_ref": "a" * 64,
+        "primary": "speech",
+        "renderers": ["elevenlabs-speech"],
+        "fallbacks": ["native-text"],
+        "accessibility": {"text_equivalent_required": True, "reduced_motion_safe": True},
+        "renderer_has_semantic_authority": False,
+    }
+    text = "KPGS governs modality; the renderer does not own meaning."
+    prepared = adapter.prepare_speech(text, request, modality, lease, target, now=now)
+    safe = prepared.safe_receipt()
+    body = json.dumps(prepared.body, sort_keys=True).lower()
+    require("api_key" not in body and "xi-api-key" not in body, "credential leaked into body")
+    require(safe["contains_text"] is False and safe["contains_secret"] is False, "safe receipt leaked text/secret")
+    require(safe["renderer_has_semantic_authority"] is False and safe["semantic_authority"] == "kpgs", "modality authority boundary violated")
+
+    captured = {}
+
+    def fake_opener(http_request, timeout):
+        captured["headers"] = dict(http_request.header_items())
+        captured["timeout"] = timeout
+        return FakeResponse()
+
+    receipt = adapter.submit_prepared(
+        prepared,
+        secret_resolver=lambda _ref: "test-eleven-key-not-real",
+        opener=fake_opener,
+    )
+    headers = {k.lower(): v for k, v in captured["headers"].items()}
+    require(headers.get("xi-api-key") == "test-eleven-key-not-real", "API key must be sent only in xi-api-key header")
+    require(receipt["http_status"] == 200 and receipt["audio_bytes"] > 0, "fake TTS execution failed")
+    require(receipt["audio_digest"] and len(receipt["audio_digest"]) == 64, "audio must be digest-bound")
+    require(receipt["contains_audio"] is False and receipt["contains_text"] is False, "receipt must not embed content")
+    require(receipt["renderer_has_semantic_authority"] is False, "renderer gained semantic authority")
+
+    bad_modality = json.loads(json.dumps(modality))
+    bad_modality["fallbacks"] = []
+    try:
+        adapter.prepare_speech(text, request, bad_modality, lease, target, now=now)
+    except adapter.GovernanceError:
+        pass
+    else:
+        raise SystemExit("KPGS-ELEVENLABS FAIL: speech without text fallback was accepted")
+
+    private_request = json.loads(json.dumps(request))
+    private_request["policy"]["data_classification"] = "private"
+    private_request["policy"]["allow_external_processing"] = False
+    try:
+        adapter.prepare_speech(text, private_request, modality, lease, target, now=now)
+    except adapter.GovernanceError:
+        pass
+    else:
+        raise SystemExit("KPGS-ELEVENLABS FAIL: private semantic text was allowed externally")
+
+    expired = dict(lease)
+    expired["issued_at"] = "2026-08-16T00:00:00Z"
+    expired["expires_at"] = "2026-08-16T00:10:00Z"
+    try:
+        adapter.prepare_speech(text, request, modality, expired, target, now=now)
+    except adapter.GovernanceError:
+        pass
+    else:
+        raise SystemExit("KPGS-ELEVENLABS FAIL: expired lease was accepted")
+
+    print("KPGS-ELEVENLABS PASS: speech is governed as a renderer, not semantic authority.")
+    print(f"Prepared: {prepared.request_id} -> {prepared.endpoint}")
+    print(f"Audio digest: {receipt['audio_digest']}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Outcome

Promotes the ElevenLabs leg of the Frontier Harness from a declared speech renderer to a **live-capable, fail-closed TTS modality adapter** while proving that KPGS can govern modality without transferring semantic authority.

Control boundary:

`KPGS evaluated semantic output -> modality contract -> current renderer capability lease -> external API-key reference -> ElevenLabs TTS -> audio digest receipt`

## Current provider alignment

Checked against ElevenLabs documentation on 2026-08-17:
- endpoint: `POST https://api.elevenlabs.io/v1/text-to-speech/{voice_id}`
- authentication: `xi-api-key`
- balanced/low-latency default: `eleven_flash_v2_5`
- permitted quality alternatives: `eleven_multilingual_v2`, `eleven_v3`
- deprecated Turbo identifiers are intentionally not allow-listed

## Modality governance

A request cannot reach ElevenLabs unless `kpgs.modality_contract.v1` proves:
- `primary=speech`
- `elevenlabs-speech` is explicitly selected
- `renderer_has_semantic_authority=false`
- `native-text` fallback exists
- `text_equivalent_required=true`

## Security / authority

- exact capability: `elevenlabs.tts.generate`
- exact lease scope: `voice/<voice_id>/model/<model_id>`
- public/synthetic external rendering only in v0.4
- API key lives behind `env://KPGS_ELEVENLABS_API_KEY`
- key is injected only into `xi-api-key` at execution time
- receipts carry text/audio SHA-256 digests and byte metadata, not raw semantic text, audio or secrets
- speech rendering cannot edit or canonicalize meaning

## Manual validation receipt

The dependency-free, network-free gate passed:

`KPGS-ELEVENLABS PASS: speech is governed as a renderer, not semantic authority.`

Prepared endpoint:
`https://api.elevenlabs.io/v1/text-to-speech/JBFqnCBsd6RMkjVDRZzb?output_format=mp3_44100_128`

Synthetic audio digest:
`6fad54e35456a529142e7626d1439b259e87ec762c6b63f4f530769eb1b32ef1`

The validator separately proves missing-text-fallback rejection, private-input rejection, expired-lease rejection, external header-only secret injection and content-free receipts.

## Live boundary

No real ElevenLabs generation is claimed because this environment has no user ElevenLabs API credential. v0.4 is live-capable; claimed live status requires a real credential-backed execution receipt.

## Risk

`R2 / draft / non-production` until an actual provider execution receipt exists.