### PR TITLE
Gate Azure production deploys with WYC-01 path authorization

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,17 +3,72 @@ name: "Kopano Context: Production Hardening Deployment"
 on:
   push:
     branches: [ "master" ]
-    paths-ignore:
-      - "skills/**"
   workflow_dispatch:
 
 permissions:
-  id-token: write
   contents: read
 
 jobs:
-  deploy:
+  authorize:
+    name: Authorize production invocation
     runs-on: ubuntu-latest
+    outputs:
+      authorized: ${{ steps.gate.outputs.authorized }}
+      reason: ${{ steps.gate.outputs.reason }}
+      production_paths: ${{ steps.gate.outputs.production_paths }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Classify deploy authorization
+        id: gate
+        shell: bash
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            python scripts/ci/production_deploy_gate.py \
+              --explicit-release \
+              --github-output "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          changed_files="${RUNNER_TEMP}/production-deploy-changed-files.txt"
+
+          if [[ -z "${BEFORE_SHA}" || "${BEFORE_SHA}" == "0000000000000000000000000000000000000000" ]]; then
+            git show --pretty="" --name-only "$GITHUB_SHA" > "$changed_files"
+          else
+            git diff --name-only "$BEFORE_SHA" "$GITHUB_SHA" > "$changed_files"
+          fi
+
+          python scripts/ci/production_deploy_gate.py \
+            --github-output "$GITHUB_OUTPUT" \
+            < "$changed_files"
+
+      - name: Record invocation decision
+        shell: bash
+        run: |
+          echo "### WYC-01 production invocation" >> "$GITHUB_STEP_SUMMARY"
+          echo "- authorized: ${{ steps.gate.outputs.authorized }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- reason: ${{ steps.gate.outputs.reason }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- production paths: ${{ steps.gate.outputs.production_paths || 'none' }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- invariant: FAILURE_SURFACED_BY_CALL != FAILURE_CAUSED_BY_CHANGE" >> "$GITHUB_STEP_SUMMARY"
+
+  deploy:
+    name: Deploy authorized production change
+    needs: authorize
+    if: needs.authorize.outputs.authorized == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/scripts/ci/production_deploy_gate.py
+++ b/scripts/ci/production_deploy_gate.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Classify changed repository paths before authorizing an Azure production deploy.
+
+WYC-01 keeps invocation provenance separate from defect provenance: a changed file may
+surface a deployment defect without itself being production-affecting. This module is
+the canonical path contract used by the deployment workflow.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import PurePosixPath
+from typing import Iterable
+
+
+ROOT_RUNTIME_FILES = {
+    "Dockerfile",
+    "kpgs_config.json",
+    "main.py",
+    "package-lock.json",
+    "package.json",
+    "pyproject.toml",
+    "uv.lock",
+}
+
+PRODUCTION_PREFIXES = (
+    "infra/",
+    "kopano-core/",
+    "src/",
+)
+
+PRODUCTION_SUFFIXES = {
+    ".bicep",
+    ".cs",
+    ".csproj",
+    ".js",
+    ".json",
+    ".jsx",
+    ".lock",
+    ".ps1",
+    ".py",
+    ".sh",
+    ".toml",
+    ".ts",
+    ".tsx",
+    ".yaml",
+    ".yml",
+}
+
+
+def normalize_path(path: str) -> str:
+    """Normalize a Git diff path into repository-relative POSIX form."""
+    return path.strip().replace("\\", "/").lstrip("./")
+
+
+def is_production_affecting(path: str) -> bool:
+    """Return True only when *path* belongs to the declared production contract."""
+    normalized = normalize_path(path)
+    if not normalized:
+        return False
+
+    if normalized in ROOT_RUNTIME_FILES:
+        return True
+
+    if not normalized.startswith(PRODUCTION_PREFIXES):
+        return False
+
+    return PurePosixPath(normalized).suffix.lower() in PRODUCTION_SUFFIXES
+
+
+def production_affecting_paths(paths: Iterable[str]) -> list[str]:
+    """Return normalized production-affecting paths, preserving input order."""
+    matched: list[str] = []
+    for path in paths:
+        normalized = normalize_path(path)
+        if normalized and is_production_affecting(normalized):
+            matched.append(normalized)
+    return matched
+
+
+def authorize_deploy(paths: Iterable[str], *, explicit_release: bool = False) -> tuple[bool, str, list[str]]:
+    """Evaluate deploy authorization and provide machine/human-readable provenance."""
+    if explicit_release:
+        return True, "explicit workflow_dispatch release intent", []
+
+    matched = production_affecting_paths(paths)
+    if matched:
+        return True, "production-affecting diff", matched
+
+    return False, "diff is outside the declared production path contract", []
+
+
+def write_github_output(path: str, *, authorized: bool, reason: str, matched: list[str]) -> None:
+    """Write stable one-line outputs for GitHub Actions job gating."""
+    with open(path, "a", encoding="utf-8") as output:
+        output.write(f"authorized={'true' if authorized else 'false'}\n")
+        output.write(f"reason={reason}\n")
+        output.write(f"production_paths={','.join(matched)}\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("paths", nargs="*", help="Repository-relative changed paths. Defaults to newline-delimited stdin.")
+    parser.add_argument("--explicit-release", action="store_true", help="Authorize explicit operator release intent.")
+    parser.add_argument("--github-output", help="Append authorized/reason/production_paths outputs to this file.")
+    args = parser.parse_args(argv)
+
+    paths = args.paths if args.paths else [line for line in sys.stdin.read().splitlines() if line.strip()]
+    authorized, reason, matched = authorize_deploy(paths, explicit_release=args.explicit_release)
+
+    if args.github_output:
+        write_github_output(args.github_output, authorized=authorized, reason=reason, matched=matched)
+    else:
+        print(f"authorized={'true' if authorized else 'false'}")
+        print(f"reason={reason}")
+        print(f"production_paths={','.join(matched)}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_production_deploy_gate.py
+++ b/tests/test_production_deploy_gate.py
@@ -1,0 +1,75 @@
+from scripts.ci.production_deploy_gate import authorize_deploy, is_production_affecting
+
+
+def test_governance_only_diff_does_not_authorize_production_deploy():
+    authorized, reason, matched = authorize_deploy(
+        [
+            "governance/kpgs-vnext/skills/kpgs-dts/SKILL.md",
+            "governance/web-estate/estate.yaml.md",
+        ]
+    )
+
+    assert authorized is False
+    assert matched == []
+    assert "outside" in reason
+
+
+def test_skill_only_diff_does_not_authorize_production_deploy():
+    authorized, _, matched = authorize_deploy(
+        [
+            "skills/pka/watch-what-you-call/SKILL.md",
+            "skills/kpgs-dts/README.md",
+        ]
+    )
+
+    assert authorized is False
+    assert matched == []
+
+
+def test_documentation_only_diff_does_not_authorize_production_deploy():
+    authorized, _, matched = authorize_deploy(
+        [
+            "README.md",
+            "docs/runtime-architecture.md",
+            "infra/DEPLOY_GUIDE.md",
+            "kopano-core/README.md",
+        ]
+    )
+
+    assert authorized is False
+    assert matched == []
+
+
+def test_infrastructure_change_authorizes_production_deploy():
+    authorized, reason, matched = authorize_deploy(["infra/main.bicep"])
+
+    assert authorized is True
+    assert reason == "production-affecting diff"
+    assert matched == ["infra/main.bicep"]
+
+
+def test_runtime_change_authorizes_production_deploy():
+    authorized, _, matched = authorize_deploy(
+        [
+            "governance/policy.md",
+            "kopano-core/kopano/runtime.py",
+        ]
+    )
+
+    assert authorized is True
+    assert matched == ["kopano-core/kopano/runtime.py"]
+
+
+def test_root_runtime_files_are_explicitly_authorized():
+    assert is_production_affecting("main.py") is True
+    assert is_production_affecting("pyproject.toml") is True
+    assert is_production_affecting("uv.lock") is True
+    assert is_production_affecting("Dockerfile") is True
+
+
+def test_manual_dispatch_is_explicit_release_intent():
+    authorized, reason, matched = authorize_deploy([], explicit_release=True)
+
+    assert authorized is True
+    assert reason == "explicit workflow_dispatch release intent"
+    assert matched == []


### PR DESCRIPTION
## What changed
- replace the broad `paths-ignore: skills/**` production trigger with an explicit authorization job
- classify changed files against a declared production path contract before Azure credentials or deployment are reachable
- keep `workflow_dispatch` as explicit operator release intent
- scope `id-token: write` to the deploy job only
- emit WYC-01 invocation provenance into the Actions summary
- add fixtures covering governance-only, skill-only, documentation-only, infrastructure, runtime, and manual-release cases

## Root cause
The production workflow treated nearly every `master` push as authority to invoke Azure. A governance or documentation change could therefore enter the production deployment call graph even when the change did not own or require that deployment.

## Validation target
`pytest -q tests/test_production_deploy_gate.py`

The deploy job is now reachable only when `authorize.outputs.authorized == 'true'`.

Closes #61