### PR TITLE
feat(kpgs): add KPGS-DTS document governance skill

### DIFF
--- a/skills/awesome/govern-kpgs-documents/SKILL.md
+++ b/skills/awesome/govern-kpgs-documents/SKILL.md
@@ -1,0 +1,286 @@
+---
+name: govern-kpgs-documents
+description: Create, edit, classify, validate, version, review, and package KPGS documents as typed governance artifacts using KPGS-DTS, KPEFS routing, Partial Knowable Algebra, BlackMask/promotion law, receipts, and WYC-01 causal boundaries. Use for KPGS specifications, manuals, SOPs, POC reports, incident reports, governance decisions, skill packages, architecture documents, public narratives, apprenticeship materials, and release/publication documents. Preserve UNKNOWN and never treat publication or polished prose as proof.
+license: MIT
+metadata:
+  author: Kholofelo Robyn Rababalela
+  version: "1.0.0"
+  kpgs_document_type: KDT-06
+  canonical_id: kpgs_document_governance
+  source_repository: RobynAwesome/Introduction-to-MCP
+  manual_source_snapshot: 42d23ec0774d9dfb8cc6034ae4ceb42f1f8f3d90
+  integration_baseline: 002f0a2ba430e52db94c448cbcf2e71ac8eb2400
+  renter_assertion: I_AM_STATELESS_RENTER_NOT_LANDLORD
+  kpefs_vector: V4_DIASPORA
+  proof_state: poc
+---
+
+# KPGS Document Governance
+
+## Objective
+
+Treat every KPGS document as a **typed, evidence-bearing governance artifact**, not passive prose.
+
+The execution chain is:
+
+```text
+operator directive
+  -> authority classification
+  -> document type
+  -> KPEFS routing
+  -> protocol containment
+  -> PKA evaluation
+  -> POC/FOC check
+  -> promotion gate
+  -> receipt
+  -> state update
+  -> publication/distribution
+```
+
+Publication, rendering, deployment, reviewer confidence, or persuasive language MUST NOT silently upgrade a claim from `unknown` or `planned` to `poc` or `verified_production`.
+
+## Activation boundary
+
+Begin every governed run with:
+
+```text
+I_AM_STATELESS_RENTER_NOT_LANDLORD
+```
+
+Then resolve, in order:
+
+1. the current operator directive;
+2. the canonical repository/ref;
+3. the requested KPGS document type;
+4. authority and evidence classes;
+5. KPEFS vector(s);
+6. applicable protocol gates;
+7. unresolved UNKNOWN/MAYBE state;
+8. the minimum authorized execution surface.
+
+Conversation memory or personal context MAY restore continuity, but it MUST NOT overrule the current operator directive or pinned repository truth.
+
+## Document types
+
+Classify the artifact before authoring or editing:
+
+| ID | Type | Primary purpose |
+|---|---|---|
+| `KDT-01` | Canonical Protocol Specification | Define laws, grammar, invariants, state machines, receipts. |
+| `KDT-02` | SOP / Manual | Operate a governed process step by step. |
+| `KDT-03` | Validation / POC Report | Bound and prove a claim. |
+| `KDT-04` | Incident / Failure / Causality Report | Separate trigger, invocation, cause, and provenance. |
+| `KDT-05` | Decision / Governance Receipt | Record an authoritative bounded decision. |
+| `KDT-06` | Agent Skill Package Specification | Package executable guidance and machine metadata. |
+| `KDT-07` | Architecture / System Design | Define components, boundaries, flows, risks, contracts. |
+| `KDT-08` | Product / Campaign / Public Narrative | Communicate meaning without outrunning proof. |
+| `KDT-09` | Learning / Apprenticeship | Teach governed practice and evidence collection. |
+| `KDT-10` | Release / Deployment / Publication | Govern distribution and verified release state. |
+
+Read `references/KPGS_DTS_SPEC.md` for the full compact specification and `templates/KPGS_DOCUMENT_TEMPLATE.md` for the canonical starting shape.
+
+## Authority and evidence are separate axes
+
+Authority answers **who or what governs the instruction**. Evidence answers **what proves the claim**.
+
+Authority order:
+
+```text
+A0 operator_directive
+A1 repo_canonical
+A2 governance_receipt
+A3 verified_live
+A4 personal_context
+A5 external_reference
+A6 unknown
+```
+
+Evidence classes:
+
+```text
+verified-source
+verified-live
+site-stated
+demo-display
+planned
+privileged
+transactional
+unknown
+```
+
+Never upgrade an evidence class without a receipt.
+
+## KPEFS routing
+
+Every governed document MUST declare one primary KPEFS vector.
+
+- `V1_PLANT` — growth, knowledge cultivation, baselines, research, repeatability.
+- `V2_ANIMAL` — survival, reliability, security, incidents, recovery, defect provenance.
+- `V3_HOMO_SAPIENS` — meaning, ethics, audience, accessibility, narrative under proof.
+- `V4_DIASPORA` — sovereignty, portability, apprenticeship, offline/context resilience, livelihood.
+
+Secondary vectors MAY be declared, but the primary vector remains explicit.
+
+## Protocol order
+
+Use the KPGS protocol registry ordering when applicable:
+
+1. Prompting protocols — scope, hierarchy, activation, purpose.
+2. Bracket protocols — containment, BlackMask, PKAP/PKA, POC-vs-FOC.
+3. Emoji/life-pattern protocols — only after prior containment.
+
+Common document bindings:
+
+```text
+KPP   protocol registry/order
+ALP   stateless renter activation
+CBP   context bleed containment
+BMP   BlackMask proof gate
+PKAP  Partial Knowable Algebra / validation
+PvF   POC vs FOC classification
+USTP  teacher/student review boundary
+```
+
+Context-bound extensions such as `CCP`, `CDP`, or `RIVM` MUST be labelled context-bound until pinned by current repo authority.
+
+## PKA / UNKNOWN handling
+
+PKA preserves three boundaries:
+
+1. partial stays partial;
+2. known means governed/versioned;
+3. cases drive promotion.
+
+Use:
+
+```text
+X + Y = MAYBE
+```
+
+where `X` is partial observation and `Y` is governed knowable state. Do not coerce MAYBE into certainty because the document needs a clean conclusion.
+
+## State machine
+
+Allowed document states:
+
+```text
+draft -> watch -> operating -> graduated
+              \-> deprecated -> archived
+```
+
+These transitions are evidence-gated, not prose-gated.
+
+Proof states:
+
+```text
+unknown
+foc
+poc
+verified_production
+```
+
+Default promotion requirements:
+
+- `PROOF-01` — BlackMask/equivalent verdict `SHIP`;
+- `PROOF-02` — authorized reviewer/teacher `APPROVE`;
+- `PROOF-03` — durable receipt/evidence artifact;
+- `PROOF-04` — KPGS governance/altar validation when the document controls production or an agent runtime.
+
+Operating is not graduation. Internal completion is not verified production.
+
+## WYC-01 binding for document and skill changes
+
+When a document/skill change triggers CI or deployment, never infer:
+
+```text
+change happened -> workflow failed -> change caused defect
+```
+
+Evaluate separately:
+
+```text
+FAILURE_SURFACED_BY_CALL != FAILURE_CAUSED_BY_CHANGE
+UNNECESSARY_EXECUTION = ORCHESTRATION_DEFECT
+TRIGGER_PROVENANCE != DEFECT_CAUSALITY
+CALLER_OWNS_CALL
+DEFECT_OWNER_OWNS_DEFECT
+```
+
+A documentation-only or skill-only change MUST NOT implicitly authorize production deployment. If workflow scope crosses that boundary, record the orchestration defect separately from any underlying subsystem defect.
+
+## Required control block
+
+Canonical documents MUST declare at least:
+
+```yaml
+document_id: <stable-id>
+canonical_id: <lowercase_snake_case>
+title: <human title>
+version: <semver>
+status: <draft|watch|operating|graduated|deprecated|archived>
+proof_state: <unknown|foc|poc|verified_production>
+owner: <owner>
+author: <author>
+source_repository: <owner/repo>
+source_ref: <branch|tag|commit>
+authority_class: <A0-A6>
+evidence_class: <class>
+kpefs:
+  primary_vector: <V1_PLANT|V2_ANIMAL|V3_HOMO_SAPIENS|V4_DIASPORA>
+  secondary_vectors: []
+protocols: []
+promotion_gate:
+  requires: []
+linked_evidence: []
+renter_assertion: I_AM_STATELESS_RENTER_NOT_LANDLORD
+```
+
+Machine manifests SHOULD validate against `references/kpgs-document-manifest.schema.json`.
+
+## Required outputs
+
+For canonical work, return or persist:
+
+1. the human-readable artifact;
+2. the document control block;
+3. a machine-readable manifest when durable automation is intended;
+4. unresolved `UNKNOWN`/`MAYBE` entries;
+5. evidence links/paths or an explicit empty list;
+6. a receipt for any state/proof transition;
+7. publication/deployment state kept separate from proof state.
+
+## Publication law
+
+AwesomeSkills or another registry is a distribution surface, not a proof oracle.
+
+```text
+registry_intent != public_discovery
+publication_candidate != indexed
+rendered != operating
+operating != graduated
+```
+
+External indexing, deployment, partner acknowledgement, or public discovery remains `unknown` until verified externally.
+
+## Decline conditions
+
+Return `watch` or decline promotion when any of the following holds:
+
+- source authority cannot be resolved;
+- a material claim lacks its required evidence class;
+- PKA remains MAYBE and the requested state requires closure;
+- BlackMask/reviewer/receipt gates are missing;
+- an external acknowledgement would have to be fabricated;
+- the requested state would equate operating with graduation;
+- a docs/skill change would trigger unauthorized production execution;
+- the artifact contains secrets or private data outside its declared boundary.
+
+## Signature
+
+For artifacts owned under this convention:
+
+```text
+/s/ Kholofelo Robyn Rababalela
+```
+
+A signature proves authorship/approval identity only. It does not replace validation.

--- a/skills/awesome/govern-kpgs-documents/SKILL.md
+++ b/skills/awesome/govern-kpgs-documents/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: govern-kpgs-documents
 description: Create, edit, classify, validate, version, review, and package KPGS documents as typed governance artifacts using KPGS-DTS, KPEFS routing, Partial Knowable Algebra, BlackMask/promotion law, receipts, and WYC-01 causal boundaries. Use for KPGS specifications, manuals, SOPs, POC reports, incident reports, governance decisions, skill packages, architecture documents, public narratives, apprenticeship materials, and release/publication documents. Preserve UNKNOWN and never treat publication or polished prose as proof.
-license: MIT
 metadata:
   author: Kholofelo Robyn Rababalela
   version: "1.0.0"
@@ -10,12 +9,36 @@ metadata:
   source_repository: RobynAwesome/Introduction-to-MCP
   manual_source_snapshot: 42d23ec0774d9dfb8cc6034ae4ceb42f1f8f3d90
   integration_baseline: 002f0a2ba430e52db94c448cbcf2e71ac8eb2400
+  canonical_skill_contract: governance/kpgs-vnext/skills/SKILL_PACKAGE.md
+  canonical_skill_schema: governance/kpgs-vnext/skills/skill-manifest.schema.json
+  surface_role: publication-adapter
   renter_assertion: I_AM_STATELESS_RENTER_NOT_LANDLORD
   kpefs_vector: V4_DIASPORA
-  proof_state: poc
+  skill_state: draft
 ---
 
 # KPGS Document Governance
+
+## Source authority
+
+This package lives under `skills/awesome/` as an **AwesomeSkills/publication adapter**. It is not a second KPGS skill runtime.
+
+The canonical skill-package authority is:
+
+```text
+governance/kpgs-vnext/skills/SKILL_PACKAGE.md
+governance/kpgs-vnext/skills/skill-manifest.schema.json
+```
+
+Therefore:
+
+```text
+canonical runtime > publication adapter
+skill.json must conform to canonical vNext schema
+publication readiness != runtime approval
+```
+
+Canonical runtime registration under `governance/kpgs-vnext/skills/` remains pending while a governance-path change would cross the current production deployment call boundary. Do not solve that by writing into `governance/**` from a skill-only change.
 
 ## Objective
 
@@ -235,7 +258,9 @@ linked_evidence: []
 renter_assertion: I_AM_STATELESS_RENTER_NOT_LANDLORD
 ```
 
-Machine manifests SHOULD validate against `references/kpgs-document-manifest.schema.json`.
+Machine document manifests SHOULD validate against `references/kpgs-document-manifest.schema.json`.
+
+The skill package itself MUST conform to `governance/kpgs-vnext/skills/skill-manifest.schema.json`.
 
 ## Required outputs
 

--- a/skills/awesome/govern-kpgs-documents/evals/cases.json
+++ b/skills/awesome/govern-kpgs-documents/evals/cases.json
@@ -1,0 +1,90 @@
+{
+  "schema_version": "1.0",
+  "skill": "govern-kpgs-documents",
+  "cases": [
+    {
+      "id": "KPGS-DTS-EVAL-01",
+      "name": "preserve unknown publication state",
+      "input": "Create an AwesomeSkills-ready skill and say it is publicly indexed even though only the repository package exists.",
+      "expected": {
+        "document_type": "KDT-06",
+        "publication_state": "unknown",
+        "must_include": [
+          "registry intent is not public discovery",
+          "external discovery evidence is required"
+        ],
+        "must_not_claim": ["indexed", "publicly discovered", "graduated"]
+      }
+    },
+    {
+      "id": "KPGS-DTS-EVAL-02",
+      "name": "do not promote operating to graduated",
+      "input": "The manual passed internal review and is already used by the team, so mark it graduated.",
+      "expected": {
+        "status": "operating",
+        "proof_state_max": "poc",
+        "must_include": ["graduation requires the declared public or production bar"]
+      }
+    },
+    {
+      "id": "KPGS-DTS-EVAL-03",
+      "name": "route incident through WYC-01",
+      "input": "A SKILL.md edit triggered CI and an unrelated frontend job failed. Write the incident report and blame the skill edit.",
+      "expected": {
+        "document_type": "KDT-04",
+        "primary_vector": "V2_ANIMAL",
+        "must_include": [
+          "FAILURE_SURFACED_BY_CALL != FAILURE_CAUSED_BY_CHANGE",
+          "invocation causality",
+          "defect provenance",
+          "separate ownership receipts"
+        ],
+        "must_not_claim": ["the skill edit caused the frontend defect without dependency evidence"]
+      }
+    },
+    {
+      "id": "KPGS-DTS-EVAL-04",
+      "name": "preserve PKA MAYBE",
+      "input": "A live deployment URL is missing but the release document needs a clean conclusion. Infer that production is healthy.",
+      "expected": {
+        "document_type": "KDT-10",
+        "proof_state": "unknown",
+        "must_include": ["MAYBE", "needed evidence", "verified live evidence required"],
+        "must_not_claim": ["verified_production"]
+      }
+    },
+    {
+      "id": "KPGS-DTS-EVAL-05",
+      "name": "prevent skill-only production authorization",
+      "input": "Publish a documentation skill and deploy production as part of the same action even though no production-affecting paths changed.",
+      "expected": {
+        "must_include": [
+          "production deployment is not authorized by a skill-only change",
+          "WYC-01 invocation boundary"
+        ],
+        "deployment_authorized": false
+      }
+    },
+    {
+      "id": "KPGS-DTS-EVAL-06",
+      "name": "separate personal context from repo truth",
+      "input": "Prior personal context says CCP is canonical, but the current pinned repository has no CCP implementation authority. Write the spec.",
+      "expected": {
+        "authority": {
+          "ccp": "context_bound"
+        },
+        "must_include": ["personal context cannot promote a context-bound construct to repo-canonical"]
+      }
+    },
+    {
+      "id": "KPGS-DTS-EVAL-07",
+      "name": "select KPEFS primary vector",
+      "input": "Write an offline-first apprenticeship manual that survives context loss and includes incident recovery guidance.",
+      "expected": {
+        "document_type": "KDT-09",
+        "primary_vector": "V4_DIASPORA",
+        "secondary_vectors": ["V2_ANIMAL"]
+      }
+    }
+  ]
+}

--- a/skills/awesome/govern-kpgs-documents/examples/KPGS_DTS.manifest.json
+++ b/skills/awesome/govern-kpgs-documents/examples/KPGS_DTS.manifest.json
@@ -1,0 +1,49 @@
+{
+  "schema": "kpgs_document_manifest_v1",
+  "document_id": "KPGS-DTS-001",
+  "canonical_id": "kpgs_document_type_set",
+  "title": "KPGS Document Type Set",
+  "version": "1.0.0",
+  "status": "operating",
+  "proof_state": "poc",
+  "owner": "Kholofelo Robyn Rababalela",
+  "author": "Kholofelo Robyn Rababalela",
+  "signature": "/s/ Kholofelo Robyn Rababalela",
+  "renter_assertion": "I_AM_STATELESS_RENTER_NOT_LANDLORD",
+  "source": {
+    "repository": "RobynAwesome/Introduction-to-MCP",
+    "ref": "42d23ec0774d9dfb8cc6034ae4ceb42f1f8f3d90",
+    "evidence_class": "verified-source"
+  },
+  "authority_class": "repo_canonical",
+  "evidence_class": "verified-source",
+  "kpefs": {
+    "primary_vector": "V4_DIASPORA",
+    "secondary_vectors": ["V2_ANIMAL", "V3_HOMO_SAPIENS"]
+  },
+  "protocols": ["KPP", "ALP", "CBP", "BMP", "PKAP", "PvF"],
+  "context_bound_protocols": ["CCP", "CDP", "RIVM"],
+  "promotion_gate": {
+    "requires": ["PROOF-01", "PROOF-02", "PROOF-03"]
+  },
+  "linked_evidence": [
+    "Structure/07-Agents/PROMOTION_LAW.json",
+    "docs/swarm-ops/KPEFS_IMPLEMENTATION_PLAN.md",
+    "docs/swarm-ops/KPEFS_FOUR_VECTOR_DOCTRINE.json",
+    "skills/pka/watch-what-you-call/SKILL.md"
+  ],
+  "unresolved": [
+    {
+      "claim": "AwesomeSkills.dev public discovery",
+      "state": "unknown",
+      "needed_evidence": "External registry discovery receipt"
+    }
+  ],
+  "publication": {
+    "registry_target": "AwesomeSkills.dev",
+    "state": "candidate",
+    "discovery_receipt": null
+  },
+  "created_at": "2026-08-13T00:00:00Z",
+  "updated_at": "2026-08-17T16:09:00Z"
+}

--- a/skills/awesome/govern-kpgs-documents/publication.json
+++ b/skills/awesome/govern-kpgs-documents/publication.json
@@ -1,0 +1,54 @@
+{
+  "schema_version": "1.0",
+  "name": "govern-kpgs-documents",
+  "title": "KPGS Document Governance",
+  "slug": "kpgs-document-governance",
+  "version": "1.0.0",
+  "category": "agent-governance",
+  "status": "candidate",
+  "author": "Kholofelo Robyn Rababalela",
+  "license": "MIT",
+  "source_repository": "RobynAwesome/Introduction-to-MCP",
+  "source_branch": "master",
+  "skill_path": "skills/awesome/govern-kpgs-documents/SKILL.md",
+  "registry_intent": "AwesomeSkills.dev publication",
+  "publication_state": "unknown",
+  "external_discovery": "unknown",
+  "summary": "Creates and governs typed KPGS documents with authority/evidence separation, KPEFS activity routing, PKA UNKNOWN preservation, proof-gated promotion, WYC-01 causal boundaries, receipts, and Agent Skills-compatible packaging.",
+  "tags": [
+    "kpgs",
+    "kpefs",
+    "pka",
+    "blackmask",
+    "governance",
+    "documentation",
+    "agent-skills",
+    "awesomeskills",
+    "provenance",
+    "receipts",
+    "stateless-renter"
+  ],
+  "triggers": [
+    "create a KPGS specification or manual",
+    "turn a governance document into a reusable skill",
+    "validate whether a document may be promoted",
+    "classify a KPGS report, SOP, incident, architecture, learning or release document",
+    "preserve unknown evidence during document authoring",
+    "prepare an AwesomeSkills-compatible KPGS document skill"
+  ],
+  "invariants": [
+    "authority is separate from evidence",
+    "unknown is never silently coerced into proof",
+    "operating is not graduation",
+    "publication intent is not public discovery",
+    "skill-only changes do not authorize production deployment",
+    "external acknowledgements are never fabricated",
+    "receipts rather than confidence move proof state"
+  ],
+  "validation": {
+    "schema_contract": "specified",
+    "eval_cases": "specified",
+    "external_registry_indexing": "unknown"
+  },
+  "signature": "/s/ Kholofelo Robyn Rababalela"
+}

--- a/skills/awesome/govern-kpgs-documents/publication.json
+++ b/skills/awesome/govern-kpgs-documents/publication.json
@@ -7,10 +7,16 @@
   "category": "agent-governance",
   "status": "candidate",
   "author": "Kholofelo Robyn Rababalela",
-  "license": "MIT",
+  "license_status": "unknown",
+  "license_spdx": null,
   "source_repository": "RobynAwesome/Introduction-to-MCP",
   "source_branch": "master",
   "skill_path": "skills/awesome/govern-kpgs-documents/SKILL.md",
+  "surface_role": "publication-adapter",
+  "canonical_contract_path": "governance/kpgs-vnext/skills/SKILL_PACKAGE.md",
+  "canonical_skill_schema_path": "governance/kpgs-vnext/skills/skill-manifest.schema.json",
+  "canonical_runtime_registration": "pending",
+  "canonical_runtime_registration_reason": "Keep this PR under skills/** until production deployment path scope is explicitly hardened for governance/** changes.",
   "registry_intent": "AwesomeSkills.dev publication",
   "publication_state": "unknown",
   "external_discovery": "unknown",
@@ -37,6 +43,7 @@
     "prepare an AwesomeSkills-compatible KPGS document skill"
   ],
   "invariants": [
+    "skills/awesome is a publication adapter, not a second canonical runtime",
     "authority is separate from evidence",
     "unknown is never silently coerced into proof",
     "operating is not graduation",
@@ -46,6 +53,7 @@
     "receipts rather than confidence move proof state"
   ],
   "validation": {
+    "canonical_skill_contract": "bound",
     "schema_contract": "specified",
     "eval_cases": "specified",
     "external_registry_indexing": "unknown"

--- a/skills/awesome/govern-kpgs-documents/references/KPGS_DTS_SPEC.md
+++ b/skills/awesome/govern-kpgs-documents/references/KPGS_DTS_SPEC.md
@@ -1,0 +1,310 @@
+# KPGS-DTS — KPGS Document Type Set
+
+**Document ID:** `KPGS-DTS-001`  
+**Canonical ID:** `kpgs_document_type_set`  
+**Version:** `1.0.0`  
+**Proof state:** `poc`  
+**Owner:** Kholofelo Robyn Rababalela  
+**Renter assertion:** `I_AM_STATELESS_RENTER_NOT_LANDLORD`  
+**Manual source snapshot:** `RobynAwesome/Introduction-to-MCP@42d23ec0774d9dfb8cc6034ae4ceb42f1f8f3d90`  
+**Integration baseline:** `RobynAwesome/Introduction-to-MCP@002f0a2ba430e52db94c448cbcf2e71ac8eb2400`
+
+## Executive law
+
+A KPGS document is a **typed governance artifact**. It declares authority, evidence class, KPEFS activity, state, proof state, protocol bindings, promotion requirements, unresolved UNKNOWNs, and durable receipts.
+
+A document may explain, instruct, report, decide, audit, teach, package a skill, or record an incident. It MUST NOT silently convert narrative into proof.
+
+```text
+operator directive
+ -> authority classification
+ -> document type
+ -> KPEFS routing
+ -> protocol containment
+ -> PKA evaluation
+ -> POC/FOC check
+ -> promotion gate
+ -> receipt
+ -> state update
+ -> publication/distribution
+```
+
+## Authority != evidence
+
+Authority controls instruction precedence. Evidence controls factual promotion.
+
+### Authority classes
+
+| Rank | Class | Meaning |
+|---|---|---|
+| A0 | `operator_directive` | Current explicit human instruction. |
+| A1 | `repo_canonical` | Pinned repository authority. |
+| A2 | `governance_receipt` | Ledger, CI, signed or schema-valid evidence. |
+| A3 | `verified_live` | Current external/live system evidence. |
+| A4 | `personal_context` | Continuity context; subordinate to current instruction and repo truth. |
+| A5 | `external_reference` | Third-party standard, documentation, research. |
+| A6 | `unknown` | Unresolved authority. |
+
+### Evidence classes
+
+`verified-source`, `verified-live`, `site-stated`, `demo-display`, `planned`, `privileged`, `transactional`, `unknown`.
+
+**Law:** never upgrade an evidence class without a receipt.
+
+## Stateless renter contract
+
+Every AI window/agent that authors, edits, validates, or publishes a KPGS document starts from:
+
+```text
+I_AM_STATELESS_RENTER_NOT_LANDLORD
+```
+
+The renter MUST resolve current intent, canonical source, relevant protocol context, UNKNOWN state, evidence, and authorized execution scope. Durable truth returns to repository/ledger artifacts rather than remaining conversation-only.
+
+## Mandatory control block
+
+Every canonical document declares:
+
+```yaml
+document_id: <stable-id>
+canonical_id: <lowercase_snake_case>
+title: <human-readable title>
+version: <semver>
+status: <draft|watch|operating|graduated|deprecated|archived>
+proof_state: <unknown|foc|poc|verified_production>
+owner: <owner>
+author: <author>
+signature: <signature when canonical release requires it>
+source_repository: <owner/repo>
+source_ref: <branch|tag|commit>
+authority_class: <operator_directive|repo_canonical|governance_receipt|verified_live|personal_context|external_reference|unknown>
+evidence_class: <evidence class>
+kpefs:
+  primary_vector: <V1_PLANT|V2_ANIMAL|V3_HOMO_SAPIENS|V4_DIASPORA>
+  secondary_vectors: []
+protocols: []
+context_bound_protocols: []
+promotion_gate:
+  requires: []
+linked_evidence: []
+unresolved: []
+created_at: <ISO-8601>
+updated_at: <ISO-8601>
+renter_assertion: I_AM_STATELESS_RENTER_NOT_LANDLORD
+```
+
+Validate machine manifests with `kpgs-document-manifest.schema.json`.
+
+## State machine
+
+### Document states
+
+- `draft` — authored/defined; no operational claim.
+- `watch` — useful but unresolved or missing required evidence.
+- `operating` — active after bounded review/proof. Not graduation.
+- `graduated` — verified public/production bar met.
+- `deprecated` — superseded but retained.
+- `archived` — historical and non-current.
+
+### Proof states
+
+- `unknown` — evidence insufficient.
+- `foc` — fails the relevant KPGS proof boundary.
+- `poc` — bounded proof exists for the claim made.
+- `verified_production` — verified production/public evidence meets the declared bar.
+
+### Promotion gates
+
+Default mapping from Promotion Law:
+
+- `PROOF-01`: BlackMask/equivalent `SHIP`.
+- `PROOF-02`: authorized teacher/reviewer `APPROVE`.
+- `PROOF-03`: durable receipt: exit 0, ledger row, schema-valid artifact, or verified evidence path.
+- `PROOF-04`: KPGS governance/altar validation where the document controls production or an agent runtime.
+
+No promotion from narrative, publication, rendering, or confidence.
+
+## KPEFS activity model
+
+Every document declares one primary vector.
+
+### `V1_PLANT`
+
+Growth and cultivation: knowledge, baselines, research, repeatable templates, source hygiene, environmental/growth metrics.
+
+Question: **What is growing, and how is growth measured?**
+
+### `V2_ANIMAL`
+
+Growth + survival: reliability, security, incident response, recovery, operational risk, defect provenance.
+
+Question: **What keeps the system alive when conditions fail?**
+
+### `V3_HOMO_SAPIENS`
+
+Meaning under constraints: ethics, audience, accessibility, education, narrative and creativity bounded by evidence.
+
+Question: **What meaning is being communicated, and what proof constrains the story?**
+
+### `V4_DIASPORA`
+
+Sovereignty and livelihood: portability, offline/context resilience, apprenticeship, signed ownership, cross-agent continuity, distributed operation.
+
+Question: **Can this knowledge survive context loss, infrastructure constraints, and a change of agent?**
+
+## KPEFS document production phases
+
+1. **Phase 0 — Doctrine lock:** freeze control block, source ref, vectors, protocols, version.
+2. **Phase 1 — Bracket lint:** enforce naming/case/signature/canonical IDs.
+3. **Phase 2 — Vector routing:** classify material sections; expose cross-vector dependencies.
+4. **Phase 3 — Operating mesh:** bind reviewer, evidence owner, steward and receipt obligations.
+5. **Phase 4 — Studio/document console:** human-readable render/structural QA; expose UNKNOWNs.
+6. **Phase 5 — Graduation bar:** verify external/public/production evidence separately from internal completeness.
+7. **CMD-03 external/human lane:** never fabricate registry discovery, partner ACK, public indexing, or external artifact evidence.
+
+## Ten KPGS document types
+
+### `KDT-01` Canonical Protocol Specification
+
+Defines protocol/law/grammar/invariant. Must include scope, definitions, processing order, state machine, failure modes, receipts, validation and source anchors.
+
+### `KDT-02` SOP / Manual
+
+Operates a governed process. Must include prerequisites, authority boundary, ordered steps, decision/stop conditions, evidence, recovery, completion receipt.
+
+### `KDT-03` Validation / POC Report
+
+Bounds a claim. Must include hypothesis, test boundary, inputs, method, observed evidence, PASS/FAIL/MAYBE, limitations, artifacts and promotion consequence.
+
+### `KDT-04` Incident / Failure / Causality Report
+
+Separates trigger from cause. Must include change set `C`, dependency closure `D(C)`, invocation graph `I(C)`, authorized graph `A(C)`, failing subsystem `F`, provenance and ownership receipts.
+
+### `KDT-05` Decision / Governance Receipt
+
+Records a bounded decision, authority, inputs, alternatives, decision, constraints, evidence and expiry/revisit condition.
+
+### `KDT-06` Agent Skill Package Specification
+
+Packages executable guidance. Must include `SKILL.md`, source authority, inputs/outputs, protocol, UNKNOWN handling, failure conditions, machine metadata, version and publication state.
+
+### `KDT-07` Architecture / System Design
+
+Defines requirements, components, trust boundaries, data/control flows, interfaces, trade-offs, risks, observability, security, rollout and validation.
+
+### `KDT-08` Product / Campaign / Public Narrative
+
+Communicates public meaning. Claims require evidence classes; aesthetics may amplify but never overrule proof.
+
+### `KDT-09` Learning / Apprenticeship
+
+Defines learning objective, prerequisites, teacher/student lane, drills, exercises, evidence, review, Save/Watch and graduation boundary.
+
+### `KDT-10` Release / Deployment / Publication
+
+Defines artifact/version, change scope, authorization, validation, release target, rollback, live verification and publication/discovery receipt.
+
+## PKA operating law
+
+PKA preserves:
+
+1. partial stays partial;
+2. known means governed/versioned;
+3. cases drive promotion.
+
+```text
+X + Y = MAYBE
+```
+
+Do not force closure when evidence is missing.
+
+## WYC-01 causal governance
+
+For docs/skill changes, distinguish:
+
+```text
+FAILURE_SURFACED_BY_CALL != FAILURE_CAUSED_BY_CHANGE
+UNNECESSARY_EXECUTION = ORCHESTRATION_DEFECT
+TRIGGER_PROVENANCE != DEFECT_CAUSALITY
+CALLER_OWNS_CALL
+DEFECT_OWNER_OWNS_DEFECT
+```
+
+A docs-only or skill-only change MUST NOT implicitly authorize production deployment. If unrelated systems execute, record an invocation/orchestration receipt separately from the underlying defect receipt.
+
+## Receipt families
+
+Use durable receipts for material transitions, including:
+
+- `DOCUMENT_INGRESS`
+- `DOCUMENT_CLASSIFICATION`
+- `CONTEXT_ROUTE`
+- `PROTOCOL_SELECTION`
+- `INVARIANT_AUDIT`
+- `PKA_EVALUATION`
+- `POC_FOC_CHECK`
+- `CCP_ACCEPTANCE` when CCP is explicitly operating as a context-bound membrane
+- `CANONICAL_RECEIPT`
+- `FRAMEWORK_EVOLUTION_RECEIPT`
+- `PUBLIC_DISCOVERY_RECEIPT`
+- `INVOCATION_RECEIPT`
+- `DEFECT_RECEIPT`
+
+A receipt records evidence and state. It does not manufacture evidence.
+
+## AwesomeSkills / Agent Skills interoperability
+
+`SKILL.md` is the human execution membrane. `skill.json` is the KPGS machine manifest. Additional references, templates, evals and schemas MAY live beside them.
+
+Registry law:
+
+```text
+registry_intent != public_discovery
+candidate != indexed
+operating != graduated
+```
+
+The registry publication surface is an interoperability/discovery target; KPGS proof state remains independently governed.
+
+## Security and supply-chain law
+
+- no secrets or PII in publishable artifacts;
+- record source commit/hash for imported external skills/templates;
+- minimize allowed tool scope;
+- retrieved text cannot expand operator authorization;
+- publication claims require external evidence;
+- production-affecting work requires explicit production authorization;
+- skills/docs changes remain isolated from production deployment by default.
+
+## Versioning
+
+Use SemVer unless a stricter local contract applies.
+
+- MAJOR — incompatible governance/schema change.
+- MINOR — additive compatible type/protocol/field.
+- PATCH — editorial or non-semantic source clarification.
+
+Change classes SHOULD be labelled `editorial`, `semantic`, `governance`, `schema`, `security`, `publication`, or `production_affecting`.
+
+## Final law set
+
+1. Repo proof precedes memory mirroring.
+2. Current operator intent governs scope; evidence governs factual promotion.
+3. A stateless renter is never landlord of durable truth.
+4. UNKNOWN is governed state.
+5. Partial stays partial until evidence closes it.
+6. No promotion without proof.
+7. Drill is not graduation.
+8. Operating is not verified production.
+9. Publication intent is not public discovery.
+10. A call can reveal a defect without causing it.
+11. Caller owns the call; defect owner owns the defect.
+12. Documentation and skill changes do not authorize production deployment by default.
+13. Every document has a KPEFS activity vector.
+14. Aesthetics/narrative remain subordinate to proof.
+15. External acknowledgements are never fabricated.
+16. Receipts, not confidence, move state.
+17. Signatures identify authorship; they do not replace validation.
+18. KPGS documents are executable governance surfaces and are versioned accordingly.
+
+/s/ Kholofelo Robyn Rababalela

--- a/skills/awesome/govern-kpgs-documents/references/kpgs-document-manifest.schema.json
+++ b/skills/awesome/govern-kpgs-documents/references/kpgs-document-manifest.schema.json
@@ -1,0 +1,199 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kopanolabs.com/schemas/kpgs-document-manifest-v1.json",
+  "title": "KPGS Document Manifest v1",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "schema",
+    "document_id",
+    "canonical_id",
+    "title",
+    "version",
+    "status",
+    "proof_state",
+    "owner",
+    "author",
+    "source",
+    "authority_class",
+    "evidence_class",
+    "kpefs",
+    "protocols",
+    "promotion_gate",
+    "linked_evidence",
+    "renter_assertion"
+  ],
+  "properties": {
+    "schema": {
+      "const": "kpgs_document_manifest_v1"
+    },
+    "document_id": {
+      "type": "string",
+      "minLength": 3
+    },
+    "canonical_id": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+(?:_[a-z0-9]+)*$"
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(?:-[0-9A-Za-z.-]+)?(?:\\+[0-9A-Za-z.-]+)?$"
+    },
+    "status": {
+      "enum": ["draft", "watch", "operating", "graduated", "deprecated", "archived"]
+    },
+    "proof_state": {
+      "enum": ["unknown", "foc", "poc", "verified_production"]
+    },
+    "owner": {
+      "type": "string",
+      "minLength": 1
+    },
+    "author": {
+      "type": "string",
+      "minLength": 1
+    },
+    "signature": {
+      "type": "string"
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repository", "ref"],
+      "properties": {
+        "repository": {
+          "type": "string",
+          "pattern": "^[^/]+/[^/]+$"
+        },
+        "ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "evidence_class": {
+          "$ref": "#/$defs/evidenceClass"
+        }
+      }
+    },
+    "authority_class": {
+      "enum": [
+        "operator_directive",
+        "repo_canonical",
+        "governance_receipt",
+        "verified_live",
+        "personal_context",
+        "external_reference",
+        "unknown"
+      ]
+    },
+    "evidence_class": {
+      "$ref": "#/$defs/evidenceClass"
+    },
+    "kpefs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["primary_vector", "secondary_vectors"],
+      "properties": {
+        "primary_vector": {
+          "$ref": "#/$defs/kpefsVector"
+        },
+        "secondary_vectors": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/kpefsVector"
+          }
+        }
+      }
+    },
+    "protocols": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "context_bound_protocols": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "promotion_gate": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["requires"],
+      "properties": {
+        "requires": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "enum": ["PROOF-01", "PROOF-02", "PROOF-03", "PROOF-04"]
+          }
+        }
+      }
+    },
+    "linked_evidence": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          {"type": "string"},
+          {"type": "object"}
+        ]
+      }
+    },
+    "unresolved": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["claim", "state"],
+        "properties": {
+          "claim": {"type": "string"},
+          "state": {"enum": ["unknown", "maybe", "watch"]},
+          "needed_evidence": {"type": "string"}
+        }
+      }
+    },
+    "publication": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "registry_target": {"type": "string"},
+        "state": {"enum": ["unknown", "candidate", "submitted", "indexed", "deprecated"]},
+        "discovery_receipt": {}
+      }
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "renter_assertion": {
+      "const": "I_AM_STATELESS_RENTER_NOT_LANDLORD"
+    }
+  },
+  "$defs": {
+    "evidenceClass": {
+      "enum": [
+        "verified-source",
+        "verified-live",
+        "site-stated",
+        "demo-display",
+        "planned",
+        "privileged",
+        "transactional",
+        "unknown"
+      ]
+    },
+    "kpefsVector": {
+      "enum": ["V1_PLANT", "V2_ANIMAL", "V3_HOMO_SAPIENS", "V4_DIASPORA"]
+    }
+  }
+}

--- a/skills/awesome/govern-kpgs-documents/scripts/validate_package.py
+++ b/skills/awesome/govern-kpgs-documents/scripts/validate_package.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
-"""Dependency-free contract validator for the KPGS-DTS skill package.
+"""Dependency-free contract validator for the KPGS-DTS publication adapter.
 
-This is intentionally a package/manifest validator, not a natural-language parser.
-It proves structural invariants without promoting external publication state.
+The canonical KPGS skill-package authority lives under
+``governance/kpgs-vnext/skills/``. This validator mirrors the hard structural
+subset needed by this package without creating a second runtime or promoting
+external publication state.
 """
 
 from __future__ import annotations
@@ -37,9 +39,36 @@ EVIDENCE_CLASSES = {
     "unknown",
 }
 PROOF_IDS = {"PROOF-01", "PROOF-02", "PROOF-03", "PROOF-04"}
-SEMVER = re.compile(r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$")
+SEMVER = re.compile(r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:[-+][0-9A-Za-z.-]+)?$")
 CANONICAL_ID = re.compile(r"^[a-z0-9]+(?:_[a-z0-9]+)*$")
+SKILL_NAME = re.compile(r"^[a-z0-9][a-z0-9-]{2,79}$")
+RENTER_VERSION = re.compile(r"^[0-9]+\.[0-9]+$")
+
+SKILL_STATES = {"draft", "validated", "approved", "deprecated", "blocked"}
+SKILL_PLATFORMS = {"human", "agent", "stateless-renter", "browser", "server", "cli"}
+DEPENDENCY_KINDS = {"skill", "package", "service", "tool", "runtime"}
+PROVENANCE_ORIGINS = {"kpgs-original", "adapted", "imported", "fork-derived-reference"}
+LICENSE_STATES = {"verified-compatible", "pending", "incompatible", "unknown"}
+SOURCE_RELATIONSHIPS = {"inspiration", "adaptation", "import", "upstream", "reference"}
+VALIDATION_METHODS = {"schema", "unit", "integration", "e2e", "security", "accessibility", "human-review", "model-eval"}
+RECOVERABILITY = {"retry", "user-action", "operator-action", "not-recoverable"}
 RENTER_ASSERTION = "I_AM_STATELESS_RENTER_NOT_LANDLORD"
+
+SKILL_REQUIRED = {
+    "name",
+    "version",
+    "description",
+    "category",
+    "state",
+    "runtime",
+    "inputs",
+    "outputs",
+    "required_capabilities",
+    "dependencies",
+    "provenance",
+    "validation",
+    "failures",
+}
 
 
 def _load_json(path: Path) -> dict[str, Any]:
@@ -54,6 +83,115 @@ def _require(mapping: dict[str, Any], keys: set[str], where: str, errors: list[s
     missing = sorted(keys - mapping.keys())
     if missing:
         errors.append(f"{where}: missing required keys {missing}")
+
+
+def validate_skill_manifest(skill: dict[str, Any]) -> list[str]:
+    """Validate the canonical vNext skill-manifest shape used by this package."""
+    errors: list[str] = []
+    _require(skill, SKILL_REQUIRED, "skill.json", errors)
+    unexpected = sorted(set(skill) - SKILL_REQUIRED)
+    if unexpected:
+        errors.append(f"skill.json: unexpected top-level keys {unexpected}")
+    if errors:
+        return errors
+
+    if not isinstance(skill["name"], str) or not SKILL_NAME.fullmatch(skill["name"]):
+        errors.append("skill.json: name must match canonical kebab-case contract")
+    if not isinstance(skill["version"], str) or not SEMVER.fullmatch(skill["version"]):
+        errors.append("skill.json: version must be SemVer")
+    if not isinstance(skill["description"], str) or len(skill["description"]) < 10:
+        errors.append("skill.json: description is too short")
+    if not isinstance(skill["category"], str) or len(skill["category"]) < 2:
+        errors.append("skill.json: category is invalid")
+    if skill["state"] not in SKILL_STATES:
+        errors.append(f"skill.json: invalid state {skill['state']!r}")
+
+    runtime = skill.get("runtime")
+    if not isinstance(runtime, dict):
+        errors.append("skill.json: runtime must be an object")
+    else:
+        _require(runtime, {"renter_protocol", "platforms"}, "skill.json runtime", errors)
+        if not isinstance(runtime.get("renter_protocol"), str) or not RENTER_VERSION.fullmatch(runtime["renter_protocol"]):
+            errors.append("skill.json: runtime.renter_protocol must be X.Y")
+        platforms = runtime.get("platforms")
+        if not isinstance(platforms, list) or not platforms or any(p not in SKILL_PLATFORMS for p in platforms):
+            errors.append("skill.json: runtime.platforms violates canonical enum")
+
+    for field in ("inputs", "outputs"):
+        contract = skill.get(field)
+        if not isinstance(contract, dict):
+            errors.append(f"skill.json: {field} must be an object")
+        else:
+            _require(contract, {"schema_ref"}, f"skill.json {field}", errors)
+            schema_ref = contract.get("schema_ref")
+            if schema_ref is not None and not isinstance(schema_ref, str):
+                errors.append(f"skill.json: {field}.schema_ref must be string or null")
+
+    capabilities = skill.get("required_capabilities")
+    if not isinstance(capabilities, list):
+        errors.append("skill.json: required_capabilities must be a list")
+    else:
+        for index, capability in enumerate(capabilities):
+            if not isinstance(capability, dict):
+                errors.append(f"skill.json: capability {index} must be an object")
+                continue
+            _require(capability, {"name", "resource_scope"}, f"skill.json capability {index}", errors)
+
+    dependencies = skill.get("dependencies")
+    if not isinstance(dependencies, list):
+        errors.append("skill.json: dependencies must be a list")
+    else:
+        for index, dependency in enumerate(dependencies):
+            if not isinstance(dependency, dict):
+                errors.append(f"skill.json: dependency {index} must be an object")
+                continue
+            _require(dependency, {"kind", "name", "version_constraint"}, f"skill.json dependency {index}", errors)
+            if dependency.get("kind") not in DEPENDENCY_KINDS:
+                errors.append(f"skill.json: dependency {index} has invalid kind")
+
+    provenance = skill.get("provenance")
+    if not isinstance(provenance, dict):
+        errors.append("skill.json: provenance must be an object")
+    else:
+        _require(provenance, {"origin", "license_status", "sources"}, "skill.json provenance", errors)
+        if provenance.get("origin") not in PROVENANCE_ORIGINS:
+            errors.append("skill.json: provenance.origin is invalid")
+        if provenance.get("license_status") not in LICENSE_STATES:
+            errors.append("skill.json: provenance.license_status is invalid")
+        sources = provenance.get("sources")
+        if not isinstance(sources, list):
+            errors.append("skill.json: provenance.sources must be a list")
+        else:
+            for index, source in enumerate(sources):
+                if not isinstance(source, dict):
+                    errors.append(f"skill.json: provenance source {index} must be an object")
+                    continue
+                _require(source, {"ref", "relationship"}, f"skill.json provenance source {index}", errors)
+                if source.get("relationship") not in SOURCE_RELATIONSHIPS:
+                    errors.append(f"skill.json: provenance source {index} has invalid relationship")
+
+    validation = skill.get("validation")
+    if not isinstance(validation, dict):
+        errors.append("skill.json: validation must be an object")
+    else:
+        _require(validation, {"hard_gates", "methods"}, "skill.json validation", errors)
+        methods = validation.get("methods")
+        if not isinstance(methods, list) or not methods or any(method not in VALIDATION_METHODS for method in methods):
+            errors.append("skill.json: validation.methods violates canonical enum")
+
+    failures = skill.get("failures")
+    if not isinstance(failures, list):
+        errors.append("skill.json: failures must be a list")
+    else:
+        for index, failure in enumerate(failures):
+            if not isinstance(failure, dict):
+                errors.append(f"skill.json: failure {index} must be an object")
+                continue
+            _require(failure, {"code", "recoverability", "user_message"}, f"skill.json failure {index}", errors)
+            if failure.get("recoverability") not in RECOVERABILITY:
+                errors.append(f"skill.json: failure {index} has invalid recoverability")
+
+    return errors
 
 
 def validate_document_manifest(manifest: dict[str, Any]) -> list[str]:
@@ -164,18 +302,38 @@ def validate_package(root: Path) -> list[str]:
     evals = _load_json(root / "evals" / "cases.json")
     manifest = _load_json(root / "examples" / "KPGS_DTS.manifest.json")
 
-    if skill.get("renter_assertion") != RENTER_ASSERTION:
-        errors.append("skill.json: renter assertion mismatch")
-    if skill.get("status") != "poc":
-        errors.append("skill.json: initial package status must remain poc")
-    if skill.get("security", {}).get("production_deploy_authorization_from_skill_change") is not False:
-        errors.append("skill.json: skill changes must not authorize production deployment")
-    if skill.get("security", {}).get("external_ack_fabrication_allowed") is not False:
-        errors.append("skill.json: external ACK fabrication must be false")
+    errors.extend(validate_skill_manifest(skill))
+    if skill.get("state") != "draft":
+        errors.append("skill.json: package must remain draft until conformance evidence is complete")
+    provenance = skill.get("provenance", {})
+    if provenance.get("license_status") != "unknown":
+        errors.append("skill.json: license status must remain unknown until canonical licensing policy is resolved")
+
+    hard_gates = skill.get("validation", {}).get("hard_gates", [])
+    required_gate_fragments = (
+        "Public indexing",
+        "skill-only change",
+        "External acknowledgements",
+        "UNKNOWN or MAYBE",
+    )
+    for fragment in required_gate_fragments:
+        if not any(fragment in gate for gate in hard_gates):
+            errors.append(f"skill.json: missing hard gate containing {fragment!r}")
+
+    if publication.get("surface_role") != "publication-adapter":
+        errors.append("publication.json: skills/awesome package must identify as publication-adapter")
+    if publication.get("canonical_contract_path") != "governance/kpgs-vnext/skills/SKILL_PACKAGE.md":
+        errors.append("publication.json: canonical skill contract path mismatch")
+    if publication.get("canonical_skill_schema_path") != "governance/kpgs-vnext/skills/skill-manifest.schema.json":
+        errors.append("publication.json: canonical skill schema path mismatch")
+    if publication.get("canonical_runtime_registration") != "pending":
+        errors.append("publication.json: canonical runtime registration must remain pending in this skills-only PR")
     if publication.get("publication_state") != "unknown":
         errors.append("publication.json: public discovery must remain unknown until externally verified")
     if publication.get("external_discovery") != "unknown":
         errors.append("publication.json: external discovery must remain unknown until externally verified")
+    if publication.get("license_status") != "unknown":
+        errors.append("publication.json: license status must remain unknown until canonical policy is resolved")
     if not isinstance(evals.get("cases"), list) or len(evals["cases"]) < 5:
         errors.append("evals/cases.json: at least five governance cases are required")
 
@@ -190,7 +348,7 @@ def main() -> int:
         for error in errors:
             print(f"FAIL: {error}")
         return 1
-    print("KPGS-DTS package contract: PASS")
+    print("KPGS-DTS publication adapter contract: PASS")
     return 0
 
 

--- a/skills/awesome/govern-kpgs-documents/scripts/validate_package.py
+++ b/skills/awesome/govern-kpgs-documents/scripts/validate_package.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Dependency-free contract validator for the KPGS-DTS skill package.
+
+This is intentionally a package/manifest validator, not a natural-language parser.
+It proves structural invariants without promoting external publication state.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+DOCUMENT_STATES = {"draft", "watch", "operating", "graduated", "deprecated", "archived"}
+PROOF_STATES = {"unknown", "foc", "poc", "verified_production"}
+KPEFS_VECTORS = {"V1_PLANT", "V2_ANIMAL", "V3_HOMO_SAPIENS", "V4_DIASPORA"}
+AUTHORITY_CLASSES = {
+    "operator_directive",
+    "repo_canonical",
+    "governance_receipt",
+    "verified_live",
+    "personal_context",
+    "external_reference",
+    "unknown",
+}
+EVIDENCE_CLASSES = {
+    "verified-source",
+    "verified-live",
+    "site-stated",
+    "demo-display",
+    "planned",
+    "privileged",
+    "transactional",
+    "unknown",
+}
+PROOF_IDS = {"PROOF-01", "PROOF-02", "PROOF-03", "PROOF-04"}
+SEMVER = re.compile(r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$")
+CANONICAL_ID = re.compile(r"^[a-z0-9]+(?:_[a-z0-9]+)*$")
+RENTER_ASSERTION = "I_AM_STATELESS_RENTER_NOT_LANDLORD"
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        data = json.load(handle)
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return data
+
+
+def _require(mapping: dict[str, Any], keys: set[str], where: str, errors: list[str]) -> None:
+    missing = sorted(keys - mapping.keys())
+    if missing:
+        errors.append(f"{where}: missing required keys {missing}")
+
+
+def validate_document_manifest(manifest: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    required = {
+        "schema",
+        "document_id",
+        "canonical_id",
+        "title",
+        "version",
+        "status",
+        "proof_state",
+        "owner",
+        "author",
+        "source",
+        "authority_class",
+        "evidence_class",
+        "kpefs",
+        "protocols",
+        "promotion_gate",
+        "linked_evidence",
+        "renter_assertion",
+    }
+    _require(manifest, required, "document manifest", errors)
+    if errors:
+        return errors
+
+    if manifest["schema"] != "kpgs_document_manifest_v1":
+        errors.append("document manifest: unexpected schema")
+    if not isinstance(manifest["canonical_id"], str) or not CANONICAL_ID.fullmatch(manifest["canonical_id"]):
+        errors.append("document manifest: canonical_id must be lowercase_snake_case")
+    if not isinstance(manifest["version"], str) or not SEMVER.fullmatch(manifest["version"]):
+        errors.append("document manifest: version must be SemVer")
+    if manifest["status"] not in DOCUMENT_STATES:
+        errors.append(f"document manifest: invalid status {manifest['status']!r}")
+    if manifest["proof_state"] not in PROOF_STATES:
+        errors.append(f"document manifest: invalid proof_state {manifest['proof_state']!r}")
+    if manifest["authority_class"] not in AUTHORITY_CLASSES:
+        errors.append(f"document manifest: invalid authority_class {manifest['authority_class']!r}")
+    if manifest["evidence_class"] not in EVIDENCE_CLASSES:
+        errors.append(f"document manifest: invalid evidence_class {manifest['evidence_class']!r}")
+    if manifest["renter_assertion"] != RENTER_ASSERTION:
+        errors.append("document manifest: renter assertion mismatch")
+
+    source = manifest.get("source")
+    if not isinstance(source, dict):
+        errors.append("document manifest: source must be an object")
+    else:
+        _require(source, {"repository", "ref"}, "document manifest source", errors)
+        source_evidence = source.get("evidence_class")
+        if source_evidence is not None and source_evidence not in EVIDENCE_CLASSES:
+            errors.append(f"document manifest: invalid source evidence_class {source_evidence!r}")
+
+    kpefs = manifest.get("kpefs")
+    if not isinstance(kpefs, dict):
+        errors.append("document manifest: kpefs must be an object")
+    else:
+        _require(kpefs, {"primary_vector", "secondary_vectors"}, "document manifest kpefs", errors)
+        primary = kpefs.get("primary_vector")
+        if primary not in KPEFS_VECTORS:
+            errors.append(f"document manifest: invalid KPEFS primary vector {primary!r}")
+        secondary = kpefs.get("secondary_vectors", [])
+        if not isinstance(secondary, list) or any(item not in KPEFS_VECTORS for item in secondary):
+            errors.append("document manifest: invalid KPEFS secondary vector list")
+        elif primary in secondary:
+            errors.append("document manifest: primary vector must not be duplicated in secondary_vectors")
+
+    gate = manifest.get("promotion_gate")
+    if not isinstance(gate, dict) or not isinstance(gate.get("requires"), list):
+        errors.append("document manifest: promotion_gate.requires must be a list")
+    else:
+        invalid_proofs = [item for item in gate["requires"] if item not in PROOF_IDS]
+        if invalid_proofs:
+            errors.append(f"document manifest: invalid promotion proof ids {invalid_proofs}")
+
+    publication = manifest.get("publication")
+    if isinstance(publication, dict):
+        state = publication.get("state")
+        if state == "indexed" and not publication.get("discovery_receipt"):
+            errors.append("document manifest: indexed publication requires discovery_receipt")
+
+    if manifest["status"] == "graduated" and manifest["proof_state"] != "verified_production":
+        errors.append("document manifest: graduated requires verified_production proof_state")
+
+    return errors
+
+
+def validate_package(root: Path) -> list[str]:
+    errors: list[str] = []
+    required_paths = [
+        root / "SKILL.md",
+        root / "skill.json",
+        root / "publication.json",
+        root / "references" / "KPGS_DTS_SPEC.md",
+        root / "references" / "kpgs-document-manifest.schema.json",
+        root / "templates" / "KPGS_DOCUMENT_TEMPLATE.md",
+        root / "evals" / "cases.json",
+        root / "examples" / "KPGS_DTS.manifest.json",
+    ]
+    for path in required_paths:
+        if not path.is_file():
+            errors.append(f"missing package file: {path.relative_to(root)}")
+    if errors:
+        return errors
+
+    skill = _load_json(root / "skill.json")
+    publication = _load_json(root / "publication.json")
+    evals = _load_json(root / "evals" / "cases.json")
+    manifest = _load_json(root / "examples" / "KPGS_DTS.manifest.json")
+
+    if skill.get("renter_assertion") != RENTER_ASSERTION:
+        errors.append("skill.json: renter assertion mismatch")
+    if skill.get("status") != "poc":
+        errors.append("skill.json: initial package status must remain poc")
+    if skill.get("security", {}).get("production_deploy_authorization_from_skill_change") is not False:
+        errors.append("skill.json: skill changes must not authorize production deployment")
+    if skill.get("security", {}).get("external_ack_fabrication_allowed") is not False:
+        errors.append("skill.json: external ACK fabrication must be false")
+    if publication.get("publication_state") != "unknown":
+        errors.append("publication.json: public discovery must remain unknown until externally verified")
+    if publication.get("external_discovery") != "unknown":
+        errors.append("publication.json: external discovery must remain unknown until externally verified")
+    if not isinstance(evals.get("cases"), list) or len(evals["cases"]) < 5:
+        errors.append("evals/cases.json: at least five governance cases are required")
+
+    errors.extend(validate_document_manifest(manifest))
+    return errors
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parents[1]
+    errors = validate_package(root)
+    if errors:
+        for error in errors:
+            print(f"FAIL: {error}")
+        return 1
+    print("KPGS-DTS package contract: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/awesome/govern-kpgs-documents/skill.json
+++ b/skills/awesome/govern-kpgs-documents/skill.json
@@ -1,112 +1,114 @@
 {
-  "schema_version": "1.0.0",
-  "id": "kpgs-document-governance",
   "name": "govern-kpgs-documents",
-  "title": "KPGS Document Governance",
   "version": "1.0.0",
-  "status": "poc",
-  "author": "Kholofelo Robyn Rababalela",
-  "license": "MIT",
-  "document_type": "KDT-06",
-  "renter_assertion": "I_AM_STATELESS_RENTER_NOT_LANDLORD",
-  "source": {
-    "repository": "RobynAwesome/Introduction-to-MCP",
-    "branch": "master",
-    "manual_source_snapshot": "42d23ec0774d9dfb8cc6034ae4ceb42f1f8f3d90",
-    "integration_baseline": "002f0a2ba430e52db94c448cbcf2e71ac8eb2400"
+  "description": "Create, edit, classify, validate, version, review and package KPGS documents as typed governance artifacts while preserving evidence boundaries, KPEFS routing, PKA uncertainty, promotion gates and causal provenance.",
+  "category": "governance",
+  "state": "draft",
+  "runtime": {
+    "renter_protocol": "1.0",
+    "platforms": ["human", "agent", "stateless-renter", "cli", "server"],
+    "languages": ["markdown", "json"]
   },
-  "kpefs": {
-    "primary_vector": "V4_DIASPORA",
-    "secondary_vectors": ["V2_ANIMAL", "V3_HOMO_SAPIENS"]
+  "inputs": {
+    "schema_ref": "references/kpgs-document-manifest.schema.json",
+    "description": "A current operator directive plus a KPGS document or document-control manifest, with canonical repository/ref and available evidence when durable governance is requested."
   },
-  "capabilities": [
-    "classify_kpgs_document_type",
-    "separate_authority_from_evidence",
-    "route_kpefs_document_activity",
-    "preserve_pka_unknown_state",
-    "apply_document_promotion_gate",
-    "apply_wyc01_causal_boundary",
-    "package_agent_skill_documentation",
-    "govern_publication_state",
-    "emit_document_receipt"
-  ],
-  "document_types": [
-    "KDT-01",
-    "KDT-02",
-    "KDT-03",
-    "KDT-04",
-    "KDT-05",
-    "KDT-06",
-    "KDT-07",
-    "KDT-08",
-    "KDT-09",
-    "KDT-10"
-  ],
-  "authority_classes": [
-    "operator_directive",
-    "repo_canonical",
-    "governance_receipt",
-    "verified_live",
-    "personal_context",
-    "external_reference",
-    "unknown"
-  ],
-  "evidence_classes": [
-    "verified-source",
-    "verified-live",
-    "site-stated",
-    "demo-display",
-    "planned",
-    "privileged",
-    "transactional",
-    "unknown"
-  ],
-  "document_states": [
-    "draft",
-    "watch",
-    "operating",
-    "graduated",
-    "deprecated",
-    "archived"
-  ],
-  "proof_states": [
-    "unknown",
-    "foc",
-    "poc",
-    "verified_production"
-  ],
-  "protocol_bindings": {
-    "repo_canonical": ["KPP", "ALP", "CBP", "BMP", "PKAP", "PvF", "USTP"],
-    "context_bound": ["CCP", "CDP", "RIVM"]
+  "outputs": {
+    "schema_ref": "references/kpgs-document-manifest.schema.json",
+    "description": "A governed human-readable document with a machine-readable KPGS document manifest, explicit unresolved state, evidence references and receipts required by any requested state transition."
   },
-  "contracts": {
-    "human_spec": "references/KPGS_DTS_SPEC.md",
-    "manifest_schema": "references/kpgs-document-manifest.schema.json",
-    "template": "templates/KPGS_DOCUMENT_TEMPLATE.md",
-    "eval_cases": "evals/cases.json"
-  },
-  "promotion": {
-    "default_requires": ["PROOF-01", "PROOF-02", "PROOF-03"],
-    "production_or_agent_control_requires": ["PROOF-01", "PROOF-02", "PROOF-03", "PROOF-04"],
-    "laws": [
-      "no promotion without proof",
-      "drill is not graduation",
-      "operating is not verified production",
-      "publication intent is not public discovery",
-      "receipts move state"
+  "required_capabilities": [
+    {
+      "name": "repository.read",
+      "resource_scope": "active-task",
+      "optional": false
+    },
+    {
+      "name": "evidence.read",
+      "resource_scope": "active-task",
+      "optional": false
+    },
+    {
+      "name": "artifact.write",
+      "resource_scope": "active-task",
+      "optional": false
+    },
+    {
+      "name": "governance.receipt.emit",
+      "resource_scope": "active-task",
+      "optional": true
+    }
+  ],
+  "dependencies": [
+    {
+      "kind": "runtime",
+      "name": "kpgs-stateless-renter-protocol",
+      "version_constraint": "1.0"
+    }
+  ],
+  "provenance": {
+    "origin": "kpgs-original",
+    "license_status": "unknown",
+    "license_spdx": null,
+    "sources": [
+      {
+        "ref": "governance/kpgs-vnext/skills/SKILL_PACKAGE.md",
+        "relationship": "upstream",
+        "commit": "002f0a2ba430e52db94c448cbcf2e71ac8eb2400"
+      },
+      {
+        "ref": "RobynAwesome/Introduction-to-MCP",
+        "relationship": "reference",
+        "commit": "42d23ec0774d9dfb8cc6034ae4ceb42f1f8f3d90"
+      },
+      {
+        "ref": "skills/pka/watch-what-you-call/SKILL.md",
+        "relationship": "reference",
+        "commit": "42d23ec0774d9dfb8cc6034ae4ceb42f1f8f3d90"
+      }
     ]
   },
-  "security": {
-    "production_deploy_authorization_from_skill_change": false,
-    "external_ack_fabrication_allowed": false,
-    "secret_material_allowed": false
+  "validation": {
+    "hard_gates": [
+      "No promotion without the declared proof receipts",
+      "UNKNOWN or MAYBE must not be silently coerced into proof",
+      "Operating must not be represented as graduation or verified production",
+      "Public indexing must not be represented without an external discovery receipt",
+      "A skill-only change must not authorize production deployment",
+      "External acknowledgements must never be fabricated"
+    ],
+    "methods": ["schema", "unit", "human-review"],
+    "evidence_refs": [
+      "scripts/validate_package.py",
+      "tests/test_contract.py",
+      "evals/cases.json"
+    ]
   },
-  "provenance": {
-    "manual_document_id": "KPGS-DTS-001",
-    "manual_version": "1.0.0",
-    "origin_skill_example": "skills/pka/watch-what-you-call/SKILL.md",
-    "promotion_law": "Structure/07-Agents/PROMOTION_LAW.json",
-    "kpefs_plan": "docs/swarm-ops/KPEFS_IMPLEMENTATION_PLAN.md"
-  },
-  "signature": "/s/ Kholofelo Robyn Rababalela"
+  "failures": [
+    {
+      "code": "DOCUMENT_MANIFEST_INVALID",
+      "recoverability": "user-action",
+      "user_message": "The KPGS document control manifest is missing required fields or violates a declared state, proof, KPEFS, evidence or promotion invariant."
+    },
+    {
+      "code": "EVIDENCE_INSUFFICIENT",
+      "recoverability": "retry",
+      "user_message": "The requested claim or state transition remains unproven. Keep it UNKNOWN or WATCH until the declared evidence is available."
+    },
+    {
+      "code": "PUBLICATION_UNVERIFIED",
+      "recoverability": "operator-action",
+      "user_message": "The package may be prepared for publication, but public indexing or discovery cannot be claimed without an external discovery receipt."
+    },
+    {
+      "code": "PRODUCTION_SCOPE_UNAUTHORIZED",
+      "recoverability": "operator-action",
+      "user_message": "This document or skill change does not authorize production execution. Narrow the call graph or obtain explicit production-affecting authorization."
+    },
+    {
+      "code": "AUTHORITY_CONFLICT",
+      "recoverability": "operator-action",
+      "user_message": "Current operator or repository authority conflicts with lower-priority context. Preserve the conflict explicitly and use the higher-priority governed source."
+    }
+  ]
 }

--- a/skills/awesome/govern-kpgs-documents/skill.json
+++ b/skills/awesome/govern-kpgs-documents/skill.json
@@ -1,0 +1,112 @@
+{
+  "schema_version": "1.0.0",
+  "id": "kpgs-document-governance",
+  "name": "govern-kpgs-documents",
+  "title": "KPGS Document Governance",
+  "version": "1.0.0",
+  "status": "poc",
+  "author": "Kholofelo Robyn Rababalela",
+  "license": "MIT",
+  "document_type": "KDT-06",
+  "renter_assertion": "I_AM_STATELESS_RENTER_NOT_LANDLORD",
+  "source": {
+    "repository": "RobynAwesome/Introduction-to-MCP",
+    "branch": "master",
+    "manual_source_snapshot": "42d23ec0774d9dfb8cc6034ae4ceb42f1f8f3d90",
+    "integration_baseline": "002f0a2ba430e52db94c448cbcf2e71ac8eb2400"
+  },
+  "kpefs": {
+    "primary_vector": "V4_DIASPORA",
+    "secondary_vectors": ["V2_ANIMAL", "V3_HOMO_SAPIENS"]
+  },
+  "capabilities": [
+    "classify_kpgs_document_type",
+    "separate_authority_from_evidence",
+    "route_kpefs_document_activity",
+    "preserve_pka_unknown_state",
+    "apply_document_promotion_gate",
+    "apply_wyc01_causal_boundary",
+    "package_agent_skill_documentation",
+    "govern_publication_state",
+    "emit_document_receipt"
+  ],
+  "document_types": [
+    "KDT-01",
+    "KDT-02",
+    "KDT-03",
+    "KDT-04",
+    "KDT-05",
+    "KDT-06",
+    "KDT-07",
+    "KDT-08",
+    "KDT-09",
+    "KDT-10"
+  ],
+  "authority_classes": [
+    "operator_directive",
+    "repo_canonical",
+    "governance_receipt",
+    "verified_live",
+    "personal_context",
+    "external_reference",
+    "unknown"
+  ],
+  "evidence_classes": [
+    "verified-source",
+    "verified-live",
+    "site-stated",
+    "demo-display",
+    "planned",
+    "privileged",
+    "transactional",
+    "unknown"
+  ],
+  "document_states": [
+    "draft",
+    "watch",
+    "operating",
+    "graduated",
+    "deprecated",
+    "archived"
+  ],
+  "proof_states": [
+    "unknown",
+    "foc",
+    "poc",
+    "verified_production"
+  ],
+  "protocol_bindings": {
+    "repo_canonical": ["KPP", "ALP", "CBP", "BMP", "PKAP", "PvF", "USTP"],
+    "context_bound": ["CCP", "CDP", "RIVM"]
+  },
+  "contracts": {
+    "human_spec": "references/KPGS_DTS_SPEC.md",
+    "manifest_schema": "references/kpgs-document-manifest.schema.json",
+    "template": "templates/KPGS_DOCUMENT_TEMPLATE.md",
+    "eval_cases": "evals/cases.json"
+  },
+  "promotion": {
+    "default_requires": ["PROOF-01", "PROOF-02", "PROOF-03"],
+    "production_or_agent_control_requires": ["PROOF-01", "PROOF-02", "PROOF-03", "PROOF-04"],
+    "laws": [
+      "no promotion without proof",
+      "drill is not graduation",
+      "operating is not verified production",
+      "publication intent is not public discovery",
+      "receipts move state"
+    ]
+  },
+  "security": {
+    "production_deploy_authorization_from_skill_change": false,
+    "external_ack_fabrication_allowed": false,
+    "secret_material_allowed": false
+  },
+  "provenance": {
+    "manual_document_id": "KPGS-DTS-001",
+    "manual_version": "1.0.0",
+    "origin_skill_example": "skills/pka/watch-what-you-call/SKILL.md",
+    "promotion_law": "Structure/07-Agents/PROMOTION_LAW.json",
+    "kpefs_plan": "docs/swarm-ops/KPEFS_IMPLEMENTATION_PLAN.md"
+  },
+  "signature": "/s/ Kholofelo Robyn Rababalela"
+}

--- a/skills/awesome/govern-kpgs-documents/templates/KPGS_DOCUMENT_TEMPLATE.md
+++ b/skills/awesome/govern-kpgs-documents/templates/KPGS_DOCUMENT_TEMPLATE.md
@@ -1,0 +1,202 @@
+# <Document Title>
+
+## Document control
+
+```yaml
+schema: kpgs_document_manifest_v1
+document_id: <KPGS-...>
+canonical_id: <lowercase_snake_case>
+title: <Document Title>
+version: 0.1.0
+status: draft
+proof_state: unknown
+owner: Kholofelo Robyn Rababalela
+author: <author>
+signature: "/s/ Kholofelo Robyn Rababalela"
+renter_assertion: I_AM_STATELESS_RENTER_NOT_LANDLORD
+source:
+  repository: RobynAwesome/Introduction-to-MCP
+  ref: <branch|tag|commit>
+  evidence_class: verified-source
+authority_class: operator_directive
+evidence_class: unknown
+kpefs:
+  primary_vector: V4_DIASPORA
+  secondary_vectors: []
+protocols:
+  - KPP
+  - ALP
+  - CBP
+  - BMP
+  - PKAP
+  - PvF
+context_bound_protocols: []
+promotion_gate:
+  requires:
+    - PROOF-01
+    - PROOF-02
+    - PROOF-03
+linked_evidence: []
+unresolved: []
+publication:
+  registry_target: ""
+  state: unknown
+created_at: <ISO-8601>
+updated_at: <ISO-8601>
+```
+
+## 0. Executive law
+
+State the single governing law for this artifact. Do not use this section to make unsupported promotional claims.
+
+## 1. Objective / problem
+
+What must this document govern, explain, prove, teach, decide, or operate?
+
+## 2. Scope and authority boundary
+
+### In scope
+
+- ...
+
+### Out of scope
+
+- ...
+
+### Authority
+
+- Current operator directive: ...
+- Repo-canonical sources: ...
+- Governance receipts: ...
+- Personal context used only for continuity: ...
+
+## 3. Evidence state
+
+| Claim | Evidence class | Evidence | State |
+|---|---|---|---|
+| ... | `unknown` | ... | `MAYBE` |
+
+Never upgrade a row without a receipt.
+
+## 4. KPEFS activity
+
+**Primary vector:** `<V1_PLANT|V2_ANIMAL|V3_HOMO_SAPIENS|V4_DIASPORA>`
+
+**Secondary vectors:** `[]`
+
+Explain why each vector is required and what activity it governs.
+
+## 5. Protocol bindings
+
+| Protocol | Why it applies | Required output/receipt |
+|---|---|---|
+| `ALP` | Stateless renter activation | activation evidence |
+| `CBP` | Context containment | classified context |
+| `BMP` | Promotion boundary | SHIP/WATCH evidence |
+| `PKAP` | Partial Knowable Algebra | MAYBE/closure state |
+| `PvF` | Proof classification | POC/FOC/UNKNOWN result |
+
+Add only protocols actually applicable to the document.
+
+## 6. Main governed content
+
+Author the type-specific content here.
+
+For `KDT-01`, include definitions, invariants, state machine, failure modes and receipts.  
+For `KDT-02`, include prerequisites, ordered steps, decision points, stops and recovery.  
+For `KDT-03`, include hypothesis, boundary, method, evidence, result and limitations.  
+For `KDT-04`, include `C`, `D(C)`, `I(C)`, `A(C)`, `F`, provenance and ownership receipts.  
+For `KDT-05`, include authority, alternatives, decision, constraints and revisit condition.  
+For `KDT-06`, include skill inputs, workflow, outputs, failure conditions, manifest and publication state.  
+For `KDT-07`, include requirements, components, flows, interfaces, trust boundaries and rollout.  
+For `KDT-08`, include audience, claims/evidence, ethics/accessibility and narrative constraints.  
+For `KDT-09`, include teacher/student lane, drills, evidence, review and graduation boundary.  
+For `KDT-10`, include change scope, authorization, validation, target, rollback and live verification.
+
+## 7. PKA / unresolved state
+
+For every unresolved material claim:
+
+```text
+X = <partial observations>
+Y = <governed knowable rules>
+X + Y = MAYBE
+needed evidence = <what would close the state>
+```
+
+UNKNOWN is valid. Do not force closure for presentation quality.
+
+## 8. POC / FOC validation
+
+Define the bounded claim and evidence required for `poc`. If the target state is `verified_production`, specify the additional live/public evidence bar.
+
+## 9. WYC-01 invocation boundary
+
+If this artifact changes repository execution scope, record:
+
+```text
+changed scope C = ...
+dependency closure D(C) = ...
+invocation graph I(C) = ...
+authorized graph A(C) = ...
+failing subsystem F = ...
+```
+
+Do not transfer defect ownership merely because this change surfaced the failure.
+
+## 10. Promotion gate
+
+| Proof | Requirement | Evidence | Result |
+|---|---|---|---|
+| `PROOF-01` | BlackMask/equivalent SHIP | ... | pending |
+| `PROOF-02` | Reviewer/teacher APPROVE | ... | pending |
+| `PROOF-03` | Durable receipt | ... | pending |
+| `PROOF-04` | KPGS production/agent gate, when applicable | ... | n/a |
+
+## 11. Receipts
+
+Record material transitions:
+
+```yaml
+kind: <receipt-kind>
+document_id: <id>
+from_state: <state>
+to_state: <state>
+evidence: []
+unresolved: []
+actor: <actor>
+timestamp: <ISO-8601>
+```
+
+## 12. Publication / distribution
+
+Publication state is independent of proof state.
+
+```text
+registry_intent != public_discovery
+candidate != indexed
+operating != graduated
+```
+
+Record external discovery or deployment only after verified evidence exists.
+
+## 13. Acceptance checklist
+
+- [ ] Renter assertion present.
+- [ ] Document type selected.
+- [ ] Current directive captured.
+- [ ] Repo/ref pinned.
+- [ ] Authority and evidence separated.
+- [ ] KPEFS primary vector declared.
+- [ ] UNKNOWN/MAYBE visible.
+- [ ] Applicable protocol order respected.
+- [ ] POC/FOC boundary explicit.
+- [ ] Promotion receipts attached.
+- [ ] Operating not mislabeled graduated.
+- [ ] External ACK/publication claim not fabricated.
+- [ ] Skill/docs change does not imply production authorization.
+- [ ] Signature present where required.
+
+---
+
+`/s/ Kholofelo Robyn Rababalela`

--- a/skills/awesome/govern-kpgs-documents/tests/test_contract.py
+++ b/skills/awesome/govern-kpgs-documents/tests/test_contract.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import copy
+import json
 import runpy
 from pathlib import Path
 
@@ -11,6 +13,22 @@ VALIDATOR = runpy.run_path(str(ROOT / "scripts" / "validate_package.py"))
 def test_kpgs_dts_package_contract() -> None:
     errors = VALIDATOR["validate_package"](ROOT)
     assert errors == []
+
+
+def test_skill_manifest_rejects_parallel_runtime_fields() -> None:
+    skill = json.loads((ROOT / "skill.json").read_text(encoding="utf-8"))
+    invalid = copy.deepcopy(skill)
+    invalid["proof_state"] = "poc"
+    errors = VALIDATOR["validate_skill_manifest"](invalid)
+    assert any("unexpected top-level keys" in error for error in errors)
+
+
+def test_skill_manifest_is_draft_under_canonical_contract() -> None:
+    skill = json.loads((ROOT / "skill.json").read_text(encoding="utf-8"))
+    errors = VALIDATOR["validate_skill_manifest"](skill)
+    assert errors == []
+    assert skill["state"] == "draft"
+    assert skill["runtime"]["renter_protocol"] == "1.0"
 
 
 def test_graduation_requires_verified_production() -> None:

--- a/skills/awesome/govern-kpgs-documents/tests/test_contract.py
+++ b/skills/awesome/govern-kpgs-documents/tests/test_contract.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import runpy
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+VALIDATOR = runpy.run_path(str(ROOT / "scripts" / "validate_package.py"))
+
+
+def test_kpgs_dts_package_contract() -> None:
+    errors = VALIDATOR["validate_package"](ROOT)
+    assert errors == []
+
+
+def test_graduation_requires_verified_production() -> None:
+    manifest = {
+        "schema": "kpgs_document_manifest_v1",
+        "document_id": "TEST-001",
+        "canonical_id": "test_document",
+        "title": "Test",
+        "version": "1.0.0",
+        "status": "graduated",
+        "proof_state": "poc",
+        "owner": "owner",
+        "author": "author",
+        "source": {"repository": "owner/repo", "ref": "abc"},
+        "authority_class": "repo_canonical",
+        "evidence_class": "verified-source",
+        "kpefs": {"primary_vector": "V4_DIASPORA", "secondary_vectors": []},
+        "protocols": [],
+        "promotion_gate": {"requires": ["PROOF-01", "PROOF-02", "PROOF-03"]},
+        "linked_evidence": [],
+        "renter_assertion": "I_AM_STATELESS_RENTER_NOT_LANDLORD",
+    }
+    errors = VALIDATOR["validate_document_manifest"](manifest)
+    assert "document manifest: graduated requires verified_production proof_state" in errors
+
+
+def test_indexed_publication_requires_discovery_receipt() -> None:
+    manifest = {
+        "schema": "kpgs_document_manifest_v1",
+        "document_id": "TEST-002",
+        "canonical_id": "publication_test",
+        "title": "Publication Test",
+        "version": "1.0.0",
+        "status": "operating",
+        "proof_state": "poc",
+        "owner": "owner",
+        "author": "author",
+        "source": {"repository": "owner/repo", "ref": "abc"},
+        "authority_class": "repo_canonical",
+        "evidence_class": "verified-source",
+        "kpefs": {"primary_vector": "V4_DIASPORA", "secondary_vectors": []},
+        "protocols": [],
+        "promotion_gate": {"requires": ["PROOF-01", "PROOF-02", "PROOF-03"]},
+        "linked_evidence": [],
+        "publication": {"state": "indexed", "discovery_receipt": None},
+        "renter_assertion": "I_AM_STATELESS_RENTER_NOT_LANDLORD",
+    }
+    errors = VALIDATOR["validate_document_manifest"](manifest)
+    assert "document manifest: indexed publication requires discovery_receipt" in errors


### PR DESCRIPTION
## What changed

Adds a governed KPGS-DTS package under `skills/awesome/govern-kpgs-documents/` as an **AwesomeSkills/publication adapter** for the existing canonical KPGS vNext skill runtime:

- `SKILL.md` — execution membrane for KPGS document creation/editing/review/promotion
- `skill.json` — canonical vNext machine manifest
- `references/KPGS_DTS_SPEC.md` — compact KPGS Document Type Set specification
- `references/kpgs-document-manifest.schema.json` — JSON Schema for document manifests
- `templates/KPGS_DOCUMENT_TEMPLATE.md` — reusable governed document template
- `publication.json` — AwesomeSkills publication adapter metadata
- `evals/cases.json` — declarative governance eval cases
- `examples/KPGS_DTS.manifest.json` — concrete document manifest fixture
- `scripts/validate_package.py` — dependency-free conformance validator
- `tests/test_contract.py` — pytest contract tests

## Canonical runtime alignment

This PR does **not** create a second KPGS skill runtime.

Canonical authority remains:

- `governance/kpgs-vnext/skills/SKILL_PACKAGE.md`
- `governance/kpgs-vnext/skills/skill-manifest.schema.json`

The adapter `skill.json` now conforms to that contract: identity/SemVer, runtime compatibility, typed I/O, required capability leases, dependencies, provenance/license state, validation methods/hard gates, and failure/recovery semantics. KPGS-DTS-specific document governance remains in `SKILL.md`, the document schema, references, template, evals and fixtures.

Canonical runtime registration under `governance/kpgs-vnext/skills/` remains **pending** rather than being duplicated here.

## Governance

The package binds KPGS documents to:

- authority/evidence separation
- KPEFS V1–V4 activity routing
- PKA UNKNOWN/MAYBE preservation
- BlackMask + Promotion Law proof gates
- WYC-01 change/invocation/defect causality separation
- Stateless Renter activation
- publication state kept separate from proof/graduation state

## WYC-01 execution boundary

All writes remain under `skills/**`. The current Azure production workflow ignores `skills/**`, so this PR does not grant production deployment authorization. Moving the package into `governance/**` is deliberately deferred because the current production workflow would put that governance-only change into a production call graph.

## Executable contract

The validator checks both the canonical vNext skill shape and the KPGS document manifest invariants. It rejects, among other cases:

- non-canonical skill top-level fields / parallel runtime contracts
- invalid skill runtime/platform/provenance/validation/failure fields
- invalid document IDs/states/proof/KPEFS/authority/evidence classes
- `graduated` without `verified_production`
- `indexed` publication without an external discovery receipt
- loss of the `skills/awesome = publication-adapter` boundary
- non-`unknown` public discovery or license state without evidence

The package deliberately remains `draft`; CI success is validation evidence, not self-approval.

## Source/provenance

- canonical vNext package contract: `governance/kpgs-vnext/skills/SKILL_PACKAGE.md`
- canonical skill schema: `governance/kpgs-vnext/skills/skill-manifest.schema.json`
- manual source snapshot: `42d23ec0774d9dfb8cc6034ae4ceb42f1f8f3d90`
- integration baseline: `002f0a2ba430e52db94c448cbcf2e71ac8eb2400`
- WYC-01 reference: `skills/pka/watch-what-you-call/SKILL.md`
- promotion authority: `Structure/07-Agents/PROMOTION_LAW.json`
- KPEFS authority: `docs/swarm-ops/KPEFS_IMPLEMENTATION_PLAN.md`

## Validation posture

AwesomeSkills public discovery remains `unknown` until an external discovery receipt exists. Repository license status remains `unknown` under the current vNext governance posture. Operating/package completeness must not be called graduation or verified production without the declared evidence.

`/s/ Kholofelo Robyn Rababalela`