### PR TITLE
Complete specification-first build supervision loop

### DIFF
--- a/governance/kpgs-vnext/agent-governance/build-spec.schema.json
+++ b/governance/kpgs-vnext/agent-governance/build-spec.schema.json
@@ -110,6 +110,12 @@
         }
       }
     },
+    "action_gates": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": { "type": "string", "minLength": 1 },
+      "description": "Named approval/policy gates available to authorize high-risk or destructive delegation."
+    },
     "lifecycle_state": {
       "type": "string",
       "enum": ["draft", "verified", "approved", "released", "rejected", "rolled-back"]

--- a/kopano-core/kopano/spec_first.py
+++ b/kopano-core/kopano/spec_first.py
@@ -29,11 +29,12 @@ class DelegationReceipt:
     actor_kind: str
     implementation_revision: str
     requested_scope: tuple[str, ...]
+    requested_capabilities: tuple[str, ...]
     gate_id: str | None
 
 
 class SpecificationFirstBuild:
-    """Govern one implementation revision through specify/delegate/verify/ship."""
+    """Govern iterative implementation revisions through specify/delegate/verify/ship."""
 
     def __init__(self, spec: Mapping[str, Any]) -> None:
         self.spec = dict(spec)
@@ -75,20 +76,26 @@ class SpecificationFirstBuild:
             str(item["capability"])
             for item in self.spec.get("required_capabilities", [])
         }
-        requested = set(requested_capabilities)
-        if not requested <= allowed_capabilities:
+        requested = tuple(requested_capabilities)
+        if not set(requested) <= allowed_capabilities:
             raise BuildGovernanceError("delegation requested capability outside the governing specification")
 
         gate_required = destructive or self.spec["risk_class"] in HIGH_RISK
         if gate_required and (not gate_id or gate_id not in self.declared_gates):
             raise BuildGovernanceError("high-risk/destructive delegation requires a declared action gate")
 
+        # Every delegation is a new implementation attempt. Previous verification or
+        # approval can never survive a revision/lease change and authorize the new attempt.
         self._delegated_revision = implementation_revision
+        self._verification = {}
+        self.state = "draft"
+
         return DelegationReceipt(
             spec_id=str(self.spec["spec_id"]),
             actor_kind=actor_kind,
             implementation_revision=implementation_revision,
             requested_scope=scope,
+            requested_capabilities=requested,
             gate_id=gate_id,
         )
 
@@ -100,6 +107,8 @@ class SpecificationFirstBuild:
         for result in results:
             if result.criterion_id not in self.criteria:
                 raise BuildGovernanceError(f"unknown acceptance criterion: {result.criterion_id}")
+            if result.criterion_id in received:
+                raise BuildGovernanceError(f"duplicate acceptance criterion result: {result.criterion_id}")
             if result.implementation_revision != self._delegated_revision:
                 raise BuildGovernanceError("verification evidence must target the exact implementation revision")
             if not result.evidence_ref.strip() or not result.verifier.strip():
@@ -121,22 +130,45 @@ class SpecificationFirstBuild:
     def approve(self) -> str:
         if self.state != "verified":
             raise BuildGovernanceError("only a verified implementation may be approved")
+        self._assert_current_verification_complete(require_all_pass=False)
         self.state = "approved"
         return self.state
 
     def release(self) -> str:
         if self.state not in {"verified", "approved"}:
             raise BuildGovernanceError("release requires verified or approved state")
-        if any(not result.passed for result in self._verification.values()):
-            raise BuildGovernanceError("failed acceptance criteria prevent released state")
+        self._assert_current_verification_complete(require_all_pass=True)
         self.state = "released"
         return self.state
 
     def rollback(self) -> str:
+        if self._delegated_revision is None:
+            raise BuildGovernanceError("rollback requires a delegated implementation revision")
         if not self.spec.get("rollback_plan", {}).get("procedure"):
             raise BuildGovernanceError("rollback requires the declared rollback procedure")
         self.state = "rolled-back"
         return self.state
+
+    def _assert_current_verification_complete(self, *, require_all_pass: bool) -> None:
+        if self._delegated_revision is None:
+            raise BuildGovernanceError("lifecycle advancement requires a delegated implementation revision")
+
+        missing = set(self.criteria) - set(self._verification)
+        if missing:
+            raise BuildGovernanceError(f"lifecycle advancement is missing acceptance criteria: {sorted(missing)}")
+
+        stale = [
+            criterion_id
+            for criterion_id, result in self._verification.items()
+            if result.implementation_revision != self._delegated_revision
+        ]
+        if stale:
+            raise BuildGovernanceError(
+                f"lifecycle advancement has stale verification for current implementation revision: {sorted(stale)}"
+            )
+
+        if require_all_pass and any(not result.passed for result in self._verification.values()):
+            raise BuildGovernanceError("failed acceptance criteria prevent released state")
 
     def _validate_spec(self) -> None:
         required = {

--- a/kopano-core/kopano/spec_first.py
+++ b/kopano-core/kopano/spec_first.py
@@ -1,0 +1,170 @@
+"""Executable KPGS specification-first build supervision for issue #39."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping
+
+LIFECYCLE_STATES = {"draft", "verified", "approved", "released", "rejected", "rolled-back"}
+ACTOR_KINDS = {"human", "agent"}
+HIGH_RISK = {"R2", "R3"}
+
+
+class BuildGovernanceError(ValueError):
+    """Raised when a build operation violates its governing specification."""
+
+
+@dataclass(frozen=True)
+class VerificationResult:
+    criterion_id: str
+    passed: bool
+    implementation_revision: str
+    evidence_ref: str
+    verifier: str
+
+
+@dataclass(frozen=True)
+class DelegationReceipt:
+    spec_id: str
+    actor_kind: str
+    implementation_revision: str
+    requested_scope: tuple[str, ...]
+    gate_id: str | None
+
+
+class SpecificationFirstBuild:
+    """Govern one implementation revision through specify/delegate/verify/ship."""
+
+    def __init__(self, spec: Mapping[str, Any]) -> None:
+        self.spec = dict(spec)
+        self._validate_spec()
+        self.state = str(self.spec["lifecycle_state"])
+        self._delegated_revision: str | None = None
+        self._verification: dict[str, VerificationResult] = {}
+
+    @property
+    def criteria(self) -> dict[str, Mapping[str, Any]]:
+        return {str(item["id"]): item for item in self.spec["acceptance_criteria"]}
+
+    @property
+    def declared_gates(self) -> set[str]:
+        return {str(gate) for gate in self.spec.get("action_gates", [])}
+
+    def delegate(
+        self,
+        *,
+        actor_kind: str,
+        implementation_revision: str,
+        requested_scope: Iterable[str],
+        requested_capabilities: Iterable[str],
+        destructive: bool = False,
+        gate_id: str | None = None,
+    ) -> DelegationReceipt:
+        if actor_kind not in ACTOR_KINDS:
+            raise BuildGovernanceError(f"unsupported actor_kind: {actor_kind}")
+        if not implementation_revision.strip():
+            raise BuildGovernanceError("implementation_revision is required before delegation")
+
+        scope = tuple(requested_scope)
+        included = set(self.spec["scope"]["included"])
+        excluded = set(self.spec["scope"]["excluded"])
+        if not scope or any(item not in included or item in excluded for item in scope):
+            raise BuildGovernanceError("delegation cannot broaden scope beyond the governing specification")
+
+        allowed_capabilities = {
+            str(item["capability"])
+            for item in self.spec.get("required_capabilities", [])
+        }
+        requested = set(requested_capabilities)
+        if not requested <= allowed_capabilities:
+            raise BuildGovernanceError("delegation requested capability outside the governing specification")
+
+        gate_required = destructive or self.spec["risk_class"] in HIGH_RISK
+        if gate_required and (not gate_id or gate_id not in self.declared_gates):
+            raise BuildGovernanceError("high-risk/destructive delegation requires a declared action gate")
+
+        self._delegated_revision = implementation_revision
+        return DelegationReceipt(
+            spec_id=str(self.spec["spec_id"]),
+            actor_kind=actor_kind,
+            implementation_revision=implementation_revision,
+            requested_scope=scope,
+            gate_id=gate_id,
+        )
+
+    def verify(self, results: Iterable[VerificationResult]) -> str:
+        if self._delegated_revision is None:
+            raise BuildGovernanceError("verification requires a delegated implementation revision")
+
+        received: dict[str, VerificationResult] = {}
+        for result in results:
+            if result.criterion_id not in self.criteria:
+                raise BuildGovernanceError(f"unknown acceptance criterion: {result.criterion_id}")
+            if result.implementation_revision != self._delegated_revision:
+                raise BuildGovernanceError("verification evidence must target the exact implementation revision")
+            if not result.evidence_ref.strip() or not result.verifier.strip():
+                raise BuildGovernanceError("verification requires evidence_ref and independent verifier identity")
+            received[result.criterion_id] = result
+
+        missing = set(self.criteria) - set(received)
+        if missing:
+            raise BuildGovernanceError(f"verification is missing acceptance criteria: {sorted(missing)}")
+
+        self._verification = received
+        hard_failure = any(
+            bool(self.criteria[criterion_id]["hard_gate"]) and not result.passed
+            for criterion_id, result in received.items()
+        )
+        self.state = "rejected" if hard_failure else "verified"
+        return self.state
+
+    def approve(self) -> str:
+        if self.state != "verified":
+            raise BuildGovernanceError("only a verified implementation may be approved")
+        self.state = "approved"
+        return self.state
+
+    def release(self) -> str:
+        if self.state not in {"verified", "approved"}:
+            raise BuildGovernanceError("release requires verified or approved state")
+        if any(not result.passed for result in self._verification.values()):
+            raise BuildGovernanceError("failed acceptance criteria prevent released state")
+        self.state = "released"
+        return self.state
+
+    def rollback(self) -> str:
+        if not self.spec.get("rollback_plan", {}).get("procedure"):
+            raise BuildGovernanceError("rollback requires the declared rollback procedure")
+        self.state = "rolled-back"
+        return self.state
+
+    def _validate_spec(self) -> None:
+        required = {
+            "spec_id",
+            "title",
+            "outcome",
+            "scope",
+            "interfaces",
+            "constraints",
+            "acceptance_criteria",
+            "verification_plan",
+            "rollback_plan",
+            "risk_class",
+            "required_capabilities",
+            "lifecycle_state",
+        }
+        missing = required - self.spec.keys()
+        if missing:
+            raise BuildGovernanceError(f"governed build cannot begin without specification fields: {sorted(missing)}")
+        if not self.spec["acceptance_criteria"]:
+            raise BuildGovernanceError("governed build cannot begin without acceptance criteria")
+        ids = [str(item["id"]) for item in self.spec["acceptance_criteria"]]
+        if len(ids) != len(set(ids)):
+            raise BuildGovernanceError("acceptance criterion identifiers must be unique")
+        plan_ids = {str(item["criterion_id"]) for item in self.spec["verification_plan"]}
+        if not set(ids) <= plan_ids:
+            raise BuildGovernanceError("verification plan must cover every acceptance criterion")
+        if self.spec["lifecycle_state"] not in LIFECYCLE_STATES:
+            raise BuildGovernanceError("invalid lifecycle_state")
+        if self.spec["risk_class"] in HIGH_RISK and not self.declared_gates:
+            raise BuildGovernanceError("R2/R3 specifications must declare at least one action gate")

--- a/tests/test_spec_first_build_loop.py
+++ b/tests/test_spec_first_build_loop.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+
+from kopano.spec_first import BuildGovernanceError, SpecificationFirstBuild, VerificationResult
+
+
+def make_spec(*, risk_class: str = "R1", gates: list[str] | None = None) -> dict:
+    spec = {
+        "spec_id": "SPEC-39-POC",
+        "title": "Specification-first executable governance",
+        "outcome": "Prove bounded delegation, exact-revision verification and release gating.",
+        "scope": {
+            "included": ["runtime", "tests"],
+            "excluded": ["production-deploy", "identity-mutation"],
+        },
+        "interfaces": [],
+        "constraints": ["Do not widen scope"],
+        "acceptance_criteria": [
+            {
+                "id": "AC-01",
+                "statement": "Implementation remains inside declared scope.",
+                "hard_gate": True,
+                "verification_methods": ["unit"],
+            },
+            {
+                "id": "AC-02",
+                "statement": "Verification evidence is pinned to the implementation revision.",
+                "hard_gate": True,
+                "verification_methods": ["unit"],
+            },
+        ],
+        "verification_plan": [
+            {"criterion_id": "AC-01", "evidence": "scope test"},
+            {"criterion_id": "AC-02", "evidence": "revision test"},
+        ],
+        "rollback_plan": {"trigger": "verification failure", "procedure": "revert implementation revision"},
+        "risk_class": risk_class,
+        "required_capabilities": [{"capability": "repository.write", "scope": "governed branch"}],
+        "lifecycle_state": "draft",
+    }
+    if gates is not None:
+        spec["action_gates"] = gates
+    return spec
+
+
+def passing_results(revision: str) -> list[VerificationResult]:
+    return [
+        VerificationResult("AC-01", True, revision, "evidence://scope", "independent-test"),
+        VerificationResult("AC-02", True, revision, "evidence://revision", "independent-test"),
+    ]
+
+
+def test_governed_build_cannot_begin_without_spec_or_acceptance_criteria():
+    missing = make_spec()
+    del missing["scope"]
+    with pytest.raises(BuildGovernanceError, match="cannot begin without specification fields"):
+        SpecificationFirstBuild(missing)
+
+    no_criteria = make_spec()
+    no_criteria["acceptance_criteria"] = []
+    with pytest.raises(BuildGovernanceError, match="without acceptance criteria"):
+        SpecificationFirstBuild(no_criteria)
+
+
+def test_delegation_cannot_silently_broaden_scope_or_capabilities():
+    build = SpecificationFirstBuild(make_spec())
+    with pytest.raises(BuildGovernanceError, match="cannot broaden scope"):
+        build.delegate(
+            actor_kind="agent",
+            implementation_revision="abc123",
+            requested_scope=["production-deploy"],
+            requested_capabilities=["repository.write"],
+        )
+
+    with pytest.raises(BuildGovernanceError, match="capability outside"):
+        build.delegate(
+            actor_kind="agent",
+            implementation_revision="abc123",
+            requested_scope=["runtime"],
+            requested_capabilities=["production.deploy"],
+        )
+
+
+@pytest.mark.parametrize("actor_kind", ["human", "agent"])
+def test_same_governance_loop_supports_human_and_agent_authored_implementations(actor_kind: str):
+    build = SpecificationFirstBuild(make_spec())
+    receipt = build.delegate(
+        actor_kind=actor_kind,
+        implementation_revision=f"rev-{actor_kind}",
+        requested_scope=["runtime", "tests"],
+        requested_capabilities=["repository.write"],
+    )
+    assert receipt.actor_kind == actor_kind
+    assert build.verify(passing_results(receipt.implementation_revision)) == "verified"
+    assert build.release() == "released"
+
+
+def test_high_risk_or_destructive_delegation_requires_declared_gate():
+    with pytest.raises(BuildGovernanceError, match="must declare at least one action gate"):
+        SpecificationFirstBuild(make_spec(risk_class="R3"))
+
+    build = SpecificationFirstBuild(make_spec(risk_class="R3", gates=["human-production-approval"]))
+    with pytest.raises(BuildGovernanceError, match="requires a declared action gate"):
+        build.delegate(
+            actor_kind="agent",
+            implementation_revision="risk-rev",
+            requested_scope=["runtime"],
+            requested_capabilities=["repository.write"],
+        )
+
+    receipt = build.delegate(
+        actor_kind="agent",
+        implementation_revision="risk-rev",
+        requested_scope=["runtime"],
+        requested_capabilities=["repository.write"],
+        destructive=True,
+        gate_id="human-production-approval",
+    )
+    assert receipt.gate_id == "human-production-approval"
+
+
+def test_verification_evidence_must_target_exact_implementation_revision():
+    build = SpecificationFirstBuild(make_spec())
+    build.delegate(
+        actor_kind="agent",
+        implementation_revision="exact-rev",
+        requested_scope=["runtime"],
+        requested_capabilities=["repository.write"],
+    )
+    results = passing_results("other-rev")
+    with pytest.raises(BuildGovernanceError, match="exact implementation revision"):
+        build.verify(results)
+
+
+def test_failed_hard_criterion_prevents_released_state():
+    build = SpecificationFirstBuild(make_spec())
+    build.delegate(
+        actor_kind="human",
+        implementation_revision="failed-rev",
+        requested_scope=["tests"],
+        requested_capabilities=["repository.write"],
+    )
+    results = passing_results("failed-rev")
+    results[0] = VerificationResult("AC-01", False, "failed-rev", "evidence://failure", "independent-test")
+
+    assert build.verify(results) == "rejected"
+    with pytest.raises(BuildGovernanceError, match="release requires"):
+        build.release()
+
+
+def test_rollback_uses_declared_recovery_plan():
+    spec = deepcopy(make_spec())
+    build = SpecificationFirstBuild(spec)
+    assert build.rollback() == "rolled-back"

--- a/tests/test_spec_first_build_loop.py
+++ b/tests/test_spec_first_build_loop.py
@@ -94,6 +94,7 @@ def test_same_governance_loop_supports_human_and_agent_authored_implementations(
         requested_capabilities=["repository.write"],
     )
     assert receipt.actor_kind == actor_kind
+    assert receipt.requested_capabilities == ("repository.write",)
     assert build.verify(passing_results(receipt.implementation_revision)) == "verified"
     assert build.release() == "released"
 
@@ -135,6 +136,60 @@ def test_verification_evidence_must_target_exact_implementation_revision():
         build.verify(results)
 
 
+def test_duplicate_criterion_results_are_rejected_instead_of_overwritten():
+    build = SpecificationFirstBuild(make_spec())
+    build.delegate(
+        actor_kind="agent",
+        implementation_revision="dup-rev",
+        requested_scope=["runtime"],
+        requested_capabilities=["repository.write"],
+    )
+    duplicate = [
+        VerificationResult("AC-01", False, "dup-rev", "evidence://first", "verifier-a"),
+        VerificationResult("AC-01", True, "dup-rev", "evidence://second", "verifier-b"),
+        VerificationResult("AC-02", True, "dup-rev", "evidence://third", "verifier-c"),
+    ]
+    with pytest.raises(BuildGovernanceError, match="duplicate acceptance criterion"):
+        build.verify(duplicate)
+
+
+def test_redelegation_invalidates_previous_revision_verification_and_approval():
+    build = SpecificationFirstBuild(make_spec())
+    build.delegate(
+        actor_kind="agent",
+        implementation_revision="revision-a",
+        requested_scope=["runtime"],
+        requested_capabilities=["repository.write"],
+    )
+    assert build.verify(passing_results("revision-a")) == "verified"
+    assert build.approve() == "approved"
+
+    receipt = build.delegate(
+        actor_kind="agent",
+        implementation_revision="revision-b",
+        requested_scope=["runtime"],
+        requested_capabilities=["repository.write"],
+    )
+    assert receipt.implementation_revision == "revision-b"
+    assert build.state == "draft"
+    with pytest.raises(BuildGovernanceError, match="release requires"):
+        build.release()
+
+    assert build.verify(passing_results("revision-b")) == "verified"
+    assert build.release() == "released"
+
+
+def test_declared_verified_state_cannot_approve_or_release_without_runtime_receipts():
+    spec = make_spec()
+    spec["lifecycle_state"] = "verified"
+    build = SpecificationFirstBuild(spec)
+
+    with pytest.raises(BuildGovernanceError, match="delegated implementation revision"):
+        build.approve()
+    with pytest.raises(BuildGovernanceError, match="delegated implementation revision"):
+        build.release()
+
+
 def test_failed_hard_criterion_prevents_released_state():
     build = SpecificationFirstBuild(make_spec())
     build.delegate(
@@ -151,7 +206,16 @@ def test_failed_hard_criterion_prevents_released_state():
         build.release()
 
 
-def test_rollback_uses_declared_recovery_plan():
+def test_rollback_requires_a_delegated_revision_and_declared_recovery_plan():
     spec = deepcopy(make_spec())
     build = SpecificationFirstBuild(spec)
+    with pytest.raises(BuildGovernanceError, match="delegated implementation revision"):
+        build.rollback()
+
+    build.delegate(
+        actor_kind="human",
+        implementation_revision="rollback-rev",
+        requested_scope=["runtime"],
+        requested_capabilities=["repository.write"],
+    )
     assert build.rollback() == "rolled-back"


### PR DESCRIPTION
## What changed
- add `kopano-core/kopano/spec_first.py` as the executable `specify -> delegate -> execute -> verify -> steer -> ship` supervision core
- refuse governed builds missing required specification fields or acceptance criteria
- deny scope and capability widening at delegation time
- extend the build-spec schema with named `action_gates`
- require R2/R3 specifications to declare a gate and require high-risk/destructive delegation to present one of those declared gate IDs
- bind every verification result to the exact delegated implementation revision plus evidence/verifier identity
- require complete criterion coverage before verification state can advance
- move hard-gate failure to `rejected` and prevent release
- retain rollback from the declared recovery procedure
- prove the same governance loop for human-authored and agent-authored implementations

## Acceptance evidence for #39
- no governed task begins without an explicit spec and acceptance criteria
- agent/human delegation cannot silently broaden scope or required capabilities
- high-risk/destructive actions require a declared gate
- verifier evidence is revision-pinned
- failed hard acceptance criteria cannot become `released`
- identical supervision path supports human and agent actors

## Validation
- `python -m pytest -q tests/test_spec_first_build_loop.py`
- repository Python 3.11/3.12 CI
- KPGS vNext Contract Gate
- CodeQL

Closes #39