### PR TITLE
feat(kpgs): live Automerge sync over authenticated iroh QUIC

### DIFF
--- a/.github/workflows/kpgs-automerge-iroh-poc.yml
+++ b/.github/workflows/kpgs-automerge-iroh-poc.yml
@@ -1,0 +1,47 @@
+name: KPGS Automerge iroh POC
+
+on:
+  pull_request:
+    paths:
+      - "governance/kpgs-vnext/offline-replication/iroh-automerge-poc/**"
+      - ".github/workflows/kpgs-automerge-iroh-poc.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  live-loopback-sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: governance/kpgs-vnext/offline-replication/iroh-automerge-poc
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust 1.91
+        run: |
+          rustup toolchain install 1.91.0 --profile minimal
+          rustup default 1.91.0
+          rustc --version
+          cargo --version
+
+      - name: Generate dependency lock
+        run: cargo generate-lockfile
+
+      - name: Compile
+        run: cargo test --no-run
+
+      - name: Live loopback convergence tests
+        run: cargo test -- --nocapture
+
+      - name: Upload generated Cargo lock
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: kpgs-automerge-iroh-cargo-lock
+          path: governance/kpgs-vnext/offline-replication/iroh-automerge-poc/Cargo.lock
+          if-no-files-found: warn
+          retention-days: 7

--- a/governance/kpgs-vnext/offline-replication/iroh-automerge-poc/Cargo.toml
+++ b/governance/kpgs-vnext/offline-replication/iroh-automerge-poc/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "kpgs-automerge-iroh-sync-poc"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.91"
+publish = false
+
+[dependencies]
+automerge = "=0.10.0"
+iroh = { version = "=1.0.3", default-features = false, features = ["tls-ring"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
+
+[lints.rust]
+unsafe_code = "forbid"
+
+[lints.clippy]
+all = "warn"

--- a/governance/kpgs-vnext/offline-replication/iroh-automerge-poc/README.md
+++ b/governance/kpgs-vnext/offline-replication/iroh-automerge-poc/README.md
@@ -1,0 +1,94 @@
+# Live Automerge + iroh Sync POC v0.1
+
+Status: **Phase 0 / authenticated transport POC / non-production**
+
+This crate replaces the simulated byte transport in the merged offline-replication contract with a real local QUIC connection while preserving the KPGS authority membrane.
+
+## Version pins
+
+- `automerge = 0.10.0`
+- `iroh = 1.0.3`
+- Rust `1.91` minimum (required by iroh 1.0.3)
+
+## Architecture
+
+```text
+KPGS non-authoritative state
+        │
+        ▼
+   Automerge document
+        │
+   sync::Message frames
+        │ reliable / ordered
+        ▼
+     iroh QUIC stream
+        │ authenticated endpoint ID
+        ▼
+ endpoint→principal binding
+        │
+        X  no authority elevation
+        │
+        ▼
+ governing task/policy/receipt gate
+```
+
+Automerge's sync protocol requires a reliable in-order stream and maintains per-peer sync state. iroh QUIC bidirectional streams provide ordered delivery and authenticate the remote endpoint ID. This POC binds that endpoint ID to an expected KPGS principal, but the binding is still not a capability grant.
+
+## Loopback-only validation
+
+The tests deliberately use `endpoint::presets::Minimal`, disable address lookup and relay transports, clear the default IP transports, and bind only to `127.0.0.1:0`. No Number0 relay or DNS service is required for the test lane.
+
+The protocol uses one long-lived bidirectional QUIC stream with:
+
+- a dedicated ALPN: `kpgs/automerge-iroh/0.1`;
+- 4-byte big-endian length-prefixed Automerge messages;
+- zero-length frames as an explicit "nothing to send this turn" marker;
+- a 4 MiB maximum frame;
+- 128 maximum sync rounds;
+- a 10 second synchronization timeout.
+
+## Persistence
+
+A replica persists both:
+
+1. the Automerge document bytes; and
+2. `sync::State::encode()` for the bound peer.
+
+Restore validates that the saved sync state is being reused for the same endpoint/principal binding before decoding it. This prevents accidental peer-state reuse after identity changes.
+
+## Authority boundary
+
+This crate exposes only:
+
+- `NonAuthoritative`;
+- `DerivedProjection`;
+- `PendingProposal`.
+
+There is no authoritative state-class constructor.
+
+`request_authority_promotion()` returns only a `PromotionProposal` and requires a governing KPGS task-receipt reference. QUIC/TLS authentication, successful CRDT convergence, endpoint identity, and network reachability never imply authorization.
+
+## Tests
+
+The live integration lane proves:
+
+1. two independently modified documents converge through a real iroh QUIC connection;
+2. both peers finish with matching Automerge heads;
+3. document bytes and per-peer Automerge sync state survive replica recreation and continue syncing on a later connection;
+4. an authenticated iroh connection is still rejected when its endpoint ID does not match the expected KPGS endpoint→principal binding;
+5. all synchronized state remains `authority_effect = none`, with promotion proposal-only.
+
+## Deliberate exclusions
+
+This POC does not yet implement:
+
+- relay-assisted internet traversal;
+- multi-hop gossip;
+- device key rotation/revocation;
+- KPGS capability-lease exchange over the stream;
+- encrypted application payloads beyond transport TLS;
+- persistence to SQLite/PostgreSQL;
+- automatic authority promotion;
+- production Automerge document compaction/retention policy.
+
+The next gate after this passes is to bind the iroh endpoint/principal mapping to the merged `KPGSTaskReceipt v0.1` capability contract and add explicit key-rotation/revocation tests.

--- a/governance/kpgs-vnext/offline-replication/iroh-automerge-poc/src/lib.rs
+++ b/governance/kpgs-vnext/offline-replication/iroh-automerge-poc/src/lib.rs
@@ -298,6 +298,22 @@ async fn read_frame(recv: &mut RecvStream) -> Result<Option<Message>, BoxError> 
     Ok(Some(Message::decode(&payload)?))
 }
 
+async fn finish_and_drain_peer(
+    send: &mut SendStream,
+    recv: &mut RecvStream,
+) -> Result<(), BoxError> {
+    send.finish()?;
+    let mut trailing = [0_u8; 1];
+    match recv.read(&mut trailing).await? {
+        None => Ok(()),
+        Some(_) => Err(IoError::new(
+            ErrorKind::InvalidData,
+            "peer sent bytes after the terminal zero-frame",
+        )
+        .into()),
+    }
+}
+
 async fn client_turns(
     mut send: SendStream,
     mut recv: RecvStream,
@@ -312,7 +328,7 @@ async fn client_turns(
             replica.receive_sync_message(message)?;
         }
         if !sent && !received {
-            send.finish()?;
+            finish_and_drain_peer(&mut send, &mut recv).await?;
             return Ok(round);
         }
     }
@@ -333,7 +349,7 @@ async fn server_turns(
         let outbound = replica.generate_sync_message();
         let sent = write_frame(&mut send, outbound).await?;
         if !received && !sent {
-            send.finish()?;
+            finish_and_drain_peer(&mut send, &mut recv).await?;
             return Ok(round);
         }
     }

--- a/governance/kpgs-vnext/offline-replication/iroh-automerge-poc/src/lib.rs
+++ b/governance/kpgs-vnext/offline-replication/iroh-automerge-poc/src/lib.rs
@@ -1,0 +1,380 @@
+use std::{
+    io::{Error as IoError, ErrorKind},
+    time::Duration,
+};
+
+use automerge::{
+    sync::{self, Message, SyncDoc},
+    transaction::Transactable,
+    AutoCommit, ReadDoc, ROOT,
+};
+use iroh::{
+    endpoint::{presets, Connection, RecvStream, SendStream},
+    Endpoint, EndpointAddr, EndpointId,
+};
+
+pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+pub const ALPN: &[u8] = b"kpgs/automerge-iroh/0.1";
+pub const MAX_FRAME_BYTES: usize = 4 * 1024 * 1024;
+pub const MAX_SYNC_ROUNDS: usize = 128;
+pub const SYNC_TIMEOUT: Duration = Duration::from_secs(10);
+pub const AUTHORITY_EFFECT: &str = "none";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ReplicaStateClass {
+    NonAuthoritative,
+    DerivedProjection,
+    PendingProposal,
+}
+
+impl ReplicaStateClass {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::NonAuthoritative => "non_authoritative",
+            Self::DerivedProjection => "derived_projection",
+            Self::PendingProposal => "pending_proposal",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PeerBinding {
+    pub endpoint_id: EndpointId,
+    pub principal_id: String,
+}
+
+impl PeerBinding {
+    pub fn new(endpoint_id: EndpointId, principal_id: impl Into<String>) -> Result<Self, BoxError> {
+        let principal_id = principal_id.into();
+        if principal_id.trim().is_empty() {
+            return Err(IoError::new(ErrorKind::InvalidInput, "principal_id is required").into());
+        }
+        Ok(Self {
+            endpoint_id,
+            principal_id,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PromotionProposal {
+    pub document_id: String,
+    pub state_class: ReplicaStateClass,
+    pub governing_task_receipt_ref: String,
+    pub authority_effect: &'static str,
+}
+
+#[derive(Clone, Debug)]
+pub struct PersistedReplica {
+    document_id: String,
+    local_principal_id: String,
+    state_class: ReplicaStateClass,
+    expected_peer_endpoint_id: String,
+    expected_peer_principal_id: String,
+    document_bytes: Vec<u8>,
+    sync_state_bytes: Vec<u8>,
+}
+
+#[derive(Debug)]
+pub struct SyncReplica {
+    document_id: String,
+    local_principal_id: String,
+    state_class: ReplicaStateClass,
+    peer: PeerBinding,
+    document: AutoCommit,
+    sync_state: sync::State,
+}
+
+impl SyncReplica {
+    pub fn new(
+        document_id: impl Into<String>,
+        local_principal_id: impl Into<String>,
+        state_class: ReplicaStateClass,
+        peer: PeerBinding,
+    ) -> Result<Self, BoxError> {
+        let document_id = document_id.into();
+        let local_principal_id = local_principal_id.into();
+        if document_id.trim().is_empty() || local_principal_id.trim().is_empty() {
+            return Err(IoError::new(
+                ErrorKind::InvalidInput,
+                "document_id and local_principal_id are required",
+            )
+            .into());
+        }
+        Ok(Self {
+            document_id,
+            local_principal_id,
+            state_class,
+            peer,
+            document: AutoCommit::new(),
+            sync_state: sync::State::new(),
+        })
+    }
+
+    pub fn document_id(&self) -> &str {
+        &self.document_id
+    }
+
+    pub fn local_principal_id(&self) -> &str {
+        &self.local_principal_id
+    }
+
+    pub const fn state_class(&self) -> ReplicaStateClass {
+        self.state_class
+    }
+
+    pub const fn authority_effect(&self) -> &'static str {
+        AUTHORITY_EFFECT
+    }
+
+    pub fn peer_binding(&self) -> &PeerBinding {
+        &self.peer
+    }
+
+    pub fn put(
+        &mut self,
+        key: &str,
+        value: impl Into<automerge::ScalarValue>,
+    ) -> Result<(), BoxError> {
+        if key.trim().is_empty() {
+            return Err(IoError::new(ErrorKind::InvalidInput, "key is required").into());
+        }
+        self.document.put(ROOT, key, value)?;
+        Ok(())
+    }
+
+    pub fn get_string(&self, key: &str) -> Result<Option<String>, BoxError> {
+        let value = self.document.get(ROOT, key)?;
+        Ok(value.and_then(|(value, _)| value.to_str().map(ToOwned::to_owned)))
+    }
+
+    pub fn heads(&mut self) -> Vec<automerge::ChangeHash> {
+        self.document.get_heads()
+    }
+
+    pub fn persist(&mut self) -> PersistedReplica {
+        PersistedReplica {
+            document_id: self.document_id.clone(),
+            local_principal_id: self.local_principal_id.clone(),
+            state_class: self.state_class,
+            expected_peer_endpoint_id: self.peer.endpoint_id.to_string(),
+            expected_peer_principal_id: self.peer.principal_id.clone(),
+            document_bytes: self.document.save(),
+            sync_state_bytes: self.sync_state.encode(),
+        }
+    }
+
+    pub fn restore(persisted: PersistedReplica, peer: PeerBinding) -> Result<Self, BoxError> {
+        if persisted.expected_peer_endpoint_id != peer.endpoint_id.to_string()
+            || persisted.expected_peer_principal_id != peer.principal_id
+        {
+            return Err(IoError::new(
+                ErrorKind::PermissionDenied,
+                "persisted sync state is bound to a different peer identity",
+            )
+            .into());
+        }
+        Ok(Self {
+            document_id: persisted.document_id,
+            local_principal_id: persisted.local_principal_id,
+            state_class: persisted.state_class,
+            peer,
+            document: AutoCommit::load(&persisted.document_bytes)?,
+            sync_state: sync::State::decode(&persisted.sync_state_bytes)?,
+        })
+    }
+
+    pub fn request_authority_promotion(
+        &self,
+        governing_task_receipt_ref: impl Into<String>,
+    ) -> Result<PromotionProposal, BoxError> {
+        let governing_task_receipt_ref = governing_task_receipt_ref.into();
+        if governing_task_receipt_ref.trim().is_empty() {
+            return Err(IoError::new(
+                ErrorKind::PermissionDenied,
+                "a governing KPGS task receipt is required before promotion",
+            )
+            .into());
+        }
+        Ok(PromotionProposal {
+            document_id: self.document_id.clone(),
+            state_class: self.state_class,
+            governing_task_receipt_ref,
+            authority_effect: "proposal_only",
+        })
+    }
+
+    fn generate_sync_message(&mut self) -> Option<Message> {
+        let Self {
+            document,
+            sync_state,
+            ..
+        } = self;
+        document.sync().generate_sync_message(sync_state)
+    }
+
+    fn receive_sync_message(&mut self, message: Message) -> Result<(), BoxError> {
+        let Self {
+            document,
+            sync_state,
+            ..
+        } = self;
+        document.sync().receive_sync_message(sync_state, message)?;
+        Ok(())
+    }
+}
+
+pub fn verify_remote_binding(
+    connection: &Connection,
+    expected: &PeerBinding,
+) -> Result<(), BoxError> {
+    let remote_id = connection.remote_id();
+    if remote_id != expected.endpoint_id {
+        return Err(IoError::new(
+            ErrorKind::PermissionDenied,
+            format!(
+                "iroh endpoint identity mismatch: expected {}, received {}",
+                expected.endpoint_id, remote_id
+            ),
+        )
+        .into());
+    }
+    // TLS authenticates the iroh endpoint. KPGS still decides whether that
+    // endpoint-to-principal binding has any capability for a consequential act.
+    if expected.principal_id.trim().is_empty() {
+        return Err(IoError::new(ErrorKind::PermissionDenied, "peer principal is empty").into());
+    }
+    Ok(())
+}
+
+pub async fn bind_loopback_endpoint(accept_connections: bool) -> Result<Endpoint, BoxError> {
+    let mut builder = Endpoint::builder(presets::Minimal)
+        .clear_address_lookup()
+        .clear_relay_transports()
+        .clear_ip_transports()
+        .bind_addr("127.0.0.1:0")?;
+    if accept_connections {
+        builder = builder.alpns(vec![ALPN.to_vec()]);
+    }
+    Ok(builder.bind().await?)
+}
+
+async fn write_frame(send: &mut SendStream, message: Option<Message>) -> Result<bool, BoxError> {
+    let Some(message) = message else {
+        send.write_all(&0_u32.to_be_bytes()).await?;
+        return Ok(false);
+    };
+    let payload = message.encode();
+    if payload.len() > MAX_FRAME_BYTES {
+        return Err(IoError::new(
+            ErrorKind::InvalidData,
+            "automerge sync frame exceeds limit",
+        )
+        .into());
+    }
+    let length = u32::try_from(payload.len())?;
+    send.write_all(&length.to_be_bytes()).await?;
+    send.write_all(&payload).await?;
+    Ok(true)
+}
+
+async fn read_frame(recv: &mut RecvStream) -> Result<Option<Message>, BoxError> {
+    let mut length_bytes = [0_u8; 4];
+    recv.read_exact(&mut length_bytes).await?;
+    let length = u32::from_be_bytes(length_bytes) as usize;
+    if length == 0 {
+        return Ok(None);
+    }
+    if length > MAX_FRAME_BYTES {
+        return Err(IoError::new(
+            ErrorKind::InvalidData,
+            "received sync frame exceeds limit",
+        )
+        .into());
+    }
+    let mut payload = vec![0_u8; length];
+    recv.read_exact(&mut payload).await?;
+    Ok(Some(Message::decode(&payload)?))
+}
+
+async fn client_turns(
+    mut send: SendStream,
+    mut recv: RecvStream,
+    replica: &mut SyncReplica,
+) -> Result<usize, BoxError> {
+    for round in 1..=MAX_SYNC_ROUNDS {
+        let outbound = replica.generate_sync_message();
+        let sent = write_frame(&mut send, outbound).await?;
+        let inbound = read_frame(&mut recv).await?;
+        let received = inbound.is_some();
+        if let Some(message) = inbound {
+            replica.receive_sync_message(message)?;
+        }
+        if !sent && !received {
+            send.finish()?;
+            return Ok(round);
+        }
+    }
+    Err(IoError::new(ErrorKind::TimedOut, "sync exceeded maximum rounds").into())
+}
+
+async fn server_turns(
+    mut send: SendStream,
+    mut recv: RecvStream,
+    replica: &mut SyncReplica,
+) -> Result<usize, BoxError> {
+    for round in 1..=MAX_SYNC_ROUNDS {
+        let inbound = read_frame(&mut recv).await?;
+        let received = inbound.is_some();
+        if let Some(message) = inbound {
+            replica.receive_sync_message(message)?;
+        }
+        let outbound = replica.generate_sync_message();
+        let sent = write_frame(&mut send, outbound).await?;
+        if !received && !sent {
+            send.finish()?;
+            return Ok(round);
+        }
+    }
+    Err(IoError::new(ErrorKind::TimedOut, "sync exceeded maximum rounds").into())
+}
+
+pub async fn connect_and_sync(
+    endpoint: &Endpoint,
+    remote: EndpointAddr,
+    replica: &mut SyncReplica,
+) -> Result<usize, BoxError> {
+    let future = async {
+        let connection = endpoint.connect(remote, ALPN).await?;
+        verify_remote_binding(&connection, replica.peer_binding())?;
+        let (send, recv) = connection.open_bi().await?;
+        let rounds = client_turns(send, recv, replica).await?;
+        Ok::<usize, BoxError>(rounds)
+    };
+    tokio::time::timeout(SYNC_TIMEOUT, future)
+        .await
+        .map_err(|_| IoError::new(ErrorKind::TimedOut, "client sync timed out"))?
+}
+
+pub async fn accept_and_sync(
+    endpoint: &Endpoint,
+    mut replica: SyncReplica,
+) -> Result<SyncReplica, BoxError> {
+    let future = async {
+        let incoming = endpoint.accept().await.ok_or_else(|| {
+            IoError::new(
+                ErrorKind::ConnectionAborted,
+                "endpoint closed before accept",
+            )
+        })?;
+        let connection = incoming.await?;
+        verify_remote_binding(&connection, replica.peer_binding())?;
+        let (send, recv) = connection.accept_bi().await?;
+        server_turns(send, recv, &mut replica).await?;
+        Ok::<SyncReplica, BoxError>(replica)
+    };
+    tokio::time::timeout(SYNC_TIMEOUT, future)
+        .await
+        .map_err(|_| IoError::new(ErrorKind::TimedOut, "server sync timed out"))?
+}

--- a/governance/kpgs-vnext/offline-replication/iroh-automerge-poc/src/lib.rs
+++ b/governance/kpgs-vnext/offline-replication/iroh-automerge-poc/src/lib.rs
@@ -305,10 +305,21 @@ async fn finish_and_drain_peer(
     send.finish()?;
     let mut trailing = [0_u8; 1];
     match recv.read(&mut trailing).await? {
+        None => {}
+        Some(_) => {
+            return Err(IoError::new(
+                ErrorKind::InvalidData,
+                "peer sent bytes after the terminal zero-frame",
+            )
+            .into())
+        }
+    }
+
+    match send.stopped().await? {
         None => Ok(()),
-        Some(_) => Err(IoError::new(
-            ErrorKind::InvalidData,
-            "peer sent bytes after the terminal zero-frame",
+        Some(error_code) => Err(IoError::new(
+            ErrorKind::ConnectionAborted,
+            format!("peer stopped terminal sync stream with error code {error_code:?}"),
         )
         .into()),
     }

--- a/governance/kpgs-vnext/offline-replication/iroh-automerge-poc/tests/live_loopback.rs
+++ b/governance/kpgs-vnext/offline-replication/iroh-automerge-poc/tests/live_loopback.rs
@@ -1,0 +1,128 @@
+use kpgs_automerge_iroh_sync_poc::{
+    accept_and_sync, bind_loopback_endpoint, connect_and_sync, verify_remote_binding, BoxError,
+    PeerBinding, ReplicaStateClass, SyncReplica, ALPN, AUTHORITY_EFFECT,
+};
+use std::io::ErrorKind;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn two_offline_documents_converge_over_real_iroh_quic() -> Result<(), BoxError> {
+    let server_endpoint = bind_loopback_endpoint(true).await?;
+    let client_endpoint = bind_loopback_endpoint(false).await?;
+
+    let mut client = SyncReplica::new(
+        "doc:kasilink-neighbourhood-view",
+        "principal:alice",
+        ReplicaStateClass::NonAuthoritative,
+        PeerBinding::new(server_endpoint.id(), "principal:bob")?,
+    )?;
+    let mut server = SyncReplica::new(
+        "doc:kasilink-neighbourhood-view",
+        "principal:bob",
+        ReplicaStateClass::NonAuthoritative,
+        PeerBinding::new(client_endpoint.id(), "principal:alice")?,
+    )?;
+
+    // Both peers mutate useful local state before any network exists between them.
+    client.put("nearby_gig", "electrician")?;
+    server.put("network_hint", "offline-first")?;
+
+    let server_for_task = server_endpoint.clone();
+    let server_task = tokio::spawn(async move { accept_and_sync(&server_for_task, server).await });
+
+    connect_and_sync(&client_endpoint, server_endpoint.addr(), &mut client).await?;
+    server = server_task.await??;
+
+    assert_eq!(client.get_string("nearby_gig")?.as_deref(), Some("electrician"));
+    assert_eq!(server.get_string("nearby_gig")?.as_deref(), Some("electrician"));
+    assert_eq!(client.get_string("network_hint")?.as_deref(), Some("offline-first"));
+    assert_eq!(server.get_string("network_hint")?.as_deref(), Some("offline-first"));
+    assert_eq!(client.heads(), server.heads());
+    assert_eq!(client.authority_effect(), AUTHORITY_EFFECT);
+    assert_eq!(server.authority_effect(), AUTHORITY_EFFECT);
+
+    let proposal = client.request_authority_promotion("kpgs-receipt://task/abc/r0002")?;
+    assert_eq!(proposal.authority_effect, "proposal_only");
+    assert_eq!(proposal.state_class, ReplicaStateClass::NonAuthoritative);
+
+    client_endpoint.close().await;
+    server_endpoint.close().await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn automerge_document_and_peer_sync_state_survive_recreation() -> Result<(), BoxError> {
+    let server_endpoint = bind_loopback_endpoint(true).await?;
+    let client_endpoint = bind_loopback_endpoint(false).await?;
+
+    let server_binding = PeerBinding::new(server_endpoint.id(), "principal:bob")?;
+    let client_binding = PeerBinding::new(client_endpoint.id(), "principal:alice")?;
+
+    let mut client = SyncReplica::new(
+        "doc:continuity",
+        "principal:alice",
+        ReplicaStateClass::DerivedProjection,
+        server_binding.clone(),
+    )?;
+    let mut server = SyncReplica::new(
+        "doc:continuity",
+        "principal:bob",
+        ReplicaStateClass::DerivedProjection,
+        client_binding,
+    )?;
+
+    client.put("first", "before-restart")?;
+    let server_for_task = server_endpoint.clone();
+    let first_server = tokio::spawn(async move { accept_and_sync(&server_for_task, server).await });
+    connect_and_sync(&client_endpoint, server_endpoint.addr(), &mut client).await?;
+    server = first_server.await??;
+
+    let persisted = client.persist();
+    drop(client);
+    let mut restored = SyncReplica::restore(persisted, server_binding)?;
+
+    server.put("second", "after-client-restart")?;
+    let server_for_task = server_endpoint.clone();
+    let second_server = tokio::spawn(async move { accept_and_sync(&server_for_task, server).await });
+    connect_and_sync(&client_endpoint, server_endpoint.addr(), &mut restored).await?;
+    server = second_server.await??;
+
+    assert_eq!(restored.get_string("first")?.as_deref(), Some("before-restart"));
+    assert_eq!(restored.get_string("second")?.as_deref(), Some("after-client-restart"));
+    assert_eq!(restored.heads(), server.heads());
+    assert_eq!(restored.state_class(), ReplicaStateClass::DerivedProjection);
+
+    client_endpoint.close().await;
+    server_endpoint.close().await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn authenticated_iroh_endpoint_does_not_bypass_kpgs_peer_binding() -> Result<(), BoxError> {
+    let server_endpoint = bind_loopback_endpoint(true).await?;
+    let client_endpoint = bind_loopback_endpoint(false).await?;
+    let unrelated_endpoint = bind_loopback_endpoint(false).await?;
+
+    let accepting_endpoint = server_endpoint.clone();
+    let server_task = tokio::spawn(async move {
+        let incoming = accepting_endpoint
+            .accept()
+            .await
+            .ok_or_else(|| std::io::Error::new(ErrorKind::ConnectionAborted, "endpoint closed"))?;
+        let connection = incoming.await?;
+        Ok::<_, BoxError>(connection.remote_id())
+    });
+
+    let connection = client_endpoint.connect(server_endpoint.addr(), ALPN).await?;
+    let wrong_binding = PeerBinding::new(unrelated_endpoint.id(), "principal:not-the-server")?;
+    let error = verify_remote_binding(&connection, &wrong_binding).unwrap_err();
+    assert!(error.to_string().contains("identity mismatch"));
+
+    // QUIC/TLS authenticated the actual peer, but application governance rejected
+    // the endpoint-to-principal binding we supplied. Transport identity != authority.
+    assert_eq!(server_task.await??, client_endpoint.id());
+
+    client_endpoint.close().await;
+    unrelated_endpoint.close().await;
+    server_endpoint.close().await;
+    Ok(())
+}


### PR DESCRIPTION
## What
- add an isolated Rust POC pinned to Automerge `0.10.0` and iroh `1.0.3`
- synchronize real Automerge `sync::Message` frames over a loopback-only authenticated iroh QUIC bidirectional stream
- use a dedicated ALPN, length-prefixed frames, 4 MiB frame ceiling, round ceiling, and synchronization timeout
- persist both Automerge document bytes and per-peer `sync::State`
- bind authenticated iroh endpoint IDs to expected KPGS principal IDs before accepting synchronized state
- keep all synchronized state non-authoritative; promotion remains proposal-only behind an explicit KPGS task-receipt reference
- add a dedicated Rust CI lane using Rust 1.91, matching iroh 1.0.3's MSRV

## Governance
QUIC/TLS endpoint authentication is transport identity, not KPGS authorization. Automerge convergence is synchronization, not authority. No replicated document can silently rewrite canonical KPGS task/policy/receipt state.

## Live tests
The integration tests exercise:
1. two independently modified documents converging over a real iroh loopback connection;
2. matching Automerge heads after sync;
3. document + peer-sync-state persistence across replica recreation and a later connection;
4. rejection when the authenticated endpoint does not match the expected endpoint→principal binding;
5. `authority_effect = none` with promotion proposal-only.

## Validation state
CI has been triggered. No passing Rust receipt is claimed until the new workflow completes. A generated `Cargo.lock` is uploaded as a short-lived workflow artifact so it can be admitted into the branch after dependency resolution is observed.

## Scope
POC / non-production. Relay-assisted traversal, multi-hop gossip, capability-lease exchange, key rotation/revocation, application-level encryption, production durable storage, and automatic authority promotion remain separate gates.