### PR TITLE
Complete executable Stateless Renter conformance runtime

### DIFF
--- a/governance/kpgs-vnext/stateless-renter/FAILURE_MATRIX.md
+++ b/governance/kpgs-vnext/stateless-renter/FAILURE_MATRIX.md
@@ -1,0 +1,30 @@
+# Stateless Renter Failure and Recovery Matrix
+
+Issue: #34
+
+Failures never widen renter authority or move canonical state into the renter process.
+
+| Failure code | Typical source | Recoverability | Required behavior |
+|---|---|---|---|
+| `input_invalid` | Payload violates declared input contract | `user_action` | Reject before durable side effects. |
+| `policy_denied` | Tenant/task/operation/resource outside capability lease | `operator_action` | Do not invoke the workload handler. |
+| `capability_expired` | Short-lived lease expired | `rehydrate` | Reject execution and obtain a fresh governed lease. |
+| `dependency_unavailable` | Required external service unavailable | `retry` | Preserve Hub-owned checkpoint and retry from canonical state. |
+| `timeout` | Bounded operation exceeds deadline | `retry` | Reuse the same idempotency key where a side effect may have committed. |
+| `execution_failed` | Unclassified handler exception | `retry` | Emit failure; never fabricate completion. |
+| `verification_failed` | Output/evidence fails verifier | `operator_action` | Keep the result unpromoted and surface verifier evidence. |
+| `cancelled` | Operator cancellation or graceful eviction | `rehydrate` | Stop new work and continue on a replacement renter from canonical state. |
+
+## Recovery invariants
+
+1. Retry never widens the capability lease.
+2. Replacement renters load checkpoints and idempotency records from the declared canonical store.
+3. Reusing an idempotency key returns the prior canonical result instead of repeating a durable side effect.
+4. Failure envelopes retain tenant, domain, session, task, renter, correlation, lease and governing-spec provenance.
+5. Cache/session-local state is disposable and is never the sole source required for recovery.
+
+## Executable evidence
+
+- Runtime: `kopano-core/kopano/stateless_renter.py`
+- Conformance/recovery suite: `tests/test_stateless_renter_conformance.py`
+- Event contract: `renter-envelope.schema.json`

--- a/governance/kpgs-vnext/stateless-renter/renter-envelope.schema.json
+++ b/governance/kpgs-vnext/stateless-renter/renter-envelope.schema.json
@@ -10,6 +10,7 @@
     "event_kind",
     "tenant_id",
     "domain_id",
+    "session_id",
     "task_id",
     "renter_id",
     "correlation_id",
@@ -44,6 +45,7 @@
     },
     "tenant_id": { "type": "string", "minLength": 1 },
     "domain_id": { "type": "string", "minLength": 1 },
+    "session_id": { "type": "string", "minLength": 1 },
     "task_id": { "type": "string", "minLength": 1 },
     "renter_id": { "type": "string", "minLength": 1 },
     "correlation_id": { "type": "string", "minLength": 1 },
@@ -70,9 +72,7 @@
       "type": "object",
       "additionalProperties": { "type": "string", "minLength": 1 }
     },
-    "payload": {
-      "type": "object"
-    },
+    "payload": { "type": "object" },
     "evidence": {
       "type": "array",
       "items": {
@@ -82,10 +82,7 @@
         "properties": {
           "kind": { "type": "string", "minLength": 1 },
           "ref": { "type": "string", "minLength": 1 },
-          "sha256": {
-            "type": "string",
-            "pattern": "^[a-fA-F0-9]{64}$"
-          }
+          "sha256": { "type": "string", "pattern": "^[a-fA-F0-9]{64}$" }
         }
       }
     },
@@ -111,23 +108,14 @@
           "type": "string",
           "enum": ["retry", "rehydrate", "user_action", "operator_action", "not_recoverable"]
         },
-        "message": {
-          "type": "string",
-          "maxLength": 2000
-        }
+        "message": { "type": "string", "maxLength": 2000 }
       }
     }
   },
   "allOf": [
     {
-      "if": {
-        "properties": {
-          "event_kind": { "const": "task.failed" }
-        }
-      },
-      "then": {
-        "required": ["failure"]
-      }
+      "if": { "properties": { "event_kind": { "const": "task.failed" } } },
+      "then": { "required": ["failure"] }
     }
   ]
 }

--- a/kopano-core/kopano/stateless_renter.py
+++ b/kopano-core/kopano/stateless_renter.py
@@ -1,0 +1,336 @@
+"""Reference implementation of the KPGS Stateless Renter Protocol vNext.
+
+The renter intentionally owns no canonical task database. Durable checkpoints and
+idempotency records are delegated to a caller-supplied canonical store so replacing
+this process does not transfer or lose authority.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Callable, Mapping, Protocol
+from uuid import uuid4
+
+PROTOCOL_VERSION = "1.0"
+FAILURE_CODES = {
+    "input_invalid",
+    "policy_denied",
+    "capability_expired",
+    "dependency_unavailable",
+    "timeout",
+    "execution_failed",
+    "verification_failed",
+    "cancelled",
+}
+RECOVERABILITY_VALUES = {"retry", "rehydrate", "user_action", "operator_action", "not_recoverable"}
+
+
+@dataclass(frozen=True)
+class TaskContext:
+    tenant_id: str
+    domain_id: str
+    session_id: str
+    task_id: str
+    correlation_id: str
+    governing_spec_ref: str
+    skill_versions: Mapping[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class CapabilityLease:
+    lease_id: str
+    tenant_id: str
+    domain_id: str
+    task_id: str
+    allowed_operations: frozenset[str]
+    allowed_resources: frozenset[str]
+    expires_at: datetime
+
+    def authorization_failure(
+        self,
+        context: TaskContext,
+        *,
+        operation: str,
+        resource: str,
+        now: datetime,
+    ) -> tuple[str, str] | None:
+        """Return failure kind/reason when this lease cannot authorize the action."""
+        if self.expires_at.tzinfo is None:
+            raise ValueError("CapabilityLease.expires_at must be timezone-aware")
+        if now >= self.expires_at:
+            return ("capability.expired", "capability lease has expired")
+        if (self.tenant_id, self.domain_id, self.task_id) != (
+            context.tenant_id,
+            context.domain_id,
+            context.task_id,
+        ):
+            return ("policy.denied", "capability lease is bound to a different tenant/domain/task")
+        if operation not in self.allowed_operations:
+            return ("policy.denied", f"operation {operation!r} is outside the capability lease")
+        if resource not in self.allowed_resources:
+            return ("policy.denied", f"resource {resource!r} is outside the capability lease")
+        return None
+
+
+@dataclass(frozen=True)
+class StepOutcome:
+    """Result returned by a bounded workload handler."""
+
+    payload: Mapping[str, Any]
+    checkpoint: Mapping[str, Any] | None = None
+    completed: bool = False
+    evidence: tuple[Mapping[str, str], ...] = ()
+
+
+@dataclass(frozen=True)
+class IdempotencyRecord:
+    """Canonical result recorded after a side-effecting operation commits."""
+
+    payload: Mapping[str, Any]
+    checkpoint_ref: str | None
+    completed: bool
+    evidence: tuple[Mapping[str, str], ...] = ()
+
+
+class RenterFailure(Exception):
+    """Typed workload failure that maps directly onto the protocol failure envelope."""
+
+    def __init__(self, code: str, recoverability: str, message: str) -> None:
+        if code not in FAILURE_CODES:
+            raise ValueError(f"unsupported renter failure code: {code}")
+        if recoverability not in RECOVERABILITY_VALUES:
+            raise ValueError(f"unsupported renter recoverability: {recoverability}")
+        super().__init__(message)
+        self.code = code
+        self.recoverability = recoverability
+        self.message = message[:2000]
+
+
+class CanonicalRenterStore(Protocol):
+    """Minimal Hub/domain-store contract required by the reference renter."""
+
+    def load_checkpoint(self, context: TaskContext) -> Mapping[str, Any] | None: ...
+
+    def save_checkpoint(self, context: TaskContext, checkpoint: Mapping[str, Any]) -> str: ...
+
+    def get_idempotency(self, context: TaskContext, idempotency_key: str) -> IdempotencyRecord | None: ...
+
+    def put_idempotency(
+        self,
+        context: TaskContext,
+        idempotency_key: str,
+        record: IdempotencyRecord,
+    ) -> None: ...
+
+
+WorkloadHandler = Callable[[Mapping[str, Any] | None, Mapping[str, Any]], StepOutcome]
+
+
+class StatelessRenter:
+    """Disposable worker that borrows context and authority for one bounded action."""
+
+    def __init__(self, renter_id: str, store: CanonicalRenterStore, *, protocol_version: str = PROTOCOL_VERSION) -> None:
+        if not renter_id:
+            raise ValueError("renter_id is required")
+        self.renter_id = renter_id
+        self.store = store
+        self.protocol_version = protocol_version
+        self._accepting_work = True
+
+    def readiness(self) -> dict[str, Any]:
+        """Return process-local readiness without claiming canonical task ownership."""
+        return {
+            "renter_id": self.renter_id,
+            "protocol_version": self.protocol_version,
+            "accepting_work": self._accepting_work,
+            "state_authority": "external-canonical-store",
+        }
+
+    def begin_eviction(self) -> None:
+        """Stop accepting new work; replacement renters can hydrate from the external store."""
+        self._accepting_work = False
+
+    def execute(
+        self,
+        *,
+        context: TaskContext,
+        lease: CapabilityLease,
+        operation: str,
+        resource: str,
+        payload: Mapping[str, Any],
+        handler: WorkloadHandler,
+        idempotency_key: str | None,
+        side_effecting: bool = True,
+        now: datetime | None = None,
+    ) -> dict[str, Any]:
+        """Execute one governed step and return a typed protocol event envelope.
+
+        The caller supplies all task authority and durable state dependencies. The
+        renter keeps no checkpoint or deduplication ledger of its own.
+        """
+        event_time = now or datetime.now(timezone.utc)
+        if event_time.tzinfo is None:
+            raise ValueError("now must be timezone-aware")
+
+        if not self._accepting_work:
+            return self._event(
+                event_kind="task.failed",
+                context=context,
+                lease=lease,
+                payload={"operation": operation, "resource": resource},
+                now=event_time,
+                failure={
+                    "code": "cancelled",
+                    "recoverability": "rehydrate",
+                    "message": "renter is draining for eviction; retry on a replacement renter",
+                },
+            )
+
+        authorization_failure = lease.authorization_failure(
+            context,
+            operation=operation,
+            resource=resource,
+            now=event_time,
+        )
+        if authorization_failure:
+            event_kind, message = authorization_failure
+            failure_code = "capability_expired" if event_kind == "capability.expired" else "policy_denied"
+            recoverability = "rehydrate" if event_kind == "capability.expired" else "operator_action"
+            return self._event(
+                event_kind=event_kind,
+                context=context,
+                lease=lease,
+                payload={"operation": operation, "resource": resource},
+                now=event_time,
+                failure={
+                    "code": failure_code,
+                    "recoverability": recoverability,
+                    "message": message,
+                },
+            )
+
+        if side_effecting and not idempotency_key:
+            return self._event(
+                event_kind="policy.denied",
+                context=context,
+                lease=lease,
+                payload={"operation": operation, "resource": resource},
+                now=event_time,
+                failure={
+                    "code": "policy_denied",
+                    "recoverability": "operator_action",
+                    "message": "side-effecting operations require an idempotency_key",
+                },
+            )
+
+        if idempotency_key:
+            existing = self.store.get_idempotency(context, idempotency_key)
+            if existing is not None:
+                return self._event(
+                    event_kind="task.completed" if existing.completed else "task.checkpointed",
+                    context=context,
+                    lease=lease,
+                    payload={**existing.payload, "replayed": True},
+                    now=event_time,
+                    idempotency_key=idempotency_key,
+                    checkpoint_ref=existing.checkpoint_ref,
+                    evidence=existing.evidence,
+                )
+
+        checkpoint = self.store.load_checkpoint(context)
+        try:
+            outcome = handler(checkpoint, payload)
+        except RenterFailure as exc:
+            return self._event(
+                event_kind="task.failed",
+                context=context,
+                lease=lease,
+                payload={"operation": operation, "resource": resource},
+                now=event_time,
+                idempotency_key=idempotency_key,
+                failure={
+                    "code": exc.code,
+                    "recoverability": exc.recoverability,
+                    "message": exc.message,
+                },
+            )
+        except Exception as exc:
+            return self._event(
+                event_kind="task.failed",
+                context=context,
+                lease=lease,
+                payload={"operation": operation, "resource": resource},
+                now=event_time,
+                idempotency_key=idempotency_key,
+                failure={
+                    "code": "execution_failed",
+                    "recoverability": "retry",
+                    "message": str(exc)[:2000],
+                },
+            )
+
+        checkpoint_ref = None
+        if outcome.checkpoint is not None:
+            checkpoint_ref = self.store.save_checkpoint(context, outcome.checkpoint)
+
+        if idempotency_key:
+            self.store.put_idempotency(
+                context,
+                idempotency_key,
+                IdempotencyRecord(
+                    payload=dict(outcome.payload),
+                    checkpoint_ref=checkpoint_ref,
+                    completed=outcome.completed,
+                    evidence=outcome.evidence,
+                ),
+            )
+
+        return self._event(
+            event_kind="task.completed" if outcome.completed else "task.checkpointed",
+            context=context,
+            lease=lease,
+            payload={**outcome.payload, "replayed": False},
+            now=event_time,
+            idempotency_key=idempotency_key,
+            checkpoint_ref=checkpoint_ref,
+            evidence=outcome.evidence,
+        )
+
+    def _event(
+        self,
+        *,
+        event_kind: str,
+        context: TaskContext,
+        lease: CapabilityLease,
+        payload: Mapping[str, Any],
+        now: datetime,
+        idempotency_key: str | None = None,
+        checkpoint_ref: str | None = None,
+        evidence: tuple[Mapping[str, str], ...] = (),
+        failure: Mapping[str, str] | None = None,
+    ) -> dict[str, Any]:
+        envelope: dict[str, Any] = {
+            "protocol_version": self.protocol_version,
+            "event_id": f"evt-{uuid4().hex}",
+            "event_kind": event_kind,
+            "tenant_id": context.tenant_id,
+            "domain_id": context.domain_id,
+            "session_id": context.session_id,
+            "task_id": context.task_id,
+            "renter_id": self.renter_id,
+            "correlation_id": context.correlation_id,
+            "lease_id": lease.lease_id,
+            "issued_at": now.isoformat(),
+            "governing_spec_ref": context.governing_spec_ref,
+            "skill_versions": dict(context.skill_versions),
+            "payload": dict(payload),
+            "evidence": [dict(item) for item in evidence],
+        }
+        if idempotency_key:
+            envelope["idempotency_key"] = idempotency_key
+        if checkpoint_ref:
+            envelope["checkpoint_ref"] = checkpoint_ref
+        if failure:
+            envelope["failure"] = dict(failure)
+        return envelope

--- a/tests/test_stateless_renter_conformance.py
+++ b/tests/test_stateless_renter_conformance.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Mapping
+
+import pytest
+
+from kopano.stateless_renter import (
+    CapabilityLease,
+    IdempotencyRecord,
+    RenterFailure,
+    StatelessRenter,
+    StepOutcome,
+    TaskContext,
+)
+
+
+class MemoryHubStore:
+    """External canonical-store test double shared across disposable renters."""
+
+    def __init__(self) -> None:
+        self.checkpoints: dict[tuple[str, str, str], dict[str, Any]] = {}
+        self.idempotency: dict[tuple[str, str, str, str], IdempotencyRecord] = {}
+        self.effects: dict[str, int] = {}
+
+    @staticmethod
+    def task_key(context: TaskContext) -> tuple[str, str, str]:
+        return (context.tenant_id, context.domain_id, context.task_id)
+
+    def load_checkpoint(self, context: TaskContext) -> Mapping[str, Any] | None:
+        checkpoint = self.checkpoints.get(self.task_key(context))
+        return dict(checkpoint) if checkpoint is not None else None
+
+    def save_checkpoint(self, context: TaskContext, checkpoint: Mapping[str, Any]) -> str:
+        self.checkpoints[self.task_key(context)] = dict(checkpoint)
+        return f"hub://checkpoint/{context.tenant_id}/{context.domain_id}/{context.task_id}"
+
+    def get_idempotency(self, context: TaskContext, key: str) -> IdempotencyRecord | None:
+        return self.idempotency.get((*self.task_key(context), key))
+
+    def put_idempotency(self, context: TaskContext, key: str, record: IdempotencyRecord) -> None:
+        self.idempotency[(*self.task_key(context), key)] = record
+
+    def record_effect(self, key: str) -> int:
+        self.effects[key] = self.effects.get(key, 0) + 1
+        return self.effects[key]
+
+
+def make_context(domain: str) -> TaskContext:
+    return TaskContext(
+        tenant_id="tenant-kopano",
+        domain_id=domain,
+        session_id=f"session-{domain}",
+        task_id=f"task-{domain}",
+        correlation_id=f"corr-{domain}",
+        governing_spec_ref="governance/kpgs-vnext/stateless-renter/PROTOCOL.md",
+        skill_versions={"kpgs-audit-verify-govern": "0.1.0"},
+    )
+
+
+def make_lease(context: TaskContext, operation: str, resource: str) -> CapabilityLease:
+    return CapabilityLease(
+        lease_id=f"lease-{context.task_id}",
+        tenant_id=context.tenant_id,
+        domain_id=context.domain_id,
+        task_id=context.task_id,
+        allowed_operations=frozenset({operation}),
+        allowed_resources=frozenset({resource}),
+        expires_at=datetime.now(timezone.utc) + timedelta(minutes=5),
+    )
+
+
+@pytest.mark.parametrize(
+    ("domain", "operation", "resource", "payload"),
+    [
+        ("bookings", "booking.reserve", "arena:five-a-side", {"slot": "18:00"}),
+        ("documents", "document.publish", "document:kpgs-dts", {"version": "1.0.0"}),
+    ],
+)
+def test_destroy_recreate_resumes_two_workloads_without_local_canonical_state(
+    domain: str,
+    operation: str,
+    resource: str,
+    payload: Mapping[str, Any],
+):
+    hub = MemoryHubStore()
+    context = make_context(domain)
+    lease = make_lease(context, operation, resource)
+
+    first = StatelessRenter("renter-before-eviction", hub).execute(
+        context=context,
+        lease=lease,
+        operation=operation,
+        resource=resource,
+        payload=payload,
+        idempotency_key=f"{domain}:step-1",
+        handler=lambda checkpoint, incoming: StepOutcome(
+            payload={"accepted": dict(incoming)},
+            checkpoint={"stage": 1, "input": dict(incoming)},
+            evidence=({"kind": "checkpoint", "ref": f"hub://evidence/{domain}/1"},),
+        ),
+    )
+    assert first["event_kind"] == "task.checkpointed"
+    assert first["checkpoint_ref"].startswith("hub://checkpoint/")
+
+    def finish(checkpoint: Mapping[str, Any] | None, incoming: Mapping[str, Any]) -> StepOutcome:
+        assert checkpoint == {"stage": 1, "input": dict(payload)}
+        hub.record_effect(f"{domain}:finish")
+        return StepOutcome(
+            payload={"completed": True, "input": dict(incoming)},
+            checkpoint={"stage": 2, "input": dict(incoming)},
+            completed=True,
+            evidence=({"kind": "completion", "ref": f"hub://evidence/{domain}/2"},),
+        )
+
+    second = StatelessRenter("renter-after-eviction", hub).execute(
+        context=context,
+        lease=lease,
+        operation=operation,
+        resource=resource,
+        payload=payload,
+        idempotency_key=f"{domain}:step-2",
+        handler=finish,
+    )
+    assert second["event_kind"] == "task.completed"
+    assert second["renter_id"] == "renter-after-eviction"
+    assert second["session_id"] == context.session_id
+    assert second["correlation_id"] == context.correlation_id
+    assert second["governing_spec_ref"] == context.governing_spec_ref
+    assert hub.effects[f"{domain}:finish"] == 1
+
+
+def test_replay_does_not_duplicate_durable_side_effect():
+    hub = MemoryHubStore()
+    context = make_context("payments")
+    lease = make_lease(context, "invoice.issue", "invoice:42")
+
+    def issue(_checkpoint: Mapping[str, Any] | None, _payload: Mapping[str, Any]) -> StepOutcome:
+        return StepOutcome(payload={"effect_count": hub.record_effect("invoice:42")}, completed=True)
+
+    first = StatelessRenter("renter-one", hub).execute(
+        context=context,
+        lease=lease,
+        operation="invoice.issue",
+        resource="invoice:42",
+        payload={},
+        handler=issue,
+        idempotency_key="invoice-42-once",
+    )
+    replay = StatelessRenter("renter-two", hub).execute(
+        context=context,
+        lease=lease,
+        operation="invoice.issue",
+        resource="invoice:42",
+        payload={},
+        handler=issue,
+        idempotency_key="invoice-42-once",
+    )
+    assert first["payload"]["replayed"] is False
+    assert replay["payload"]["replayed"] is True
+    assert hub.effects["invoice:42"] == 1
+
+
+def test_capability_scope_is_enforced_before_handler_execution():
+    hub = MemoryHubStore()
+    context = make_context("bookings")
+    lease = make_lease(context, "booking.read", "booking:123")
+    called = False
+
+    def forbidden(_checkpoint: Mapping[str, Any] | None, _payload: Mapping[str, Any]) -> StepOutcome:
+        nonlocal called
+        called = True
+        return StepOutcome(payload={}, completed=True)
+
+    event = StatelessRenter("renter-denied", hub).execute(
+        context=context,
+        lease=lease,
+        operation="booking.delete",
+        resource="booking:123",
+        payload={},
+        handler=forbidden,
+        idempotency_key="delete-123",
+    )
+    assert event["event_kind"] == "policy.denied"
+    assert event["failure"]["code"] == "policy_denied"
+    assert called is False
+
+
+def test_expired_lease_and_missing_idempotency_key_fail_closed():
+    hub = MemoryHubStore()
+    context = make_context("documents")
+    expired = CapabilityLease(
+        lease_id="lease-expired",
+        tenant_id=context.tenant_id,
+        domain_id=context.domain_id,
+        task_id=context.task_id,
+        allowed_operations=frozenset({"document.write"}),
+        allowed_resources=frozenset({"document:1"}),
+        expires_at=datetime.now(timezone.utc) - timedelta(seconds=1),
+    )
+    expired_event = StatelessRenter("renter-expired", hub).execute(
+        context=context,
+        lease=expired,
+        operation="document.write",
+        resource="document:1",
+        payload={},
+        handler=lambda _checkpoint, _payload: StepOutcome(payload={}, completed=True),
+        idempotency_key="doc-1",
+    )
+    assert expired_event["event_kind"] == "capability.expired"
+
+    valid = make_lease(context, "document.write", "document:1")
+    no_key = StatelessRenter("renter-no-key", hub).execute(
+        context=context,
+        lease=valid,
+        operation="document.write",
+        resource="document:1",
+        payload={},
+        handler=lambda _checkpoint, _payload: StepOutcome(payload={}, completed=True),
+        idempotency_key=None,
+    )
+    assert no_key["event_kind"] == "policy.denied"
+    assert "idempotency_key" in no_key["failure"]["message"]
+
+
+def test_failure_classification_and_graceful_eviction_are_deterministic():
+    hub = MemoryHubStore()
+    context = make_context("recovery")
+    lease = make_lease(context, "work.execute", "work:item")
+
+    def fail(_checkpoint: Mapping[str, Any] | None, _payload: Mapping[str, Any]) -> StepOutcome:
+        raise RenterFailure("verification_failed", "operator_action", "evidence mismatch")
+
+    failed = StatelessRenter("renter-failure", hub).execute(
+        context=context,
+        lease=lease,
+        operation="work.execute",
+        resource="work:item",
+        payload={},
+        handler=fail,
+        idempotency_key="failure-once",
+    )
+    assert failed["failure"] == {
+        "code": "verification_failed",
+        "recoverability": "operator_action",
+        "message": "evidence mismatch",
+    }
+
+    draining = StatelessRenter("renter-draining", hub)
+    draining.begin_eviction()
+    denied = draining.execute(
+        context=context,
+        lease=lease,
+        operation="work.execute",
+        resource="work:item",
+        payload={},
+        handler=lambda _checkpoint, _payload: StepOutcome(payload={}, completed=True),
+        idempotency_key="draining",
+    )
+    assert denied["failure"]["code"] == "cancelled"
+    assert denied["failure"]["recoverability"] == "rehydrate"


### PR DESCRIPTION
## What changed
- add `kopano-core/kopano/stateless_renter.py` as the reference disposable renter
- keep canonical checkpoints and idempotency records behind an external Hub/store interface; renter instances own no canonical task database
- enforce tenant/domain/task-bound short-lived capability leases, operation/resource scope, expiry and side-effect idempotency keys
- carry tenant/domain/session/task/renter/correlation/lease/spec/skill provenance in emitted events
- add graceful eviction/readiness and deterministic failure/recovery classification
- require `session_id` in the machine event envelope
- add the canonical failure/recovery matrix
- add one parameterized conformance harness that runs destroy/recreate recovery across bookings and documents workloads

## Acceptance evidence for #34
- destroy/recreate resumes from externally owned canonical checkpoint state
- out-of-lease actions are denied before handler execution
- replaying the same idempotency key cannot repeat the durable effect handler
- the same harness runs against two domain workloads
- emitted results retain session/correlation/governing-spec provenance
- no renter-local database is required for continuity
- recovery behavior covers expired leases, missing idempotency keys, verification failure and graceful eviction

## Validation
- `python -m pytest -q tests/test_stateless_renter_conformance.py`
- repository CI on Python 3.11/3.12
- KPGS vNext Contract Gate
- CodeQL

This supersedes conflicted PR #66 and is rebuilt from current `master` after #65 and #67.

Closes #34