### PR TITLE
feat(kpgs): prove non-authoritative offline convergence

### DIFF
--- a/governance/kpgs-vnext/offline-replication/README.md
+++ b/governance/kpgs-vnext/offline-replication/README.md
@@ -1,0 +1,168 @@
+# KPGS Offline Replication Contract v0.1
+
+Status: **Phase 0 / convergence-safety POC / non-production**
+
+This slice proves one sovereign-runtime law in executable form:
+
+> **Availability and synchronization are not authority.**
+
+A device may continue producing benign local state while disconnected. Peer replicas may later exchange, deduplicate, and converge that state. None of those operations grant permission to mutate KPGS constitutional truth.
+
+## Why this slice exists
+
+KPGS already requires realtime transports to remain subordinate to canonical workflow state. The same rule must hold when the transport becomes peer-to-peer and the state layer becomes CRDT-like.
+
+```text
+LOCAL DEVICE STATE
+      │
+      ├── works offline
+      ├── persists locally
+      └── emits non-authoritative operations
+                  │
+                  ▼
+           peer synchronization
+                  │
+          duplicate/reorder safe
+                  │
+                  ▼
+         deterministic convergence
+                  │
+                  X
+           NO AUTHORITY JUMP
+                  │
+                  ▼
+       governed promotion proposal
+                  │
+                  ▼
+        KPGS task/policy/receipt gate
+```
+
+## Executable POC
+
+`replication_contract.py` implements a small transport-neutral Last-Write-Wins map CRDT:
+
+- operations are immutable and content-hashed;
+- operation IDs are replica/counter scoped;
+- merge is set union;
+- visible values are projected by a deterministic Lamport-counter + replica-ID ordering;
+- duplicate and reordered delivery is idempotent;
+- peer identity is bound to an expected principal before imported operations enter the projection;
+- local state can be serialized, destroyed, restored, and synchronized again;
+- replicated records are locked to `authority_effect = "none"`;
+- direct mutation of the canonical authority store is refused;
+- promotion produces only a proposal and requires an explicit governing task-receipt reference;
+- provenance is hash-first so private source content does not enter replication metadata by default.
+
+The POC intentionally accepts only operations originated by the sending peer. Forwarded/gossip operations remain a later protocol gate so transitive trust cannot appear accidentally.
+
+## State classes
+
+The v0.1 replicated surface admits only:
+
+- `non_authoritative` — local user/runtime state with no governance effect;
+- `derived_projection` — a cache/view derived from authoritative sources;
+- `pending_proposal` — candidate state awaiting a separate governance decision.
+
+`constitutional_truth` and any other authoritative state class are rejected.
+
+## Transport boundary
+
+The core contract deals in deterministic bytes:
+
+```text
+LocalReplica
+   ↓ export_batch()
+ReplicaBatch bytes
+   ↓
+transport adapter
+   ↓
+peer
+   ↓ import_batch()
+LocalReplica
+```
+
+The transport may later be:
+
+- iroh;
+- LAN/local IPC;
+- WebSocket;
+- Bluetooth-adjacent bridge;
+- store-and-forward;
+- another byte-oriented peer channel.
+
+The transport cannot widen authority.
+
+## Automerge / iroh placement
+
+This POC deliberately locks the governance semantics **before** introducing networking dependencies.
+
+The intended live experiment is:
+
+```text
+KPGS non-authoritative state contract
+            │
+            ▼
+      Automerge document
+            │
+       sync messages
+            │
+            ▼
+      iroh byte channel
+            │
+            ▼
+       trusted peer
+```
+
+Automerge/iroh may replace the POC merge/transport machinery after their adapter passes the same conformance tests. They may not replace the KPGS authority membrane.
+
+## Conformance gates
+
+`tests/test_kpgs_offline_replication.py` proves:
+
+1. two disconnected peers can perform concurrent benign writes and later converge;
+2. equal-clock conflicts resolve deterministically independent of delivery order;
+3. duplicate delivery creates no duplicate state effect;
+4. untrusted peers are rejected before projection;
+5. trusted peer IDs are bound to expected principals;
+6. batch tampering is detected;
+7. local persistence survives replica recreation and can resynchronize;
+8. converged state cannot directly mutate canonical authority;
+9. authority promotion requires a governing task receipt and yields a proposal only;
+10. authoritative state classes/authority effects are refused;
+11. provenance enters the replicated surface as a hash, not source payload.
+
+## Relationship to Sovereign Everyday Mode
+
+A PWA can safely show `offline` or `reconnecting` while continuing to mutate permitted local state. On reconnect, authoritative task/workflow state still refreshes from the canonical KPGS surface before client-only state is trusted.
+
+This means:
+
+```text
+offline continuity     YES
+local preferences      YES
+non-authoritative UX   YES
+cached projections     YES
+
+silent privilege       NO
+canonical task rewrite NO
+policy bypass          NO
+receipt fabrication    NO
+```
+
+## Scope boundary
+
+This branch does **not** claim:
+
+- production CRDT storage;
+- Automerge integration;
+- live iroh networking;
+- multi-hop gossip;
+- cryptographic peer signatures;
+- key rotation/revocation;
+- production encryption at rest;
+- authoritative distributed consensus;
+- automatic promotion of replicated state.
+
+Those remain separate gates.
+
+The next transport experiment should implement the current Automerge synchronization model over a current iroh byte channel and run this contract's partition, replay, tamper, restoration, and authority-separation tests against the live adapter.

--- a/governance/kpgs-vnext/offline-replication/replicated-state.schema.json
+++ b/governance/kpgs-vnext/offline-replication/replicated-state.schema.json
@@ -1,0 +1,100 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kopanolabs.com/kpgs/offline-replication/replicated-state.schema.json",
+  "title": "KPGS Non-Authoritative Replicated State v0.1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "document_id",
+    "replica_id",
+    "principal_id",
+    "state_class",
+    "authority_effect",
+    "sync_status",
+    "content_sha256",
+    "last_merge_sha256",
+    "governing_task_receipt_ref",
+    "provenance_refs"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "kpgs.replica.v0.1"
+    },
+    "document_id": {
+      "type": "string",
+      "minLength": 3
+    },
+    "replica_id": {
+      "type": "string",
+      "minLength": 3
+    },
+    "principal_id": {
+      "type": "string",
+      "minLength": 3
+    },
+    "state_class": {
+      "enum": [
+        "non_authoritative",
+        "derived_projection",
+        "pending_proposal"
+      ]
+    },
+    "authority_effect": {
+      "const": "none"
+    },
+    "sync_status": {
+      "enum": [
+        "local_only",
+        "pending",
+        "synced",
+        "conflict_observed",
+        "quarantined"
+      ]
+    },
+    "content_sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "last_merge_sha256": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "governing_task_receipt_ref": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "provenance_refs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "sha256",
+          "ref",
+          "content_captured"
+        ],
+        "properties": {
+          "sha256": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{64}$"
+          },
+          "ref": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "content_captured": {
+            "const": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/governance/kpgs-vnext/offline-replication/replication_contract.py
+++ b/governance/kpgs-vnext/offline-replication/replication_contract.py
@@ -1,0 +1,397 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import json
+from typing import Any, Mapping
+
+
+SCHEMA_VERSION = "kpgs.replica.v0.1"
+AUTHORITY_EFFECT = "none"
+NON_AUTHORITATIVE_CLASSES = frozenset(
+    {"non_authoritative", "derived_projection", "pending_proposal"}
+)
+
+
+class ReplicationError(ValueError):
+    pass
+
+
+class IntegrityError(ReplicationError):
+    pass
+
+
+class PeerAuthorizationError(ReplicationError):
+    pass
+
+
+class AuthorityViolation(ReplicationError):
+    pass
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def canonical_sha256(value: Any) -> str:
+    return hashlib.sha256(canonical_json_bytes(value)).hexdigest()
+
+
+@dataclass(frozen=True)
+class ReplicaOperation:
+    document_id: str
+    actor_replica_id: str
+    actor_principal_id: str
+    counter: int
+    key: str
+    value: Any
+    state_class: str = "non_authoritative"
+    authority_effect: str = AUTHORITY_EFFECT
+    provenance_sha256: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.document_id.strip():
+            raise ReplicationError("document_id is required")
+        if not self.actor_replica_id.strip():
+            raise ReplicationError("actor_replica_id is required")
+        if not self.actor_principal_id.strip():
+            raise ReplicationError("actor_principal_id is required")
+        if self.counter < 1:
+            raise ReplicationError("counter must be >= 1")
+        if not self.key.strip():
+            raise ReplicationError("key is required")
+        if self.state_class not in NON_AUTHORITATIVE_CLASSES:
+            raise AuthorityViolation("replicated state class cannot be authoritative")
+        if self.authority_effect != AUTHORITY_EFFECT:
+            raise AuthorityViolation("replicated operation cannot carry authority")
+        if self.provenance_sha256 is not None and (
+            len(self.provenance_sha256) != 64
+            or any(ch not in "0123456789abcdef" for ch in self.provenance_sha256)
+        ):
+            raise IntegrityError("provenance_sha256 must be lowercase SHA-256 hex")
+
+    @property
+    def op_id(self) -> str:
+        return f"{self.actor_replica_id}:{self.counter}"
+
+    @property
+    def order_key(self) -> tuple[int, str, str]:
+        """Total order used by the LWW-register projection.
+
+        Counter is the Lamport component. Replica and operation IDs break ties
+        deterministically; transport arrival order never participates.
+        """
+        return (self.counter, self.actor_replica_id, self.op_id)
+
+    def unsigned_payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "document_id": self.document_id,
+            "actor_replica_id": self.actor_replica_id,
+            "actor_principal_id": self.actor_principal_id,
+            "counter": self.counter,
+            "key": self.key,
+            "value": self.value,
+            "state_class": self.state_class,
+            "authority_effect": self.authority_effect,
+            "provenance_sha256": self.provenance_sha256,
+        }
+
+    @property
+    def sha256(self) -> str:
+        return canonical_sha256(self.unsigned_payload())
+
+    def to_wire(self) -> dict[str, Any]:
+        return {
+            **self.unsigned_payload(),
+            "op_id": self.op_id,
+            "sha256": self.sha256,
+        }
+
+    @classmethod
+    def from_wire(cls, raw: Mapping[str, Any]) -> "ReplicaOperation":
+        required = {
+            "schema_version",
+            "document_id",
+            "actor_replica_id",
+            "actor_principal_id",
+            "counter",
+            "key",
+            "value",
+            "state_class",
+            "authority_effect",
+            "provenance_sha256",
+            "op_id",
+            "sha256",
+        }
+        missing = required.difference(raw)
+        if missing:
+            raise IntegrityError(f"wire operation missing fields: {sorted(missing)}")
+        if raw["schema_version"] != SCHEMA_VERSION:
+            raise IntegrityError("unsupported replica schema version")
+        operation = cls(
+            document_id=str(raw["document_id"]),
+            actor_replica_id=str(raw["actor_replica_id"]),
+            actor_principal_id=str(raw["actor_principal_id"]),
+            counter=int(raw["counter"]),
+            key=str(raw["key"]),
+            value=raw["value"],
+            state_class=str(raw["state_class"]),
+            authority_effect=str(raw["authority_effect"]),
+            provenance_sha256=raw["provenance_sha256"],
+        )
+        if raw["op_id"] != operation.op_id:
+            raise IntegrityError("operation id does not match canonical identity")
+        if raw["sha256"] != operation.sha256:
+            raise IntegrityError("operation hash does not match canonical payload")
+        return operation
+
+
+@dataclass(frozen=True)
+class ReplicaBatch:
+    document_id: str
+    sender_replica_id: str
+    operations: tuple[ReplicaOperation, ...]
+
+    def to_wire(self) -> bytes:
+        payload = {
+            "schema_version": SCHEMA_VERSION,
+            "document_id": self.document_id,
+            "sender_replica_id": self.sender_replica_id,
+            "authority_effect": AUTHORITY_EFFECT,
+            "operations": [operation.to_wire() for operation in self.operations],
+        }
+        envelope = {
+            **payload,
+            "batch_sha256": canonical_sha256(payload),
+        }
+        return canonical_json_bytes(envelope)
+
+    @classmethod
+    def from_wire(cls, wire: bytes) -> "ReplicaBatch":
+        try:
+            raw = json.loads(wire.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise IntegrityError("replica batch is not valid UTF-8 JSON") from exc
+        expected_hash = raw.pop("batch_sha256", None)
+        if expected_hash is None or expected_hash != canonical_sha256(raw):
+            raise IntegrityError("replica batch hash mismatch")
+        if raw.get("schema_version") != SCHEMA_VERSION:
+            raise IntegrityError("unsupported batch schema version")
+        if raw.get("authority_effect") != AUTHORITY_EFFECT:
+            raise AuthorityViolation("replica batch cannot carry authority")
+        operations = tuple(
+            ReplicaOperation.from_wire(item) for item in raw.get("operations", [])
+        )
+        document_id = str(raw.get("document_id", ""))
+        if any(operation.document_id != document_id for operation in operations):
+            raise IntegrityError("batch contains an operation for another document")
+        return cls(
+            document_id=document_id,
+            sender_replica_id=str(raw.get("sender_replica_id", "")),
+            operations=operations,
+        )
+
+
+class LocalReplica:
+    """Transport-agnostic LWW-map CRDT POC for non-authoritative state.
+
+    Operations form a grow-only set keyed by op_id. The visible document is a
+    deterministic projection selecting the highest Lamport/actor tuple for each
+    key. Merge is set union, so duplicate/reordered delivery is harmless.
+
+    This class deliberately does not mutate a KPGS canonical authority store.
+    """
+
+    def __init__(
+        self,
+        *,
+        document_id: str,
+        replica_id: str,
+        principal_id: str,
+        trusted_peers: Mapping[str, str] | None = None,
+    ) -> None:
+        if not document_id.strip() or not replica_id.strip() or not principal_id.strip():
+            raise ReplicationError("document_id, replica_id and principal_id are required")
+        self.document_id = document_id
+        self.replica_id = replica_id
+        self.principal_id = principal_id
+        self.trusted_peers = dict(trusted_peers or {})
+        self._operations: dict[str, ReplicaOperation] = {}
+        self._counter = 0
+
+    @property
+    def operation_count(self) -> int:
+        return len(self._operations)
+
+    @property
+    def state_hash(self) -> str:
+        return canonical_sha256(self.snapshot())
+
+    def local_set(
+        self,
+        key: str,
+        value: Any,
+        *,
+        state_class: str = "non_authoritative",
+        provenance: Any | None = None,
+    ) -> ReplicaOperation:
+        self._counter += 1
+        operation = ReplicaOperation(
+            document_id=self.document_id,
+            actor_replica_id=self.replica_id,
+            actor_principal_id=self.principal_id,
+            counter=self._counter,
+            key=key,
+            value=value,
+            state_class=state_class,
+            authority_effect=AUTHORITY_EFFECT,
+            provenance_sha256=(
+                canonical_sha256(provenance) if provenance is not None else None
+            ),
+        )
+        self._operations[operation.op_id] = operation
+        return operation
+
+    def snapshot(self) -> dict[str, Any]:
+        winners: dict[str, ReplicaOperation] = {}
+        for operation in self._operations.values():
+            current = winners.get(operation.key)
+            if current is None or operation.order_key > current.order_key:
+                winners[operation.key] = operation
+        return {
+            key: winners[key].value
+            for key in sorted(winners)
+        }
+
+    def export_batch(self) -> bytes:
+        batch = ReplicaBatch(
+            document_id=self.document_id,
+            sender_replica_id=self.replica_id,
+            operations=tuple(
+                sorted(
+                    (
+                        operation
+                        for operation in self._operations.values()
+                        if operation.actor_replica_id == self.replica_id
+                    ),
+                    key=lambda operation: operation.op_id,
+                )
+            ),
+        )
+        return batch.to_wire()
+
+    def import_batch(self, wire: bytes) -> int:
+        batch = ReplicaBatch.from_wire(wire)
+        if batch.document_id != self.document_id:
+            raise IntegrityError("replica batch document does not match local document")
+        expected_principal = self.trusted_peers.get(batch.sender_replica_id)
+        if expected_principal is None:
+            raise PeerAuthorizationError("sender replica is not trusted")
+        for operation in batch.operations:
+            if operation.actor_replica_id != batch.sender_replica_id:
+                raise PeerAuthorizationError(
+                    "forwarded operations are not accepted in v0.1 peer batches"
+                )
+            if operation.actor_principal_id != expected_principal:
+                raise PeerAuthorizationError(
+                    "operation principal does not match trusted peer binding"
+                )
+        before = len(self._operations)
+        for operation in batch.operations:
+            existing = self._operations.get(operation.op_id)
+            if existing is not None and existing.sha256 != operation.sha256:
+                raise IntegrityError("operation id collision with different payload")
+            self._operations[operation.op_id] = operation
+            self._counter = max(self._counter, operation.counter)
+        return len(self._operations) - before
+
+    def dump_local(self) -> bytes:
+        payload = {
+            "schema_version": SCHEMA_VERSION,
+            "document_id": self.document_id,
+            "replica_id": self.replica_id,
+            "principal_id": self.principal_id,
+            "trusted_peers": self.trusted_peers,
+            "counter": self._counter,
+            "authority_effect": AUTHORITY_EFFECT,
+            "operations": [
+                operation.to_wire()
+                for operation in sorted(
+                    self._operations.values(), key=lambda item: item.op_id
+                )
+            ],
+        }
+        envelope = {**payload, "local_sha256": canonical_sha256(payload)}
+        return canonical_json_bytes(envelope)
+
+    @classmethod
+    def restore_local(cls, wire: bytes) -> "LocalReplica":
+        try:
+            raw = json.loads(wire.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise IntegrityError("local replica state is not valid UTF-8 JSON") from exc
+        expected_hash = raw.pop("local_sha256", None)
+        if expected_hash is None or expected_hash != canonical_sha256(raw):
+            raise IntegrityError("local replica state hash mismatch")
+        if raw.get("schema_version") != SCHEMA_VERSION:
+            raise IntegrityError("unsupported local replica schema version")
+        if raw.get("authority_effect") != AUTHORITY_EFFECT:
+            raise AuthorityViolation("restored replica state cannot carry authority")
+        replica = cls(
+            document_id=str(raw["document_id"]),
+            replica_id=str(raw["replica_id"]),
+            principal_id=str(raw["principal_id"]),
+            trusted_peers=raw.get("trusted_peers", {}),
+        )
+        operations = [
+            ReplicaOperation.from_wire(item) for item in raw.get("operations", [])
+        ]
+        if any(operation.document_id != replica.document_id for operation in operations):
+            raise IntegrityError("local state contains another document")
+        for operation in operations:
+            replica._operations[operation.op_id] = operation
+        replica._counter = max(
+            int(raw.get("counter", 0)),
+            max((operation.counter for operation in operations), default=0),
+        )
+        return replica
+
+
+@dataclass(frozen=True)
+class PromotionProposal:
+    document_id: str
+    state_sha256: str
+    governing_task_receipt_ref: str
+    authority_effect: str = "proposal_only"
+
+
+def request_authority_promotion(
+    replica: LocalReplica,
+    *,
+    governing_task_receipt_ref: str,
+) -> PromotionProposal:
+    """Create a promotion proposal; never mutate canonical authority directly."""
+    if not governing_task_receipt_ref.strip():
+        raise AuthorityViolation(
+            "replicated state requires a governing task receipt before promotion"
+        )
+    return PromotionProposal(
+        document_id=replica.document_id,
+        state_sha256=replica.state_hash,
+        governing_task_receipt_ref=governing_task_receipt_ref,
+    )
+
+
+class CanonicalAuthorityStore:
+    """Guard rail proving replicated state cannot self-promote in this POC."""
+
+    def apply_replica_snapshot(self, _replica: LocalReplica) -> None:
+        raise AuthorityViolation(
+            "replica convergence is not authority; submit a governed promotion proposal"
+        )

--- a/tests/test_kpgs_offline_replication.py
+++ b/tests/test_kpgs_offline_replication.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import sys
+
+import pytest
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "governance"
+    / "kpgs-vnext"
+    / "offline-replication"
+    / "replication_contract.py"
+)
+SPEC = importlib.util.spec_from_file_location("kpgs_offline_replication", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+module = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = module
+SPEC.loader.exec_module(module)
+
+AUTHORITY_EFFECT = module.AUTHORITY_EFFECT
+AuthorityViolation = module.AuthorityViolation
+CanonicalAuthorityStore = module.CanonicalAuthorityStore
+IntegrityError = module.IntegrityError
+LocalReplica = module.LocalReplica
+PeerAuthorizationError = module.PeerAuthorizationError
+canonical_sha256 = module.canonical_sha256
+request_authority_promotion = module.request_authority_promotion
+
+
+def _pair():
+    alice = LocalReplica(
+        document_id="doc:kasilink-neighbourhood-view",
+        replica_id="device-a",
+        principal_id="principal:alice",
+        trusted_peers={"device-b": "principal:bob"},
+    )
+    bob = LocalReplica(
+        document_id="doc:kasilink-neighbourhood-view",
+        replica_id="device-b",
+        principal_id="principal:bob",
+        trusted_peers={"device-a": "principal:alice"},
+    )
+    return alice, bob
+
+
+def test_partitioned_peers_converge_after_concurrent_updates():
+    alice, bob = _pair()
+
+    alice.local_set("nearby_gigs", ["electrician", "tutor"])
+    bob.local_set("network_hint", "offline")
+    alice.local_set("shared_banner", "from-a")
+    bob.local_set("shared_banner", "from-b")
+
+    assert alice.snapshot() != bob.snapshot()
+
+    alice_batch = alice.export_batch()
+    bob_batch = bob.export_batch()
+    alice.import_batch(bob_batch)
+    bob.import_batch(alice_batch)
+
+    assert alice.snapshot() == bob.snapshot()
+    assert alice.state_hash == bob.state_hash
+    # Same Lamport counter: deterministic replica-id tie-break, not arrival order.
+    assert alice.snapshot()["shared_banner"] == "from-b"
+
+
+def test_duplicate_and_reordered_delivery_are_idempotent():
+    alice, bob = _pair()
+    alice.local_set("status", "ready")
+    batch = alice.export_batch()
+
+    assert bob.import_batch(batch) == 1
+    first_hash = bob.state_hash
+    assert bob.import_batch(batch) == 0
+    assert bob.state_hash == first_hash
+    assert bob.operation_count == 1
+
+
+def test_untrusted_peer_is_rejected_before_projection():
+    receiver = LocalReplica(
+        document_id="doc:kasilink-neighbourhood-view",
+        replica_id="device-a",
+        principal_id="principal:alice",
+    )
+    sender = LocalReplica(
+        document_id="doc:kasilink-neighbourhood-view",
+        replica_id="device-z",
+        principal_id="principal:mallory",
+    )
+    sender.local_set("status", "owned")
+
+    with pytest.raises(PeerAuthorizationError, match="not trusted"):
+        receiver.import_batch(sender.export_batch())
+
+    assert receiver.snapshot() == {}
+
+
+def test_peer_principal_binding_is_enforced():
+    alice, _ = _pair()
+    impostor = LocalReplica(
+        document_id=alice.document_id,
+        replica_id="device-b",
+        principal_id="principal:mallory",
+    )
+    impostor.local_set("status", "forged")
+
+    with pytest.raises(PeerAuthorizationError, match="principal"):
+        alice.import_batch(impostor.export_batch())
+
+
+def test_batch_corruption_is_detected():
+    alice, bob = _pair()
+    alice.local_set("status", "ready")
+    raw = json.loads(alice.export_batch().decode("utf-8"))
+    raw["operations"][0]["value"] = "tampered"
+    corrupted = json.dumps(raw, sort_keys=True).encode("utf-8")
+
+    with pytest.raises(IntegrityError, match="batch hash mismatch"):
+        bob.import_batch(corrupted)
+
+
+def test_local_persistence_restores_replica_and_can_resync():
+    alice, bob = _pair()
+    alice.local_set("status", "offline")
+    persisted = alice.dump_local()
+
+    restored = LocalReplica.restore_local(persisted)
+    assert restored.snapshot() == alice.snapshot()
+    assert restored.state_hash == alice.state_hash
+
+    bob.local_set("utility_notice", "water interruption")
+    restored.import_batch(bob.export_batch())
+    bob.import_batch(restored.export_batch())
+
+    assert restored.snapshot() == bob.snapshot()
+
+
+def test_replication_can_never_directly_mutate_canonical_authority():
+    alice, _ = _pair()
+    alice.local_set("status", "candidate")
+    store = CanonicalAuthorityStore()
+
+    with pytest.raises(AuthorityViolation, match="not authority"):
+        store.apply_replica_snapshot(alice)
+
+
+def test_promotion_requires_explicit_governing_task_receipt():
+    alice, _ = _pair()
+    alice.local_set("status", "candidate")
+
+    with pytest.raises(AuthorityViolation, match="task receipt"):
+        request_authority_promotion(alice, governing_task_receipt_ref="")
+
+    proposal = request_authority_promotion(
+        alice,
+        governing_task_receipt_ref="kpgs-receipt://task/abc/r0002",
+    )
+    assert proposal.state_sha256 == alice.state_hash
+    assert proposal.authority_effect == "proposal_only"
+
+
+def test_authoritative_state_class_and_authority_effect_are_refused():
+    alice, _ = _pair()
+
+    with pytest.raises(AuthorityViolation, match="authoritative"):
+        alice.local_set("status", "x", state_class="constitutional_truth")
+
+    with pytest.raises(AuthorityViolation, match="carry authority"):
+        module.ReplicaOperation(
+            document_id=alice.document_id,
+            actor_replica_id=alice.replica_id,
+            actor_principal_id=alice.principal_id,
+            counter=1,
+            key="status",
+            value="x",
+            authority_effect="grant",
+        )
+
+
+def test_provenance_is_hash_only():
+    alice, _ = _pair()
+    source = {"private": "do-not-replicate"}
+    operation = alice.local_set("status", "ready", provenance=source)
+
+    wire_operation = json.loads(alice.export_batch().decode("utf-8"))["operations"][0]
+    assert operation.provenance_sha256 == canonical_sha256(source)
+    assert wire_operation["provenance_sha256"] == operation.provenance_sha256
+    assert "private" not in wire_operation
+    assert wire_operation["authority_effect"] == AUTHORITY_EFFECT


### PR DESCRIPTION
## What
- add a transport-neutral LWW-map CRDT POC for benign local/offline state
- lock replicated state to `authority_effect = none`
- separate peer/principal admission from merge semantics
- add deterministic conflict resolution, replay/idempotency safety, tamper detection, local persistence/restore, and hash-first provenance
- require a governing task-receipt reference before replicated state can even become an authority-promotion proposal
- explicitly refuse direct mutation of canonical KPGS authority from converged replica state

## Why
This makes the sovereign-runtime invariant executable: **availability and synchronization are not authority**. A device can keep useful local state during network loss and later converge with a peer without turning connectivity or CRDT merge into a governance bypass.

## Validation receipts
- focused offline-replication tests: **10 passed**
- Python compile: passed
- JSON schema parse: passed
- KPGS vNext Contract Gate: passed
- Kopano CI Pipeline: passed, including ruff and pytest on Python 3.11/3.12
- CodeQL Advanced: passed

## Scope
Phase 0 / convergence-safety POC / non-production. This does not claim live Automerge or iroh integration yet. The next transport experiment is to run the same conformance gates against Automerge sync messages over a current iroh byte channel. Multi-hop gossip, cryptographic signatures, key rotation/revocation, production encryption, and authoritative distributed consensus remain separate gates.