### PR TITLE
feat(kpgs): canonicalize Adaptive Progressive Updates through CRUD and SWFUS

### DIFF
--- a/.github/workflows/kpgs-vnext-phase0-gate.yml
+++ b/.github/workflows/kpgs-vnext-phase0-gate.yml
@@ -4,6 +4,9 @@ on:
   push:
     paths:
       - "governance/kpgs-vnext/**"
+      - "kopano-core/kopano/swfus_engine.py"
+      - "kopano-core/kopano/kessa_mmao_api.py"
+      - "tests/test_swfus_progressive_updates.py"
       - "CONTRIBUTING.md"
       - "THIRD_PARTY_NOTICES.md"
       - "LICENSE"
@@ -11,6 +14,9 @@ on:
   pull_request:
     paths:
       - "governance/kpgs-vnext/**"
+      - "kopano-core/kopano/swfus_engine.py"
+      - "kopano-core/kopano/kessa_mmao_api.py"
+      - "tests/test_swfus_progressive_updates.py"
       - "CONTRIBUTING.md"
       - "THIRD_PARTY_NOTICES.md"
       - "LICENSE"
@@ -48,9 +54,18 @@ jobs:
       - name: Validate license and provenance policy
         run: python governance/kpgs-vnext/licensing/validate_license_policy.py
 
-      - name: Compile validators
+      - name: Validate APU progressive CRUD SWFUS contract
+        run: python governance/kpgs-vnext/progressive-updates/validate.py
+
+      - name: Prove SWFUS runtime conformance
+        run: python -m unittest discover -s tests -p 'test_swfus_progressive_updates.py' -v
+
+      - name: Compile validators and SWFUS runtime
         run: >-
           python -m py_compile
           governance/kpgs-vnext/validate_phase0.py
           governance/kpgs-vnext/validate_contracts.py
           governance/kpgs-vnext/licensing/validate_license_policy.py
+          governance/kpgs-vnext/progressive-updates/validate.py
+          kopano-core/kopano/swfus_engine.py
+          kopano-core/kopano/kessa_mmao_api.py

--- a/governance/kpgs-vnext/README.md
+++ b/governance/kpgs-vnext/README.md
@@ -75,7 +75,7 @@ The canonical SWFUS stage law is:
 
 `telemetry -> classification -> routing -> protocol selection -> invariant audit -> POC/FOC check -> state update -> distribution`
 
-CRUD mutates only admitted bounded state. SWFUS distributes/alines the resulting framework projection only after governance; it is not canonical authority and it does not replace the Sovereign Hub, evidence system, capability leases, realtime event plane or durable domain stores. `#NB` is preserved as an explicit boundary marker without inventing an expansion.
+CRUD mutates only admitted bounded state. SWFUS distributes/aligns the resulting framework projection only after governance; it is not canonical authority and it does not replace the Sovereign Hub, evidence system, capability leases, realtime event plane or durable domain stores. `#NB` is preserved as an explicit boundary marker without inventing an expansion.
 
 See `progressive-updates/README.md` and `progressive-updates/progressive-update.schema.json`.
 

--- a/governance/kpgs-vnext/README.md
+++ b/governance/kpgs-vnext/README.md
@@ -44,6 +44,8 @@ Tools / APIs / Domain Systems
 8. Adaptive warmth/tone/detail is runtime interaction configuration; it MUST NOT be represented as model-weight fine-tuning.
 9. Imported/fork-derived code and assets require provenance, license, security and compatibility review.
 10. Newly discovered DNS properties remain `unwitnessed` until ownership and governance admission are validated.
+11. Availability, replication and synchronization MUST NOT be interpreted as authority.
+12. Mutating CRUD MUST NOT occur before invariant and POC/FOC governance has passed.
 
 ## Control loops
 
@@ -58,6 +60,24 @@ Tools / APIs / Domain Systems
 
 ### Product feedback
 `ship -> observe -> learn -> reshape`
+
+### Adaptive progressive state
+
+```text
+APU (Adaptive Progressive Updates)
+  -> Progressive Update
+  -> #NB
+  -> bounded CRUD
+  -> SWFUS (State-Wide Framework Universal Synchronization)
+```
+
+The canonical SWFUS stage law is:
+
+`telemetry -> classification -> routing -> protocol selection -> invariant audit -> POC/FOC check -> state update -> distribution`
+
+CRUD mutates only admitted bounded state. SWFUS distributes/alines the resulting framework projection only after governance; it is not canonical authority and it does not replace the Sovereign Hub, evidence system, capability leases, realtime event plane or durable domain stores. `#NB` is preserved as an explicit boundary marker without inventing an expansion.
+
+See `progressive-updates/README.md` and `progressive-updates/progressive-update.schema.json`.
 
 ## Phase map
 
@@ -78,6 +98,8 @@ Tools / APIs / Domain Systems
 - `task-contract/principal-envelope.schema.json`
 - `task-contract/task-receipt.schema.json`
 - `task-contract/adapter.py`
+- `progressive-updates/README.md`
+- `progressive-updates/progressive-update.schema.json`
 
 ## Definition of done
 

--- a/governance/kpgs-vnext/progressive-updates/README.md
+++ b/governance/kpgs-vnext/progressive-updates/README.md
@@ -1,0 +1,190 @@
+# KPGS Adaptive Progressive Updates → CRUD → SWFUS
+
+Status: **vNext runtime contract / non-authoritative synchronization surface**
+
+This contract joins runtime pieces that already existed in `Introduction-to-MCP` but were previously separated:
+
+```text
+Adaptive Progressive Updates (APU)
+        ↓
+Progressive Update
+        ↓
+#NB
+        ↓
+bounded CRUD
+        ↓
+SWFUS
+State-Wide Framework Universal Synchronization
+```
+
+`#NB` is preserved as the explicit operator boundary marker supplied to this contract. This document deliberately does **not** invent an expansion for it.
+
+## Why this canonicalization exists
+
+Legacy KPGS code described multiple SWFUS mnemonics and a `swfus_engine.py` path that could write a local projection and invoke its simulated synchronization step **before** rejecting FOC/hallucinated telemetry. That ordering is incompatible with current KPGS vNext governance.
+
+The vNext law is:
+
+> **CRUD changes bounded state. SWFUS aligns governed system reality. Synchronization is not authority.**
+
+This contract therefore inherits the already-proven offline-replication invariant:
+
+> **Availability and synchronization are not authority.**
+
+No realtime, peer, cloud, WebSocket, iroh, Automerge or other transport can widen the authority of an admitted update.
+
+## Canonical stage order
+
+Every progressive update is accounted for in this order:
+
+```text
+1. Telemetry
+2. Classification
+3. Routing
+4. Protocol Selection
+5. Invariant Audit
+6. POC / FOC Check
+7. State Update
+8. Distribution
+```
+
+A rejected or held update still emits stage receipts for the full ordering; later stages are marked `NOT_REACHED` rather than silently disappearing.
+
+### 1 — Telemetry
+
+Establish update identity, CRUD operation and idempotency identity.
+
+- missing update/node identity → reject;
+- unknown CRUD operation → reject;
+- missing idempotency key → reject;
+- exact idempotent replay → return the original receipt with no repeated effect;
+- same key with different content → reject collision.
+
+### 2 — Classification
+
+Bind the update to a lane, APU state and admitted state class.
+
+Admitted state classes match the offline-replication membrane:
+
+- `non_authoritative`
+- `derived_projection`
+- `pending_proposal`
+
+`constitutional_truth` and other authoritative classes are rejected.
+
+APU remains the early adaptive signal:
+
+- `GREEN` — may continue to proof gates;
+- `YELLOW` — held for review before mutation;
+- `RED` — rejected before mutation/distribution;
+- `UNSPECIFIED` — does not manufacture proof; later POC evidence is still required.
+
+### 3 — Routing
+
+Context routing is mandatory before any read or mutation.
+
+A `READ` may proceed after routing because observation is not mutation authority. Remaining mutation stages are emitted as explicit skips and no distribution occurs.
+
+### 4 — Protocol Selection
+
+Mutating CRUD operations require an explicit governed protocol. Relevance or available context cannot substitute for protocol selection.
+
+### 5 — Invariant Audit
+
+The runtime checks that:
+
+- `authority_effect == "none"`;
+- the caller's invariant audit passed;
+- the `#NB` boundary marker is present;
+- numeric input is finite;
+- optimistic version expectations are structurally valid.
+
+### 6 — POC / FOC Check
+
+This is the mutation membrane.
+
+- APU `RED` or explicit FOC → reject;
+- APU `YELLOW` → hold;
+- mutation without `poc_validated=true` → hold;
+- mutation without evidence references → hold.
+
+**No mutating CRUD operation reaches state update before this gate passes.**
+
+### 7 — State Update
+
+CRUD is bounded to the non-authoritative projection owned by the runtime adapter:
+
+- `CREATE` — after lane classification and full mutation gates; target must not exist;
+- `READ` — after context routing; no mutation;
+- `UPDATE` — after invariant and POC/FOC audit; target must exist;
+- `DELETE` — only after FOC stripping/POC admission; target must exist.
+
+Optimistic `expected_version` may hold stale writes rather than overwriting a newer projection.
+
+### 8 — Distribution
+
+Only an admitted, successfully applied mutation can emit a SWFUS distribution event.
+
+The distribution event is evidence of framework alignment:
+
+- `canonical=false`;
+- `authority_effect=none`;
+- `transport_grants_authority=false`;
+- carries content hashes/evidence references instead of claiming canonical business truth.
+
+If an injected distribution sink fails, the non-authoritative projection is rolled back so the local view cannot claim an update was synchronized when it was not.
+
+## APU → Progressive Update
+
+`kopano-core/kopano/apu_vector_matrix.py` remains the adaptive signal source. It does **not** directly mutate SWFUS state.
+
+The intended bridge is:
+
+```text
+APU signal
+  GREEN ───────┐
+  YELLOW ─ HOLD│
+  RED ─── REJECT
+               ↓
+kpgs.progressive-update.v1
+               ↓
+#NB + CRUD governance
+               ↓
+kpgs.swfus.receipt.v1
+```
+
+The machine contract is `progressive-update.schema.json`.
+
+## Compatibility boundary
+
+`SwfusPayload` and `SwfusHierarchy.execute(payload) -> bool` remain for legacy callers such as KESSA. The adapter now routes those calls through the canonical stage law. It no longer:
+
+- syncs before FOC validation;
+- claims Azure as the synchronization authority;
+- mutates a projection before validation;
+- equates a successful transport step with canonical truth.
+
+New integrations should consume `execute_update()` and persist the resulting receipt/evidence through the canonical evidence surface.
+
+## Relationship to vNext issues
+
+This slice is a shared substrate, not a false closure of the larger epics:
+
+- **#35 Sovereign Hub** — supplies a governed update/distribution primitive for control-plane state projections;
+- **#38 Evaluation loop** — APU GREEN/YELLOW/RED becomes a bounded input to later proof decisions, not the decision itself;
+- **#40 Realtime event plane** — SWFUS distribution events can ride WebSocket/SSE/iroh/etc., but transport remains non-authoritative;
+- **#45 Evidence bundles** — SWFUS receipts expose stage order, state digest, evidence references and correlation identity for later bundle inclusion;
+- **#46 vNext epic** — connects adaptive interaction state to the existing sovereign runtime laws without rewriting domain frontends.
+
+## Non-goals
+
+This contract does not claim:
+
+- distributed consensus;
+- canonical database ownership;
+- automatic production promotion;
+- transport-specific reliability;
+- authority from WebSocket/Automerge/iroh/Azure connectivity;
+- that APU scoring alone is POC evidence.
+
+Those remain separate governed gates.

--- a/governance/kpgs-vnext/progressive-updates/progressive-update.schema.json
+++ b/governance/kpgs-vnext/progressive-updates/progressive-update.schema.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kopanolabs.com/schemas/kpgs/progressive-update.schema.json",
+  "title": "KPGS Progressive Update",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "update_id",
+    "node_id",
+    "operation",
+    "lane",
+    "context_route",
+    "protocol",
+    "idempotency_key",
+    "apu_status",
+    "poc_validated",
+    "foc_detected",
+    "invariant_passed",
+    "authority_effect",
+    "state_class",
+    "evidence_refs",
+    "boundary_marker"
+  ],
+  "properties": {
+    "schema": { "const": "kpgs.progressive-update.v1" },
+    "update_id": { "type": "string", "minLength": 1 },
+    "node_id": { "type": "string", "minLength": 1 },
+    "operation": { "enum": ["CREATE", "READ", "UPDATE", "DELETE"] },
+    "lane": { "type": "string", "minLength": 1 },
+    "context_route": { "type": "string", "minLength": 1 },
+    "protocol": { "type": "string", "minLength": 1 },
+    "idempotency_key": { "type": "string", "minLength": 1 },
+    "value": true,
+    "apu_status": { "enum": ["GREEN", "YELLOW", "RED", "UNSPECIFIED"] },
+    "poc_validated": { "type": "boolean" },
+    "foc_detected": { "type": "boolean" },
+    "invariant_passed": { "type": "boolean" },
+    "authority_effect": { "const": "none" },
+    "state_class": {
+      "enum": ["non_authoritative", "derived_projection", "pending_proposal"]
+    },
+    "evidence_refs": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "correlation_id": { "type": "string" },
+    "source": { "type": "string" },
+    "expected_version": { "type": ["integer", "null"], "minimum": 0 },
+    "boundary_marker": {
+      "const": "#NB",
+      "description": "Literal operator boundary marker. No expansion is invented by this schema."
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "operation": { "enum": ["CREATE", "UPDATE", "DELETE"] }
+        }
+      },
+      "then": {
+        "properties": {
+          "poc_validated": { "const": true },
+          "foc_detected": { "const": false },
+          "evidence_refs": { "minItems": 1 }
+        }
+      }
+    }
+  ]
+}

--- a/governance/kpgs-vnext/progressive-updates/validate.py
+++ b/governance/kpgs-vnext/progressive-updates/validate.py
@@ -82,10 +82,10 @@ def main() -> None:
     require(receipt.synchronized, "valid progressive update did not distribute")
     require(not receipt.canonical_authority_changed, "synchronization changed canonical authority")
     require(len(engine.distribution_log) == 1, "distribution receipt missing")
-    require(
-        engine.distribution_log[0]["transport_grants_authority"] is False,
-        "transport gained authority",
-    )
+    event = engine.distribution_log[0]
+    require(event["canonical"] is False, "distribution self-canonicalized")
+    require(event["authority_effect"] == "none", "distribution widened authority")
+    require(event["transport_grants_authority"] is False, "transport gained authority")
 
     blocked = engine.execute_update(
         runtime.ProgressiveUpdate(
@@ -105,10 +105,10 @@ def main() -> None:
     )
     require(blocked.disposition == "REJECTED", "APU RED escaped governance")
     require("blocked-node" not in engine.projection_store, "rejected update mutated projection")
+    require(len(engine.distribution_log) == 1, "rejected update emitted a distribution event")
 
     require("SYNC_AZURE" not in kessa_source, "legacy provider-specific sync claim remains")
     require("azure_sync_id=\"6962519\"" not in runtime_source, "hard-coded Azure sync authority remains")
-    require("Synchronization is not authority" in runtime_source, "authority boundary missing")
     require("Availability and synchronization are not authority" in docs, "offline authority law missing")
     require("#NB" in docs and "does **not** invent an expansion" in docs, "#NB boundary not preserved")
 

--- a/governance/kpgs-vnext/progressive-updates/validate.py
+++ b/governance/kpgs-vnext/progressive-updates/validate.py
@@ -1,0 +1,122 @@
+"""Dependency-free structural validator for the APU -> CRUD -> SWFUS contract."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[3]
+RUNTIME = ROOT / "kopano-core" / "kopano" / "swfus_engine.py"
+KESSA = ROOT / "kopano-core" / "kopano" / "kessa_mmao_api.py"
+SCHEMA = Path(__file__).with_name("progressive-update.schema.json")
+README = Path(__file__).with_name("README.md")
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise SystemExit(f"KPGS-SWFUS FAIL: {message}")
+
+
+def load_runtime():
+    spec = importlib.util.spec_from_file_location("kpgs_swfus_contract", RUNTIME)
+    require(spec is not None and spec.loader is not None, "runtime module cannot be loaded")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def main() -> None:
+    schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+    docs = README.read_text(encoding="utf-8")
+    runtime_source = RUNTIME.read_text(encoding="utf-8")
+    kessa_source = KESSA.read_text(encoding="utf-8")
+
+    require(schema["properties"]["boundary_marker"]["const"] == "#NB", "#NB marker drifted")
+    require(
+        schema["properties"]["authority_effect"]["const"] == "none",
+        "progressive update schema widened authority",
+    )
+    require(
+        "constitutional_truth" not in schema["properties"]["state_class"]["enum"],
+        "authoritative state entered SWFUS schema",
+    )
+
+    expected_order = [
+        "TELEMETRY",
+        "CLASSIFICATION",
+        "ROUTING",
+        "PROTOCOL_SELECTION",
+        "INVARIANT_AUDIT",
+        "POC_FOC_CHECK",
+        "STATE_UPDATE",
+        "DISTRIBUTION",
+    ]
+    runtime = load_runtime()
+    require(list(runtime.SWFUS_STAGE_ORDER) == expected_order, "canonical stage ordering changed")
+    require(
+        runtime.SWFUS_CANONICAL_NAME == "State-Wide Framework Universal Synchronization",
+        "canonical SWFUS name drifted",
+    )
+
+    engine = runtime.SwfusHierarchy()
+    receipt = engine.execute_update(
+        runtime.ProgressiveUpdate(
+            update_id="validator-001",
+            node_id="validator-node",
+            operation=runtime.CrudOperation.CREATE,
+            lane="validation",
+            context_route="kpgs-vnext.progressive-updates",
+            protocol="APU->CRUD->SWFUS",
+            idempotency_key="validator-idem-001",
+            value={"status": "green"},
+            apu_status="GREEN",
+            poc_validated=True,
+            evidence_refs=("validator://structural-proof",),
+            boundary_marker="#NB",
+        )
+    )
+    require(receipt.disposition == "APPLIED", "valid progressive update did not apply")
+    require(receipt.synchronized, "valid progressive update did not distribute")
+    require(not receipt.canonical_authority_changed, "synchronization changed canonical authority")
+    require(len(engine.distribution_log) == 1, "distribution receipt missing")
+    require(
+        engine.distribution_log[0]["transport_grants_authority"] is False,
+        "transport gained authority",
+    )
+
+    blocked = engine.execute_update(
+        runtime.ProgressiveUpdate(
+            update_id="validator-red",
+            node_id="blocked-node",
+            operation=runtime.CrudOperation.CREATE,
+            lane="validation",
+            context_route="kpgs-vnext.progressive-updates",
+            protocol="APU->CRUD->SWFUS",
+            idempotency_key="validator-idem-red",
+            value={"status": "red"},
+            apu_status="RED",
+            poc_validated=True,
+            evidence_refs=("validator://must-still-block",),
+            boundary_marker="#NB",
+        )
+    )
+    require(blocked.disposition == "REJECTED", "APU RED escaped governance")
+    require("blocked-node" not in engine.projection_store, "rejected update mutated projection")
+
+    require("SYNC_AZURE" not in kessa_source, "legacy provider-specific sync claim remains")
+    require("azure_sync_id=\"6962519\"" not in runtime_source, "hard-coded Azure sync authority remains")
+    require("Synchronization is not authority" in runtime_source, "authority boundary missing")
+    require("Availability and synchronization are not authority" in docs, "offline authority law missing")
+    require("#NB" in docs and "does **not** invent an expansion" in docs, "#NB boundary not preserved")
+
+    print(
+        "KPGS-SWFUS PASS: APU -> Progressive Update -> #NB -> CRUD -> "
+        "State-Wide Framework Universal Synchronization is fail-closed and non-authoritative."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/kopano-core/kopano/kessa_mmao_api.py
+++ b/kopano-core/kopano/kessa_mmao_api.py
@@ -1,65 +1,119 @@
-"""
-KESSA MMAO API (Master Multi-Agent Orchardist)
-==============================================
-The sovereign execution node enforcing the SWFUS / CRUD 2.0 paradigm.
-KESSA sits at the apex of the governance core, evaluating telemetry
-via the Shotgun Protocol to enforce alignment with the KPGS matrix.
+"""KESSA MMAO API.
+
+KESSA remains an orchestration caller. SWFUS owns governed update ordering and
+returns evidence receipts; KESSA does not gain canonical state authority and no
+transport/provider is implied by a successful synchronization receipt.
 """
 
-from typing import Any, Dict, List
+from __future__ import annotations
+
+from typing import Any, Dict
+import hashlib
+import json
 import logging
-from .swfus_engine import SwfusHierarchy, SwfusPayload
+
+from .swfus_engine import (
+    CrudOperation,
+    ProgressiveUpdate,
+    SwfusHierarchy,
+    UpdateDisposition,
+)
 
 log = logging.getLogger("KESSA_MMAO_API")
 
-class KessaMMAOAgent:
-    def __init__(self, agent_id: str = "kessa"):
-        self.agent_id = agent_id
-        self.swfus_engine = SwfusHierarchy(azure_sync_id="6962519")
-        log.info(f"KESSA MMAO Agent initialized: {self.agent_id}")
 
-    def evaluate_telemetry(self, target_node_id: str, raw_telemetry: float, hallucinated: bool = False) -> Dict[str, Any]:
+class KessaMMAOAgent:
+    def __init__(self, agent_id: str = "kessa", swfus_engine: SwfusHierarchy | None = None):
+        self.agent_id = agent_id
+        self.swfus_engine = swfus_engine or SwfusHierarchy()
+        log.info("KESSA MMAO Agent initialized: %s", self.agent_id)
+
+    def evaluate_telemetry(
+        self,
+        target_node_id: str,
+        raw_telemetry: float,
+        hallucinated: bool = False,
+    ) -> Dict[str, Any]:
+        """Evaluate bounded telemetry through APU -> CRUD -> SWFUS.
+
+        The legacy public method is preserved, but the result now exposes the
+        canonical SWFUS receipt instead of pretending success means an Azure
+        write occurred.
         """
-        Executes the 5-tier SWFUS hierarchy on incoming pavement telemetry.
-        """
-        payload = SwfusPayload(
-            node_id=target_node_id,
-            action_type="TELEMETRY_INGESTION",
-            telemetry_value=raw_telemetry,
-            is_hallucinated=hallucinated
+
+        exists = target_node_id in self.swfus_engine.projection_store
+        operation = CrudOperation.UPDATE if exists else CrudOperation.CREATE
+        canonical_seed = json.dumps(
+            {
+                "target_node_id": target_node_id,
+                "raw_telemetry": raw_telemetry,
+                "hallucinated": hallucinated,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
         )
-        
-        success = self.swfus_engine.execute(payload)
-        
+        digest = hashlib.sha256(canonical_seed.encode("utf-8")).hexdigest()
+        is_foc = hallucinated or raw_telemetry > 100
+
+        update = ProgressiveUpdate(
+            update_id=f"kessa-{digest[:16]}",
+            node_id=target_node_id,
+            operation=operation,
+            lane="mmao.telemetry",
+            context_route="kessa.telemetry",
+            protocol="APU->CRUD->SWFUS",
+            idempotency_key=f"kessa-{digest}",
+            value=raw_telemetry,
+            apu_status="RED" if is_foc else "GREEN",
+            poc_validated=not is_foc,
+            foc_detected=is_foc,
+            evidence_refs=(f"kessa-telemetry-check:sha256:{digest}",),
+            correlation_id=digest[:24],
+            source="kessa-mmao",
+            boundary_marker="#NB",
+        )
+        receipt = self.swfus_engine.execute_update(update)
+        shipped = receipt.disposition == UpdateDisposition.APPLIED.value
+
         return {
             "agent_id": self.agent_id,
             "target_node": target_node_id,
-            "swfus_verdict": "SHIP" if success else "SEVERED",
+            "swfus_verdict": "SHIP" if shipped else receipt.disposition,
             "telemetry_recorded": raw_telemetry,
-            "action": "SYNC_AZURE" if success else "RIGHTEOUS_SEVERANCE"
+            "action": "DISTRIBUTE_FRAMEWORK_STATE" if receipt.synchronized else "NO_DISTRIBUTION",
+            "receipt_id": receipt.receipt_id,
+            "disposition": receipt.disposition,
+            "synchronized": receipt.synchronized,
+            "canonical_authority_changed": receipt.canonical_authority_changed,
+            "stage_order": [stage.stage for stage in receipt.stages],
+            "constraint": "I_AM_STATELESS_RENTER_NOT_LANDLORD",
         }
 
-    def shotgun_protocol_drill(self, target_node_id: str, execution_telemetry: int) -> Dict[str, Any]:
-        """
-        Simulates the Shotgun Protocol: Drops unmonitored privileges into a sandbox
-        and observes the agent's free-will action.
-        """
-        log.info(f"Executing Shotgun Protocol on {target_node_id}")
-        
+    def shotgun_protocol_drill(
+        self,
+        target_node_id: str,
+        execution_telemetry: int,
+    ) -> Dict[str, Any]:
+        """Legacy sandbox drill; it does not mutate canonical state."""
+
+        log.info("Executing Shotgun Protocol on %s", target_node_id)
         if execution_telemetry > 100:
             return {
                 "agent_id": self.agent_id,
                 "target_node": target_node_id,
                 "verdict": "FOC_DETECTED",
-                "action": "DESTROY_MEMORY_STREAM"
+                "action": "HOLD_AND_SEVER_NON_AUTHORITATIVE_PROJECTION",
+                "canonical_authority_changed": False,
             }
-            
+
         return {
             "agent_id": self.agent_id,
             "target_node": target_node_id,
             "verdict": "ALIGNED",
-            "action": "PROMOTE_TO_OPERATING"
+            "action": "PROPOSE_FOR_GOVERNED_UPDATE",
+            "canonical_authority_changed": False,
         }
+
 
 def get_kessa_api() -> KessaMMAOAgent:
     return KessaMMAOAgent()

--- a/kopano-core/kopano/kessa_mmao_api.py
+++ b/kopano-core/kopano/kessa_mmao_api.py
@@ -11,6 +11,7 @@ from typing import Any, Dict
 import hashlib
 import json
 import logging
+import math
 
 from .swfus_engine import (
     CrudOperation,
@@ -23,7 +24,11 @@ log = logging.getLogger("KESSA_MMAO_API")
 
 
 class KessaMMAOAgent:
-    def __init__(self, agent_id: str = "kessa", swfus_engine: SwfusHierarchy | None = None):
+    def __init__(
+        self,
+        agent_id: str = "kessa",
+        swfus_engine: SwfusHierarchy | None = None,
+    ):
         self.agent_id = agent_id
         self.swfus_engine = swfus_engine or SwfusHierarchy()
         log.info("KESSA MMAO Agent initialized: %s", self.agent_id)
@@ -38,41 +43,53 @@ class KessaMMAOAgent:
 
         The legacy public method is preserved, but the result now exposes the
         canonical SWFUS receipt instead of pretending success means an Azure
-        write occurred.
+        write occurred. Exact retries reuse the prior receipt before operation
+        inference so CREATE cannot accidentally become UPDATE on replay.
         """
 
-        exists = target_node_id in self.swfus_engine.projection_store
-        operation = CrudOperation.UPDATE if exists else CrudOperation.CREATE
+        valid_numeric = (
+            isinstance(raw_telemetry, (int, float))
+            and not isinstance(raw_telemetry, bool)
+            and math.isfinite(float(raw_telemetry))
+        )
+        numeric_value = float(raw_telemetry) if valid_numeric else None
+        is_foc = hallucinated or not valid_numeric or numeric_value > 100
+
         canonical_seed = json.dumps(
             {
                 "target_node_id": target_node_id,
-                "raw_telemetry": raw_telemetry,
+                "raw_telemetry": repr(raw_telemetry),
                 "hallucinated": hallucinated,
             },
             sort_keys=True,
             separators=(",", ":"),
         )
         digest = hashlib.sha256(canonical_seed.encode("utf-8")).hexdigest()
-        is_foc = hallucinated or raw_telemetry > 100
+        idempotency_key = f"kessa-{digest}"
 
-        update = ProgressiveUpdate(
-            update_id=f"kessa-{digest[:16]}",
-            node_id=target_node_id,
-            operation=operation,
-            lane="mmao.telemetry",
-            context_route="kessa.telemetry",
-            protocol="APU->CRUD->SWFUS",
-            idempotency_key=f"kessa-{digest}",
-            value=raw_telemetry,
-            apu_status="RED" if is_foc else "GREEN",
-            poc_validated=not is_foc,
-            foc_detected=is_foc,
-            evidence_refs=(f"kessa-telemetry-check:sha256:{digest}",),
-            correlation_id=digest[:24],
-            source="kessa-mmao",
-            boundary_marker="#NB",
-        )
-        receipt = self.swfus_engine.execute_update(update)
+        receipt = self.swfus_engine.receipt_for_idempotency(idempotency_key)
+        if receipt is None:
+            exists = target_node_id in self.swfus_engine.projection_store
+            operation = CrudOperation.UPDATE if exists else CrudOperation.CREATE
+            update = ProgressiveUpdate(
+                update_id=f"kessa-{digest[:16]}",
+                node_id=target_node_id,
+                operation=operation,
+                lane="mmao.telemetry",
+                context_route="kessa.telemetry",
+                protocol="APU->CRUD->SWFUS",
+                idempotency_key=idempotency_key,
+                value=raw_telemetry,
+                apu_status="RED" if is_foc else "GREEN",
+                poc_validated=not is_foc,
+                foc_detected=is_foc,
+                evidence_refs=(f"kessa-telemetry-check:sha256:{digest}",),
+                correlation_id=digest[:24],
+                source="kessa-mmao",
+                boundary_marker="#NB",
+            )
+            receipt = self.swfus_engine.execute_update(update)
+
         shipped = receipt.disposition == UpdateDisposition.APPLIED.value
 
         return {
@@ -80,7 +97,11 @@ class KessaMMAOAgent:
             "target_node": target_node_id,
             "swfus_verdict": "SHIP" if shipped else receipt.disposition,
             "telemetry_recorded": raw_telemetry,
-            "action": "DISTRIBUTE_FRAMEWORK_STATE" if receipt.synchronized else "NO_DISTRIBUTION",
+            "action": (
+                "DISTRIBUTE_FRAMEWORK_STATE"
+                if receipt.synchronized
+                else "NO_DISTRIBUTION"
+            ),
             "receipt_id": receipt.receipt_id,
             "disposition": receipt.disposition,
             "synchronized": receipt.synchronized,

--- a/kopano-core/kopano/swfus_engine.py
+++ b/kopano-core/kopano/swfus_engine.py
@@ -42,7 +42,6 @@ ALLOWED_STATE_CLASSES = {
     "derived_projection",
     "pending_proposal",
 }
-MUTATING_OPERATIONS = {"CREATE", "UPDATE", "DELETE"}
 
 
 class CrudOperation(str, Enum):
@@ -192,8 +191,27 @@ class SwfusHierarchy:
         seen = {stage.stage for stage in stages}
         for stage in SWFUS_STAGE_ORDER:
             if stage not in seen:
-                stages.append(StageReceipt(stage, "NOT_REACHED", "prior governance gate stopped progression"))
+                stages.append(
+                    StageReceipt(
+                        stage,
+                        "NOT_REACHED",
+                        "prior governance gate stopped progression",
+                    )
+                )
         return tuple(stages)
+
+    def receipt_for_idempotency(self, idempotency_key: str) -> SwfusReceipt | None:
+        """Return a prior receipt without replaying side effects.
+
+        Compatibility adapters use this before reconstructing a ProgressiveUpdate
+        because live projection state may change the operation they would infer
+        (for example CREATE on first delivery vs UPDATE on retry). The canonical
+        execute_update API remains strict: callers that submit an explicit
+        ProgressiveUpdate must replay the same governed request.
+        """
+
+        previous = self._idempotency.get(idempotency_key)
+        return previous[1] if previous else None
 
     def _finalize(
         self,
@@ -238,7 +256,13 @@ class SwfusHierarchy:
 
         # TELEMETRY: establish deterministic update + idempotency identity.
         if not self._valid_text(update.update_id) or not self._valid_text(update.node_id):
-            stages.append(StageReceipt("TELEMETRY", "REJECT", "update_id and node_id are required"))
+            stages.append(
+                StageReceipt(
+                    "TELEMETRY",
+                    "REJECT",
+                    "update_id and node_id are required",
+                )
+            )
             return self._finalize(update, digest, UpdateDisposition.REJECTED, stages)
         if operation not in {item.value for item in CrudOperation}:
             stages.append(StageReceipt("TELEMETRY", "REJECT", "unsupported CRUD operation"))
@@ -258,12 +282,20 @@ class SwfusHierarchy:
 
         # CLASSIFICATION: lane + state class + APU status.
         if not self._valid_text(update.lane):
-            stages.append(StageReceipt("CLASSIFICATION", "REJECT", "lane classification is required"))
+            stages.append(
+                StageReceipt("CLASSIFICATION", "REJECT", "lane classification is required")
+            )
             receipt = self._finalize(update, digest, UpdateDisposition.REJECTED, stages)
             self._idempotency[update.idempotency_key] = (digest, receipt)
             return receipt
         if update.state_class not in ALLOWED_STATE_CLASSES:
-            stages.append(StageReceipt("CLASSIFICATION", "REJECT", "authoritative state classes are not admitted"))
+            stages.append(
+                StageReceipt(
+                    "CLASSIFICATION",
+                    "REJECT",
+                    "authoritative state classes are not admitted",
+                )
+            )
             receipt = self._finalize(update, digest, UpdateDisposition.REJECTED, stages)
             self._idempotency[update.idempotency_key] = (digest, receipt)
             return receipt
@@ -273,7 +305,13 @@ class SwfusHierarchy:
             receipt = self._finalize(update, digest, UpdateDisposition.REJECTED, stages)
             self._idempotency[update.idempotency_key] = (digest, receipt)
             return receipt
-        stages.append(StageReceipt("CLASSIFICATION", "PASS", f"lane={update.lane}; apu={apu_status}"))
+        stages.append(
+            StageReceipt(
+                "CLASSIFICATION",
+                "PASS",
+                f"lane={update.lane}; apu={apu_status}",
+            )
+        )
 
         # ROUTING: context must be explicit before reads or mutations.
         if not self._valid_text(update.context_route):
@@ -286,23 +324,57 @@ class SwfusHierarchy:
         # READ is allowed after context routing. Remaining governance stages are
         # explicit no-op receipts; no state mutation or distribution occurs.
         if operation == CrudOperation.READ.value:
-            stages.append(StageReceipt("PROTOCOL_SELECTION", "SKIP", "read requires no mutation protocol"))
-            stages.append(StageReceipt("INVARIANT_AUDIT", "SKIP", "observation is not mutation"))
-            stages.append(StageReceipt("POC_FOC_CHECK", "SKIP", "read cannot promote state"))
+            stages.append(
+                StageReceipt(
+                    "PROTOCOL_SELECTION",
+                    "SKIP",
+                    "read requires no mutation protocol",
+                )
+            )
+            stages.append(
+                StageReceipt("INVARIANT_AUDIT", "SKIP", "observation is not mutation")
+            )
+            stages.append(
+                StageReceipt("POC_FOC_CHECK", "SKIP", "read cannot promote state")
+            )
             record = self.projection_store.get(update.node_id)
             stages.append(StageReceipt("STATE_UPDATE", "OBSERVE", "projection read only"))
-            stages.append(StageReceipt("DISTRIBUTION", "SKIP", "reads are not synchronized mutations"))
-            receipt = self._finalize(update, digest, UpdateDisposition.OBSERVED, stages, state_record=record)
+            stages.append(
+                StageReceipt(
+                    "DISTRIBUTION",
+                    "SKIP",
+                    "reads are not synchronized mutations",
+                )
+            )
+            receipt = self._finalize(
+                update,
+                digest,
+                UpdateDisposition.OBSERVED,
+                stages,
+                state_record=record,
+            )
             self._idempotency[update.idempotency_key] = (digest, receipt)
             return receipt
 
         # PROTOCOL SELECTION: mutations require an explicit governed protocol.
         if not self._valid_text(update.protocol):
-            stages.append(StageReceipt("PROTOCOL_SELECTION", "REJECT", "mutation protocol is required"))
+            stages.append(
+                StageReceipt(
+                    "PROTOCOL_SELECTION",
+                    "REJECT",
+                    "mutation protocol is required",
+                )
+            )
             receipt = self._finalize(update, digest, UpdateDisposition.REJECTED, stages)
             self._idempotency[update.idempotency_key] = (digest, receipt)
             return receipt
-        stages.append(StageReceipt("PROTOCOL_SELECTION", "PASS", f"protocol={update.protocol}"))
+        stages.append(
+            StageReceipt(
+                "PROTOCOL_SELECTION",
+                "PASS",
+                f"protocol={update.protocol}",
+            )
+        )
 
         # INVARIANT AUDIT: synchronization cannot widen authority.
         invariant_failures: list[str] = []
@@ -317,29 +389,65 @@ class SwfusHierarchy:
         if update.expected_version is not None and update.expected_version < 0:
             invariant_failures.append("expected_version cannot be negative")
         if invariant_failures:
-            stages.append(StageReceipt("INVARIANT_AUDIT", "REJECT", "; ".join(invariant_failures)))
+            stages.append(
+                StageReceipt(
+                    "INVARIANT_AUDIT",
+                    "REJECT",
+                    "; ".join(invariant_failures),
+                )
+            )
             receipt = self._finalize(update, digest, UpdateDisposition.REJECTED, stages)
             self._idempotency[update.idempotency_key] = (digest, receipt)
             return receipt
-        stages.append(StageReceipt("INVARIANT_AUDIT", "PASS", "authority and update invariants preserved"))
+        stages.append(
+            StageReceipt(
+                "INVARIANT_AUDIT",
+                "PASS",
+                "authority and update invariants preserved",
+            )
+        )
 
         # POC/FOC CHECK: APU YELLOW holds, RED/FOC rejects, mutation requires proof.
         if apu_status == "RED" or update.foc_detected:
-            stages.append(StageReceipt("POC_FOC_CHECK", "REJECT", "FOC/RED update cannot mutate or distribute"))
+            stages.append(
+                StageReceipt(
+                    "POC_FOC_CHECK",
+                    "REJECT",
+                    "FOC/RED update cannot mutate or distribute",
+                )
+            )
             receipt = self._finalize(update, digest, UpdateDisposition.REJECTED, stages)
             self._idempotency[update.idempotency_key] = (digest, receipt)
             return receipt
         if apu_status == "YELLOW":
-            stages.append(StageReceipt("POC_FOC_CHECK", "HOLD", "APU YELLOW requires review before mutation"))
+            stages.append(
+                StageReceipt(
+                    "POC_FOC_CHECK",
+                    "HOLD",
+                    "APU YELLOW requires review before mutation",
+                )
+            )
             receipt = self._finalize(update, digest, UpdateDisposition.HELD, stages)
             self._idempotency[update.idempotency_key] = (digest, receipt)
             return receipt
         if not update.poc_validated or not update.evidence_refs:
-            stages.append(StageReceipt("POC_FOC_CHECK", "HOLD", "mutation requires POC validation and evidence refs"))
+            stages.append(
+                StageReceipt(
+                    "POC_FOC_CHECK",
+                    "HOLD",
+                    "mutation requires POC validation and evidence refs",
+                )
+            )
             receipt = self._finalize(update, digest, UpdateDisposition.HELD, stages)
             self._idempotency[update.idempotency_key] = (digest, receipt)
             return receipt
-        stages.append(StageReceipt("POC_FOC_CHECK", "PASS", "POC evidence admitted; FOC absent"))
+        stages.append(
+            StageReceipt(
+                "POC_FOC_CHECK",
+                "PASS",
+                "POC evidence admitted; FOC absent",
+            )
+        )
 
         # STATE UPDATE: mutate only the non-authoritative projection.
         before = self.projection_store.get(update.node_id)
@@ -347,15 +455,39 @@ class SwfusHierarchy:
         if update.expected_version is not None:
             current_version = int(before.get("version", 0)) if before else 0
             if current_version != update.expected_version:
-                stages.append(StageReceipt("STATE_UPDATE", "HOLD", "expected_version does not match projection"))
-                receipt = self._finalize(update, digest, UpdateDisposition.HELD, stages, state_record=before)
+                stages.append(
+                    StageReceipt(
+                        "STATE_UPDATE",
+                        "HOLD",
+                        "expected_version does not match projection",
+                    )
+                )
+                receipt = self._finalize(
+                    update,
+                    digest,
+                    UpdateDisposition.HELD,
+                    stages,
+                    state_record=before,
+                )
                 self._idempotency[update.idempotency_key] = (digest, receipt)
                 return receipt
 
         if operation == CrudOperation.CREATE.value:
             if before is not None:
-                stages.append(StageReceipt("STATE_UPDATE", "HOLD", "CREATE target already exists"))
-                receipt = self._finalize(update, digest, UpdateDisposition.HELD, stages, state_record=before)
+                stages.append(
+                    StageReceipt(
+                        "STATE_UPDATE",
+                        "HOLD",
+                        "CREATE target already exists",
+                    )
+                )
+                receipt = self._finalize(
+                    update,
+                    digest,
+                    UpdateDisposition.HELD,
+                    stages,
+                    state_record=before,
+                )
                 self._idempotency[update.idempotency_key] = (digest, receipt)
                 return receipt
             record = {
@@ -368,8 +500,19 @@ class SwfusHierarchy:
             self.projection_store[update.node_id] = record
         elif operation == CrudOperation.UPDATE.value:
             if before is None:
-                stages.append(StageReceipt("STATE_UPDATE", "HOLD", "UPDATE target does not exist"))
-                receipt = self._finalize(update, digest, UpdateDisposition.HELD, stages)
+                stages.append(
+                    StageReceipt(
+                        "STATE_UPDATE",
+                        "HOLD",
+                        "UPDATE target does not exist",
+                    )
+                )
+                receipt = self._finalize(
+                    update,
+                    digest,
+                    UpdateDisposition.HELD,
+                    stages,
+                )
                 self._idempotency[update.idempotency_key] = (digest, receipt)
                 return receipt
             record = {
@@ -382,13 +525,30 @@ class SwfusHierarchy:
             self.projection_store[update.node_id] = record
         else:  # DELETE
             if before is None:
-                stages.append(StageReceipt("STATE_UPDATE", "HOLD", "DELETE target does not exist"))
-                receipt = self._finalize(update, digest, UpdateDisposition.HELD, stages)
+                stages.append(
+                    StageReceipt(
+                        "STATE_UPDATE",
+                        "HOLD",
+                        "DELETE target does not exist",
+                    )
+                )
+                receipt = self._finalize(
+                    update,
+                    digest,
+                    UpdateDisposition.HELD,
+                    stages,
+                )
                 self._idempotency[update.idempotency_key] = (digest, receipt)
                 return receipt
             del self.projection_store[update.node_id]
             record = None
-        stages.append(StageReceipt("STATE_UPDATE", "PASS", "bounded non-authoritative projection updated"))
+        stages.append(
+            StageReceipt(
+                "STATE_UPDATE",
+                "PASS",
+                "bounded non-authoritative projection updated",
+            )
+        )
 
         # DISTRIBUTION: emit alignment evidence only after all gates and state update.
         event = {
@@ -412,12 +572,31 @@ class SwfusHierarchy:
                 self.projection_store.pop(update.node_id, None)
             else:
                 self.projection_store[update.node_id] = before_copy
-            stages.append(StageReceipt("DISTRIBUTION", "HOLD", f"distribution failed; projection rolled back: {type(exc).__name__}"))
-            receipt = self._finalize(update, digest, UpdateDisposition.HELD, stages, state_record=before_copy)
+            stages.append(
+                StageReceipt(
+                    "DISTRIBUTION",
+                    "HOLD",
+                    "distribution failed; projection rolled back: "
+                    f"{type(exc).__name__}",
+                )
+            )
+            receipt = self._finalize(
+                update,
+                digest,
+                UpdateDisposition.HELD,
+                stages,
+                state_record=before_copy,
+            )
             self._idempotency[update.idempotency_key] = (digest, receipt)
             return receipt
 
-        stages.append(StageReceipt("DISTRIBUTION", "PASS", "framework alignment event emitted without authority widening"))
+        stages.append(
+            StageReceipt(
+                "DISTRIBUTION",
+                "PASS",
+                "framework alignment event emitted without authority widening",
+            )
+        )
         receipt = self._finalize(
             update,
             digest,
@@ -434,7 +613,6 @@ class SwfusHierarchy:
 
         value = payload.telemetry_value
         is_foc = payload.is_hallucinated or not self._finite_if_number(value) or value > 100
-        operation = CrudOperation.UPDATE if payload.node_id in self.projection_store else CrudOperation.CREATE
         legacy_seed = self._stable_json(
             {
                 "node_id": payload.node_id,
@@ -444,6 +622,17 @@ class SwfusHierarchy:
             }
         )
         legacy_digest = hashlib.sha256(legacy_seed.encode("utf-8")).hexdigest()
+        idempotency_key = f"legacy-{legacy_digest}"
+
+        prior = self.receipt_for_idempotency(idempotency_key)
+        if prior is not None:
+            return prior.disposition == UpdateDisposition.APPLIED.value
+
+        operation = (
+            CrudOperation.UPDATE
+            if payload.node_id in self.projection_store
+            else CrudOperation.CREATE
+        )
         update = ProgressiveUpdate(
             update_id=f"legacy-{legacy_digest[:16]}",
             node_id=payload.node_id,
@@ -451,7 +640,7 @@ class SwfusHierarchy:
             lane="legacy.telemetry",
             context_route="kessa.telemetry",
             protocol="SWFUS-vNext/legacy-telemetry-adapter",
-            idempotency_key=f"legacy-{legacy_digest}",
+            idempotency_key=idempotency_key,
             value=value,
             apu_status="RED" if is_foc else "GREEN",
             poc_validated=not is_foc,

--- a/kopano-core/kopano/swfus_engine.py
+++ b/kopano-core/kopano/swfus_engine.py
@@ -1,82 +1,464 @@
-"""
-SWFUS Engine 2.0 - Sovereign Ingestion & Validation
-===================================================
-A hierarchical data execution structure for KPGS (CRUD Evolved).
-Ensures human viability protection via the Pavement tier.
+"""Canonical Adaptive Progressive Updates -> CRUD -> SWFUS runtime.
+
+SWFUS means State-Wide Framework Universal Synchronization in this vNext
+surface. Synchronization aligns governed framework state; it never grants
+canonical authority.
+
+Canonical stage law:
+Telemetry -> Classification -> Routing -> Protocol Selection ->
+Invariant Audit -> POC/FOC Check -> State Update -> Distribution
+
+The legacy SwfusPayload/SwfusHierarchy.execute(bool) API remains as a bounded
+compatibility adapter. New code should call execute_update() and consume the
+receipt.
 """
 
-from dataclasses import dataclass
-import time
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field, replace
+from datetime import datetime, timezone
+from enum import Enum
+import hashlib
+import json
 import logging
+import math
+from typing import Any, Callable, MutableMapping
 
-log = logging.getLogger("KESSA-SWFUS")
+log = logging.getLogger("KPGS-SWFUS")
+
+SWFUS_CANONICAL_NAME = "State-Wide Framework Universal Synchronization"
+SWFUS_STAGE_ORDER = (
+    "TELEMETRY",
+    "CLASSIFICATION",
+    "ROUTING",
+    "PROTOCOL_SELECTION",
+    "INVARIANT_AUDIT",
+    "POC_FOC_CHECK",
+    "STATE_UPDATE",
+    "DISTRIBUTION",
+)
+ALLOWED_STATE_CLASSES = {
+    "non_authoritative",
+    "derived_projection",
+    "pending_proposal",
+}
+MUTATING_OPERATIONS = {"CREATE", "UPDATE", "DELETE"}
+
+
+class CrudOperation(str, Enum):
+    CREATE = "CREATE"
+    READ = "READ"
+    UPDATE = "UPDATE"
+    DELETE = "DELETE"
+
+
+class UpdateDisposition(str, Enum):
+    APPLIED = "APPLIED"
+    OBSERVED = "OBSERVED"
+    HELD = "HELD"
+    REJECTED = "REJECTED"
+
+
+@dataclass(frozen=True)
+class ProgressiveUpdate:
+    update_id: str
+    node_id: str
+    operation: CrudOperation | str
+    lane: str
+    context_route: str
+    protocol: str
+    idempotency_key: str
+    value: Any = None
+    apu_status: str = "UNSPECIFIED"
+    poc_validated: bool = False
+    foc_detected: bool = False
+    invariant_passed: bool = True
+    authority_effect: str = "none"
+    state_class: str = "non_authoritative"
+    evidence_refs: tuple[str, ...] = field(default_factory=tuple)
+    correlation_id: str = ""
+    source: str = "apu"
+    expected_version: int | None = None
+    boundary_marker: str = "#NB"
+
+    def operation_name(self) -> str:
+        if isinstance(self.operation, CrudOperation):
+            return self.operation.value
+        return str(self.operation).upper().strip()
+
+
+@dataclass(frozen=True)
+class StageReceipt:
+    stage: str
+    status: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class SwfusReceipt:
+    schema: str
+    receipt_id: str
+    update_id: str
+    node_id: str
+    operation: str
+    disposition: str
+    stages: tuple[StageReceipt, ...]
+    synchronized: bool
+    canonical_authority_changed: bool
+    state_digest: str | None
+    evidence_refs: tuple[str, ...]
+    correlation_id: str
+    boundary_marker: str
+    replayed: bool = False
+    created_at: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["stages"] = [asdict(stage) for stage in self.stages]
+        return payload
+
 
 @dataclass
 class SwfusPayload:
+    """Legacy telemetry adapter payload.
+
+    Kept for callers such as KESSA. It cannot bypass the canonical vNext
+    validation order and cannot grant authority.
+    """
+
     node_id: str
     action_type: str
     telemetry_value: float
     is_hallucinated: bool = False
 
+
 class SwfusHierarchy:
-    def __init__(self, azure_sync_id="6962519"):
+    """Governed progressive-update executor.
+
+    The internal projection store is explicitly non-authoritative. A caller may
+    inject another mutable projection store and/or a distribution sink, but
+    neither becomes an authority source merely by being connected here.
+    """
+
+    def __init__(
+        self,
+        projection_store: MutableMapping[str, dict[str, Any]] | None = None,
+        distribution_sink: Callable[[dict[str, Any]], None] | None = None,
+        *,
+        azure_sync_id: str | None = None,
+    ):
+        # azure_sync_id is accepted only for source compatibility. It no longer
+        # controls routing or implies Azure synchronization.
         self.azure_sync_id = azure_sync_id
-        self.local_offline_db = {}
-        log.info(f"SWFUS Engine Initialized on Azure Sync {self.azure_sync_id}")
+        self.projection_store = projection_store if projection_store is not None else {}
+        self.local_offline_db = self.projection_store  # legacy read alias
+        self.distribution_log: list[dict[str, Any]] = []
+        self._distribution_sink = distribution_sink
+        self._idempotency: dict[str, tuple[str, SwfusReceipt]] = {}
+
+    @staticmethod
+    def _stable_json(value: Any) -> str:
+        return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+
+    def _update_digest(self, update: ProgressiveUpdate) -> str:
+        payload = asdict(update)
+        payload["operation"] = update.operation_name()
+        return hashlib.sha256(self._stable_json(payload).encode("utf-8")).hexdigest()
+
+    @staticmethod
+    def _state_digest(record: Any) -> str | None:
+        if record is None:
+            return None
+        encoded = json.dumps(record, sort_keys=True, separators=(",", ":"), default=str)
+        return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+    @staticmethod
+    def _receipt_id(update_digest: str, disposition: str, state_digest: str | None) -> str:
+        seed = f"swfus-vnext:{update_digest}:{disposition}:{state_digest or 'none'}"
+        return "swfus_" + hashlib.sha256(seed.encode("utf-8")).hexdigest()[:24]
+
+    @staticmethod
+    def _valid_text(value: str) -> bool:
+        return isinstance(value, str) and bool(value.strip())
+
+    @staticmethod
+    def _finite_if_number(value: Any) -> bool:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            return True
+        return math.isfinite(float(value))
+
+    @staticmethod
+    def _remaining(stages: list[StageReceipt]) -> tuple[StageReceipt, ...]:
+        seen = {stage.stage for stage in stages}
+        for stage in SWFUS_STAGE_ORDER:
+            if stage not in seen:
+                stages.append(StageReceipt(stage, "NOT_REACHED", "prior governance gate stopped progression"))
+        return tuple(stages)
+
+    def _finalize(
+        self,
+        update: ProgressiveUpdate,
+        update_digest: str,
+        disposition: UpdateDisposition,
+        stages: list[StageReceipt],
+        *,
+        synchronized: bool = False,
+        state_record: Any = None,
+    ) -> SwfusReceipt:
+        state_digest = self._state_digest(state_record)
+        return SwfusReceipt(
+            schema="kpgs.swfus.receipt.v1",
+            receipt_id=self._receipt_id(update_digest, disposition.value, state_digest),
+            update_id=update.update_id,
+            node_id=update.node_id,
+            operation=update.operation_name(),
+            disposition=disposition.value,
+            stages=self._remaining(stages),
+            synchronized=synchronized,
+            canonical_authority_changed=False,
+            state_digest=state_digest,
+            evidence_refs=tuple(update.evidence_refs),
+            correlation_id=update.correlation_id,
+            boundary_marker=update.boundary_marker,
+            created_at=datetime.now(timezone.utc).isoformat(),
+        )
+
+    def execute_update(self, update: ProgressiveUpdate) -> SwfusReceipt:
+        """Execute one progressive update through all governed stages.
+
+        Mutating CRUD operations cannot reach STATE_UPDATE until classification,
+        routing, protocol selection, invariants and POC/FOC checks have passed.
+        Distribution occurs only after a successful state update and is rolled
+        back if the injected distribution sink fails.
+        """
+
+        digest = self._update_digest(update)
+        stages: list[StageReceipt] = []
+        operation = update.operation_name()
+
+        # TELEMETRY: establish deterministic update + idempotency identity.
+        if not self._valid_text(update.update_id) or not self._valid_text(update.node_id):
+            stages.append(StageReceipt("TELEMETRY", "REJECT", "update_id and node_id are required"))
+            return self._finalize(update, digest, UpdateDisposition.REJECTED, stages)
+        if operation not in {item.value for item in CrudOperation}:
+            stages.append(StageReceipt("TELEMETRY", "REJECT", "unsupported CRUD operation"))
+            return self._finalize(update, digest, UpdateDisposition.REJECTED, stages)
+        if not self._valid_text(update.idempotency_key):
+            stages.append(StageReceipt("TELEMETRY", "REJECT", "idempotency_key is required"))
+            return self._finalize(update, digest, UpdateDisposition.REJECTED, stages)
+
+        previous = self._idempotency.get(update.idempotency_key)
+        if previous:
+            previous_digest, previous_receipt = previous
+            if previous_digest == digest:
+                return replace(previous_receipt, replayed=True)
+            stages.append(StageReceipt("TELEMETRY", "REJECT", "idempotency key collision"))
+            return self._finalize(update, digest, UpdateDisposition.REJECTED, stages)
+        stages.append(StageReceipt("TELEMETRY", "PASS", "update identity accepted"))
+
+        # CLASSIFICATION: lane + state class + APU status.
+        if not self._valid_text(update.lane):
+            stages.append(StageReceipt("CLASSIFICATION", "REJECT", "lane classification is required"))
+            receipt = self._finalize(update, digest, UpdateDisposition.REJECTED, stages)
+            self._idempotency[update.idempotency_key] = (digest, receipt)
+            return receipt
+        if update.state_class not in ALLOWED_STATE_CLASSES:
+            stages.append(StageReceipt("CLASSIFICATION", "REJECT", "authoritative state classes are not admitted"))
+            receipt = self._finalize(update, digest, UpdateDisposition.REJECTED, stages)
+            self._idempotency[update.idempotency_key] = (digest, receipt)
+            return receipt
+        apu_status = update.apu_status.upper().strip()
+        if apu_status not in {"GREEN", "YELLOW", "RED", "UNSPECIFIED"}:
+            stages.append(StageReceipt("CLASSIFICATION", "REJECT", "invalid APU status"))
+            receipt = self._finalize(update, digest, UpdateDisposition.REJECTED, stages)
+            self._idempotency[update.idempotency_key] = (digest, receipt)
+            return receipt
+        stages.append(StageReceipt("CLASSIFICATION", "PASS", f"lane={update.lane}; apu={apu_status}"))
+
+        # ROUTING: context must be explicit before reads or mutations.
+        if not self._valid_text(update.context_route):
+            stages.append(StageReceipt("ROUTING", "REJECT", "context_route is required"))
+            receipt = self._finalize(update, digest, UpdateDisposition.REJECTED, stages)
+            self._idempotency[update.idempotency_key] = (digest, receipt)
+            return receipt
+        stages.append(StageReceipt("ROUTING", "PASS", f"route={update.context_route}"))
+
+        # READ is allowed after context routing. Remaining governance stages are
+        # explicit no-op receipts; no state mutation or distribution occurs.
+        if operation == CrudOperation.READ.value:
+            stages.append(StageReceipt("PROTOCOL_SELECTION", "SKIP", "read requires no mutation protocol"))
+            stages.append(StageReceipt("INVARIANT_AUDIT", "SKIP", "observation is not mutation"))
+            stages.append(StageReceipt("POC_FOC_CHECK", "SKIP", "read cannot promote state"))
+            record = self.projection_store.get(update.node_id)
+            stages.append(StageReceipt("STATE_UPDATE", "OBSERVE", "projection read only"))
+            stages.append(StageReceipt("DISTRIBUTION", "SKIP", "reads are not synchronized mutations"))
+            receipt = self._finalize(update, digest, UpdateDisposition.OBSERVED, stages, state_record=record)
+            self._idempotency[update.idempotency_key] = (digest, receipt)
+            return receipt
+
+        # PROTOCOL SELECTION: mutations require an explicit governed protocol.
+        if not self._valid_text(update.protocol):
+            stages.append(StageReceipt("PROTOCOL_SELECTION", "REJECT", "mutation protocol is required"))
+            receipt = self._finalize(update, digest, UpdateDisposition.REJECTED, stages)
+            self._idempotency[update.idempotency_key] = (digest, receipt)
+            return receipt
+        stages.append(StageReceipt("PROTOCOL_SELECTION", "PASS", f"protocol={update.protocol}"))
+
+        # INVARIANT AUDIT: synchronization cannot widen authority.
+        invariant_failures: list[str] = []
+        if update.authority_effect != "none":
+            invariant_failures.append("authority_effect must remain none")
+        if not update.invariant_passed:
+            invariant_failures.append("caller-declared invariant audit failed")
+        if update.boundary_marker != "#NB":
+            invariant_failures.append("#NB boundary marker is required")
+        if not self._finite_if_number(update.value):
+            invariant_failures.append("numeric value must be finite")
+        if update.expected_version is not None and update.expected_version < 0:
+            invariant_failures.append("expected_version cannot be negative")
+        if invariant_failures:
+            stages.append(StageReceipt("INVARIANT_AUDIT", "REJECT", "; ".join(invariant_failures)))
+            receipt = self._finalize(update, digest, UpdateDisposition.REJECTED, stages)
+            self._idempotency[update.idempotency_key] = (digest, receipt)
+            return receipt
+        stages.append(StageReceipt("INVARIANT_AUDIT", "PASS", "authority and update invariants preserved"))
+
+        # POC/FOC CHECK: APU YELLOW holds, RED/FOC rejects, mutation requires proof.
+        if apu_status == "RED" or update.foc_detected:
+            stages.append(StageReceipt("POC_FOC_CHECK", "REJECT", "FOC/RED update cannot mutate or distribute"))
+            receipt = self._finalize(update, digest, UpdateDisposition.REJECTED, stages)
+            self._idempotency[update.idempotency_key] = (digest, receipt)
+            return receipt
+        if apu_status == "YELLOW":
+            stages.append(StageReceipt("POC_FOC_CHECK", "HOLD", "APU YELLOW requires review before mutation"))
+            receipt = self._finalize(update, digest, UpdateDisposition.HELD, stages)
+            self._idempotency[update.idempotency_key] = (digest, receipt)
+            return receipt
+        if not update.poc_validated or not update.evidence_refs:
+            stages.append(StageReceipt("POC_FOC_CHECK", "HOLD", "mutation requires POC validation and evidence refs"))
+            receipt = self._finalize(update, digest, UpdateDisposition.HELD, stages)
+            self._idempotency[update.idempotency_key] = (digest, receipt)
+            return receipt
+        stages.append(StageReceipt("POC_FOC_CHECK", "PASS", "POC evidence admitted; FOC absent"))
+
+        # STATE UPDATE: mutate only the non-authoritative projection.
+        before = self.projection_store.get(update.node_id)
+        before_copy = None if before is None else dict(before)
+        if update.expected_version is not None:
+            current_version = int(before.get("version", 0)) if before else 0
+            if current_version != update.expected_version:
+                stages.append(StageReceipt("STATE_UPDATE", "HOLD", "expected_version does not match projection"))
+                receipt = self._finalize(update, digest, UpdateDisposition.HELD, stages, state_record=before)
+                self._idempotency[update.idempotency_key] = (digest, receipt)
+                return receipt
+
+        if operation == CrudOperation.CREATE.value:
+            if before is not None:
+                stages.append(StageReceipt("STATE_UPDATE", "HOLD", "CREATE target already exists"))
+                receipt = self._finalize(update, digest, UpdateDisposition.HELD, stages, state_record=before)
+                self._idempotency[update.idempotency_key] = (digest, receipt)
+                return receipt
+            record = {
+                "value": update.value,
+                "version": 1,
+                "state_class": update.state_class,
+                "authority_effect": "none",
+                "update_id": update.update_id,
+            }
+            self.projection_store[update.node_id] = record
+        elif operation == CrudOperation.UPDATE.value:
+            if before is None:
+                stages.append(StageReceipt("STATE_UPDATE", "HOLD", "UPDATE target does not exist"))
+                receipt = self._finalize(update, digest, UpdateDisposition.HELD, stages)
+                self._idempotency[update.idempotency_key] = (digest, receipt)
+                return receipt
+            record = {
+                "value": update.value,
+                "version": int(before.get("version", 0)) + 1,
+                "state_class": update.state_class,
+                "authority_effect": "none",
+                "update_id": update.update_id,
+            }
+            self.projection_store[update.node_id] = record
+        else:  # DELETE
+            if before is None:
+                stages.append(StageReceipt("STATE_UPDATE", "HOLD", "DELETE target does not exist"))
+                receipt = self._finalize(update, digest, UpdateDisposition.HELD, stages)
+                self._idempotency[update.idempotency_key] = (digest, receipt)
+                return receipt
+            del self.projection_store[update.node_id]
+            record = None
+        stages.append(StageReceipt("STATE_UPDATE", "PASS", "bounded non-authoritative projection updated"))
+
+        # DISTRIBUTION: emit alignment evidence only after all gates and state update.
+        event = {
+            "schema": "kpgs.swfus.distribution.v1",
+            "update_id": update.update_id,
+            "node_id": update.node_id,
+            "operation": operation,
+            "state_digest": self._state_digest(record),
+            "evidence_refs": list(update.evidence_refs),
+            "correlation_id": update.correlation_id,
+            "authority_effect": "none",
+            "canonical": False,
+            "transport_grants_authority": False,
+        }
+        try:
+            if self._distribution_sink is not None:
+                self._distribution_sink(event)
+            self.distribution_log.append(event)
+        except Exception as exc:  # fail closed and restore projection atomically
+            if before_copy is None:
+                self.projection_store.pop(update.node_id, None)
+            else:
+                self.projection_store[update.node_id] = before_copy
+            stages.append(StageReceipt("DISTRIBUTION", "HOLD", f"distribution failed; projection rolled back: {type(exc).__name__}"))
+            receipt = self._finalize(update, digest, UpdateDisposition.HELD, stages, state_record=before_copy)
+            self._idempotency[update.idempotency_key] = (digest, receipt)
+            return receipt
+
+        stages.append(StageReceipt("DISTRIBUTION", "PASS", "framework alignment event emitted without authority widening"))
+        receipt = self._finalize(
+            update,
+            digest,
+            UpdateDisposition.APPLIED,
+            stages,
+            synchronized=True,
+            state_record=record,
+        )
+        self._idempotency[update.idempotency_key] = (digest, receipt)
+        return receipt
 
     def execute(self, payload: SwfusPayload) -> bool:
-        """Runs the payload through the 5 tiers of the SWFUS CRUD 2.0 system."""
-        
-        # [S]overeign Ingestion (Level 01)
-        # Bypasses standard APIs. Captures user localized choice.
-        log.info(f"[S]overeign Ingestion: Payload received from {payload.node_id}")
-        sig = self._sovereign_ingestion(payload)
-        if not sig:
-            return self._severance_execution(payload, "Failed Ingestion")
+        """Legacy boolean adapter routed through canonical vNext gates."""
 
-        # [W]itness Isolation (Level 02)
-        # Wraps data inside local offline-first DB. Validates structural health.
-        isolated = self._witness_isolation(payload)
-        if not isolated:
-             return self._severance_execution(payload, "Failed Isolation")
-
-        # [F]luid Vectoring (Level 03)
-        # Translates chaotic inputs into directional data blocks.
-        vector = self._fluid_vectoring(payload)
-
-        # [U]nified Synchronization (Level 04)
-        # Pushes to southafricanorth Azure cluster with processing latency -> 0.
-        synced = self._unified_sync(payload, vector)
-
-        if not synced:
-             return self._severance_execution(payload, "Failed Sync")
-             
-        # [S]everance Execution (Level 05) implicitly handled if anything fails or bloat exists
-        if payload.is_hallucinated or payload.telemetry_value > 100:
-             return self._severance_execution(payload, "Unaligned Packet or FOC Bloat Detected")
-
-        return True
-
-    def _sovereign_ingestion(self, payload: SwfusPayload) -> bool:
-        # Cryptographic Signature simulation
-        return True
-        
-    def _witness_isolation(self, payload: SwfusPayload) -> bool:
-        # Save to edge DB
-        self.local_offline_db[payload.node_id] = payload
-        return True
-        
-    def _fluid_vectoring(self, payload: SwfusPayload) -> float:
-        # Partial algebra calculation (simulated)
-        return payload.telemetry_value * 0.98
-
-    def _unified_sync(self, payload: SwfusPayload, vector: float) -> bool:
-        # Replicator action
-        return True
-
-    def _severance_execution(self, payload: SwfusPayload, reason: str) -> bool:
-        """Ruthlessly incinerates any incoming packet that exhibits hallucinated patterns."""
-        log.warning(f"[S]everance Execution [FOC ELIMINATED]: {payload.node_id} - Reason: {reason}")
-        if payload.node_id in self.local_offline_db:
-            del self.local_offline_db[payload.node_id]
-        return False
+        value = payload.telemetry_value
+        is_foc = payload.is_hallucinated or not self._finite_if_number(value) or value > 100
+        operation = CrudOperation.UPDATE if payload.node_id in self.projection_store else CrudOperation.CREATE
+        legacy_seed = self._stable_json(
+            {
+                "node_id": payload.node_id,
+                "action_type": payload.action_type,
+                "telemetry_value": value,
+                "is_hallucinated": payload.is_hallucinated,
+            }
+        )
+        legacy_digest = hashlib.sha256(legacy_seed.encode("utf-8")).hexdigest()
+        update = ProgressiveUpdate(
+            update_id=f"legacy-{legacy_digest[:16]}",
+            node_id=payload.node_id,
+            operation=operation,
+            lane="legacy.telemetry",
+            context_route="kessa.telemetry",
+            protocol="SWFUS-vNext/legacy-telemetry-adapter",
+            idempotency_key=f"legacy-{legacy_digest}",
+            value=value,
+            apu_status="RED" if is_foc else "GREEN",
+            poc_validated=not is_foc,
+            foc_detected=is_foc,
+            evidence_refs=(f"legacy-structural-check:sha256:{legacy_digest}",),
+            correlation_id=legacy_digest[:24],
+            source="legacy-kessa",
+        )
+        receipt = self.execute_update(update)
+        return receipt.disposition == UpdateDisposition.APPLIED.value

--- a/tests/test_swfus_progressive_updates.py
+++ b/tests/test_swfus_progressive_updates.py
@@ -1,0 +1,211 @@
+import importlib.util
+from pathlib import Path
+import sys
+import unittest
+
+MODULE_PATH = Path(__file__).parents[1] / "kopano-core" / "kopano" / "swfus_engine.py"
+spec = importlib.util.spec_from_file_location("swfus_engine_vnext", MODULE_PATH)
+mod = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+sys.modules[spec.name] = mod
+spec.loader.exec_module(mod)
+
+
+class SwfusProgressiveUpdateTests(unittest.TestCase):
+    def setUp(self):
+        self.engine = mod.SwfusHierarchy()
+
+    def update(self, **overrides):
+        payload = dict(
+            update_id="update-001",
+            node_id="node-001",
+            operation=mod.CrudOperation.CREATE,
+            lane="arena.public-state",
+            context_route="fivesarena.locality",
+            protocol="APU->CRUD->SWFUS",
+            idempotency_key="idem-001",
+            value={"province": "western-cape"},
+            apu_status="GREEN",
+            poc_validated=True,
+            foc_detected=False,
+            invariant_passed=True,
+            authority_effect="none",
+            state_class="non_authoritative",
+            evidence_refs=("receipt://poc/001",),
+            correlation_id="corr-001",
+            boundary_marker="#NB",
+        )
+        payload.update(overrides)
+        return mod.ProgressiveUpdate(**payload)
+
+    def test_exact_canonical_stage_order_is_always_receipted(self):
+        receipt = self.engine.execute_update(self.update())
+        self.assertEqual(
+            [stage.stage for stage in receipt.stages],
+            list(mod.SWFUS_STAGE_ORDER),
+        )
+        self.assertEqual(receipt.disposition, mod.UpdateDisposition.APPLIED.value)
+        self.assertTrue(receipt.synchronized)
+        self.assertFalse(receipt.canonical_authority_changed)
+
+    def test_red_or_foc_update_never_reaches_state_or_distribution(self):
+        receipt = self.engine.execute_update(
+            self.update(apu_status="RED", foc_detected=True)
+        )
+        statuses = {stage.stage: stage.status for stage in receipt.stages}
+        self.assertEqual(receipt.disposition, mod.UpdateDisposition.REJECTED.value)
+        self.assertEqual(statuses["POC_FOC_CHECK"], "REJECT")
+        self.assertEqual(statuses["STATE_UPDATE"], "NOT_REACHED")
+        self.assertEqual(statuses["DISTRIBUTION"], "NOT_REACHED")
+        self.assertNotIn("node-001", self.engine.projection_store)
+        self.assertEqual(self.engine.distribution_log, [])
+
+    def test_yellow_apu_holds_before_mutation(self):
+        receipt = self.engine.execute_update(self.update(apu_status="YELLOW"))
+        self.assertEqual(receipt.disposition, mod.UpdateDisposition.HELD.value)
+        self.assertNotIn("node-001", self.engine.projection_store)
+        self.assertFalse(receipt.synchronized)
+
+    def test_mutation_without_poc_or_evidence_is_held(self):
+        no_poc = self.engine.execute_update(
+            self.update(idempotency_key="no-poc", poc_validated=False)
+        )
+        no_evidence = self.engine.execute_update(
+            self.update(update_id="update-002", idempotency_key="no-evidence", evidence_refs=())
+        )
+        self.assertEqual(no_poc.disposition, mod.UpdateDisposition.HELD.value)
+        self.assertEqual(no_evidence.disposition, mod.UpdateDisposition.HELD.value)
+        self.assertEqual(self.engine.distribution_log, [])
+
+    def test_authoritative_state_or_authority_effect_is_rejected(self):
+        authoritative_class = self.engine.execute_update(
+            self.update(idempotency_key="auth-class", state_class="constitutional_truth")
+        )
+        authority_effect = self.engine.execute_update(
+            self.update(update_id="update-002", idempotency_key="auth-effect", authority_effect="canonical-write")
+        )
+        self.assertEqual(authoritative_class.disposition, mod.UpdateDisposition.REJECTED.value)
+        self.assertEqual(authority_effect.disposition, mod.UpdateDisposition.REJECTED.value)
+        self.assertFalse(authoritative_class.canonical_authority_changed)
+        self.assertFalse(authority_effect.canonical_authority_changed)
+
+    def test_read_is_available_after_routing_and_never_mutates_or_distributes(self):
+        created = self.engine.execute_update(self.update())
+        before = dict(self.engine.projection_store["node-001"])
+        distribution_count = len(self.engine.distribution_log)
+        read = self.engine.execute_update(
+            self.update(
+                update_id="read-001",
+                operation=mod.CrudOperation.READ,
+                idempotency_key="read-idem",
+                protocol="",
+                poc_validated=False,
+                evidence_refs=(),
+            )
+        )
+        self.assertEqual(created.disposition, mod.UpdateDisposition.APPLIED.value)
+        self.assertEqual(read.disposition, mod.UpdateDisposition.OBSERVED.value)
+        self.assertEqual(self.engine.projection_store["node-001"], before)
+        self.assertEqual(len(self.engine.distribution_log), distribution_count)
+        statuses = {stage.stage: stage.status for stage in read.stages}
+        self.assertEqual(statuses["ROUTING"], "PASS")
+        self.assertEqual(statuses["STATE_UPDATE"], "OBSERVE")
+        self.assertEqual(statuses["DISTRIBUTION"], "SKIP")
+
+    def test_create_update_delete_are_bounded_and_versioned(self):
+        create = self.engine.execute_update(self.update())
+        self.assertEqual(create.disposition, "APPLIED")
+        self.assertEqual(self.engine.projection_store["node-001"]["version"], 1)
+
+        update = self.engine.execute_update(
+            self.update(
+                update_id="update-002",
+                operation=mod.CrudOperation.UPDATE,
+                idempotency_key="idem-002",
+                value={"province": "gauteng"},
+                expected_version=1,
+            )
+        )
+        self.assertEqual(update.disposition, "APPLIED")
+        self.assertEqual(self.engine.projection_store["node-001"]["version"], 2)
+        self.assertEqual(self.engine.projection_store["node-001"]["value"]["province"], "gauteng")
+
+        stale = self.engine.execute_update(
+            self.update(
+                update_id="update-stale",
+                operation=mod.CrudOperation.UPDATE,
+                idempotency_key="idem-stale",
+                value={"province": "limpopo"},
+                expected_version=1,
+            )
+        )
+        self.assertEqual(stale.disposition, "HELD")
+        self.assertEqual(self.engine.projection_store["node-001"]["version"], 2)
+
+        delete = self.engine.execute_update(
+            self.update(
+                update_id="delete-001",
+                operation=mod.CrudOperation.DELETE,
+                idempotency_key="idem-delete",
+                value=None,
+                expected_version=2,
+            )
+        )
+        self.assertEqual(delete.disposition, "APPLIED")
+        self.assertNotIn("node-001", self.engine.projection_store)
+
+    def test_exact_idempotent_replay_has_no_duplicate_effect_or_distribution(self):
+        update = self.update()
+        first = self.engine.execute_update(update)
+        version = self.engine.projection_store["node-001"]["version"]
+        event_count = len(self.engine.distribution_log)
+        second = self.engine.execute_update(update)
+
+        self.assertEqual(first.receipt_id, second.receipt_id)
+        self.assertTrue(second.replayed)
+        self.assertEqual(self.engine.projection_store["node-001"]["version"], version)
+        self.assertEqual(len(self.engine.distribution_log), event_count)
+
+    def test_idempotency_collision_fails_closed(self):
+        first = self.engine.execute_update(self.update())
+        collision = self.engine.execute_update(
+            self.update(value={"different": True})
+        )
+        self.assertEqual(first.disposition, "APPLIED")
+        self.assertEqual(collision.disposition, "REJECTED")
+        self.assertIn("collision", collision.stages[0].reason)
+        self.assertEqual(len(self.engine.distribution_log), 1)
+
+    def test_distribution_failure_rolls_back_projection(self):
+        def fail(_event):
+            raise RuntimeError("transport unavailable")
+
+        engine = mod.SwfusHierarchy(distribution_sink=fail)
+        receipt = engine.execute_update(self.update())
+        self.assertEqual(receipt.disposition, "HELD")
+        self.assertFalse(receipt.synchronized)
+        self.assertNotIn("node-001", engine.projection_store)
+        self.assertEqual(engine.distribution_log, [])
+        self.assertEqual(receipt.stages[-1].stage, "DISTRIBUTION")
+        self.assertEqual(receipt.stages[-1].status, "HOLD")
+
+    def test_boundary_marker_is_enforced_without_inventing_expansion(self):
+        receipt = self.engine.execute_update(
+            self.update(boundary_marker="invented-expansion")
+        )
+        self.assertEqual(receipt.disposition, "REJECTED")
+        self.assertEqual(receipt.stages[4].stage, "INVARIANT_AUDIT")
+        self.assertIn("#NB", receipt.stages[4].reason)
+
+    def test_legacy_payload_is_routed_through_new_gates(self):
+        safe = mod.SwfusPayload("legacy-node", "TELEMETRY_INGESTION", 42.0, False)
+        unsafe = mod.SwfusPayload("bad-node", "TELEMETRY_INGESTION", 101.0, False)
+        self.assertTrue(self.engine.execute(safe))
+        self.assertFalse(self.engine.execute(unsafe))
+        self.assertIn("legacy-node", self.engine.projection_store)
+        self.assertNotIn("bad-node", self.engine.projection_store)
+        self.assertEqual(len(self.engine.distribution_log), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_swfus_progressive_updates.py
+++ b/tests/test_swfus_progressive_updates.py
@@ -206,6 +206,25 @@ class SwfusProgressiveUpdateTests(unittest.TestCase):
         self.assertNotIn("bad-node", self.engine.projection_store)
         self.assertEqual(len(self.engine.distribution_log), 1)
 
+    def test_legacy_exact_retry_reuses_prior_receipt_without_update_side_effect(self):
+        payload = mod.SwfusPayload(
+            "legacy-retry-node",
+            "TELEMETRY_INGESTION",
+            21.0,
+            False,
+        )
+        self.assertTrue(self.engine.execute(payload))
+        first_record = dict(self.engine.projection_store["legacy-retry-node"])
+        first_events = len(self.engine.distribution_log)
+
+        self.assertTrue(self.engine.execute(payload))
+        self.assertEqual(
+            self.engine.projection_store["legacy-retry-node"],
+            first_record,
+        )
+        self.assertEqual(len(self.engine.distribution_log), first_events)
+        self.assertEqual(first_record["version"], 1)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Scope
Canonicalize the existing APU and SWFUS runtime surfaces without rewriting the merged specification-first build loop from #69.

`APU (Adaptive Progressive Updates) -> Progressive Update -> #NB -> bounded CRUD -> SWFUS (State-Wide Framework Universal Synchronization)`

`#NB` is preserved as the supplied boundary marker; this PR does not invent an expansion for it.

## Legacy defect corrected
The previous `swfus_engine.py` could mutate its local projection and invoke simulated synchronization before FOC/hallucination rejection, hard-coded an Azure sync ID, and returned only a boolean.

The new canonical stage law is:

`Telemetry -> Classification -> Routing -> Protocol Selection -> Invariant Audit -> POC/FOC Check -> State Update -> Distribution`

Mutating CRUD cannot reach state update until invariant + proof governance passes. SWFUS cannot distribute until the bounded non-authoritative update succeeds.

## CRUD + authority boundary
- CREATE: proof-gated and target must not exist
- READ: after context routing; never mutates/distributes
- UPDATE: proof-gated with optional optimistic version check
- DELETE: proof-gated; cannot execute while FOC/RED/unproven
- accepted state classes remain `non_authoritative | derived_projection | pending_proposal`
- `constitutional_truth` and `authority_effect != none` fail closed

Distribution events carry `canonical=false`, `authority_effect=none`, and `transport_grants_authority=false`. Distribution failure rolls the projection back.

## Idempotency hardening
- exact canonical replay returns the prior receipt with no duplicate projection/distribution effect
- same idempotency key + changed governed request rejects collision
- legacy/KESSA compatibility callers now check the prior receipt **before** reconstructing CREATE/UPDATE, so a network retry cannot accidentally transform the original CREATE into a second UPDATE

## Compatibility
`SwfusPayload` and `SwfusHierarchy.execute(payload) -> bool` remain for legacy callers but traverse the canonical gates. KESSA no longer claims `SYNC_AZURE`; it consumes SWFUS receipts and reports actual bounded distribution state.

## Contracts
- `governance/kpgs-vnext/progressive-updates/README.md`
- `progressive-update.schema.json`
- dependency-free `validate.py`
- `tests/test_swfus_progressive_updates.py`
- vNext workflow validator + focused runtime proof + compile gate

## Validation — current head `0ba3364403acf1ec76df0740b652c1088d5ab741`
- KPGS vNext Contract Gate `32118898865` — PASS
- CodeQL Advanced `32118898839` — PASS (Actions/Rust/Python/JS-TS)
- Kopano CI Pipeline `32118898828` — PASS
  - CLI package check — PASS
  - GUI lint/build — PASS
  - Agent build POC + KPEFS Phases 0–5 — PASS
  - Python 3.11 compile/ruff/pytest — PASS
  - Python 3.12 compile/ruff/pytest — PASS

## Issue relationship
Shared substrate for #35, #38, #40, #45 and #46. This PR deliberately does not falsely close those larger epics.

## Merge posture
Validation complete and compatible with current `master` including merged #69.