### PR TITLE
feat(security): enforce short-lived capability leases and tenant isolation

### DIFF
--- a/.github/workflows/kpgs-vnext-phase0-gate.yml
+++ b/.github/workflows/kpgs-vnext-phase0-gate.yml
@@ -7,6 +7,7 @@ on:
       - "kopano-core/kopano/swfus_engine.py"
       - "kopano-core/kopano/kessa_mmao_api.py"
       - "tests/test_swfus_progressive_updates.py"
+      - "tests/test_capability_lease_runtime.py"
       - "CONTRIBUTING.md"
       - "THIRD_PARTY_NOTICES.md"
       - "LICENSE"
@@ -17,6 +18,7 @@ on:
       - "kopano-core/kopano/swfus_engine.py"
       - "kopano-core/kopano/kessa_mmao_api.py"
       - "tests/test_swfus_progressive_updates.py"
+      - "tests/test_capability_lease_runtime.py"
       - "CONTRIBUTING.md"
       - "THIRD_PARTY_NOTICES.md"
       - "LICENSE"
@@ -60,12 +62,20 @@ jobs:
       - name: Prove SWFUS runtime conformance
         run: python -m unittest discover -s tests -p 'test_swfus_progressive_updates.py' -v
 
-      - name: Compile validators and SWFUS runtime
+      - name: Validate capability lease authority contract
+        run: python governance/kpgs-vnext/security/validate_capability_lease.py
+
+      - name: Prove capability lease runtime conformance
+        run: python -m unittest discover -s tests -p 'test_capability_lease_runtime.py' -v
+
+      - name: Compile validators and governed runtimes
         run: >-
           python -m py_compile
           governance/kpgs-vnext/validate_phase0.py
           governance/kpgs-vnext/validate_contracts.py
           governance/kpgs-vnext/licensing/validate_license_policy.py
           governance/kpgs-vnext/progressive-updates/validate.py
+          governance/kpgs-vnext/security/validate_capability_lease.py
+          governance/kpgs-vnext/security/capability_lease.py
           kopano-core/kopano/swfus_engine.py
           kopano-core/kopano/kessa_mmao_api.py

--- a/governance/kpgs-vnext/README.md
+++ b/governance/kpgs-vnext/README.md
@@ -1,6 +1,6 @@
 # KPGS vNext — Sovereign Hub Re-engineering
 
-Status: **Phase 0 — Truth and Contracts**
+Status: **Phase 1 — Governance Substrate**
 Epic: #46
 
 KPGS vNext makes `Introduction-to-MCP` the canonical specification and governance layer for the Kopano DNS estate. Existing frontends may remain React/Next/Vite/PWA or other appropriate stacks; the canonical integration boundary is a governed domain adapter, Sovereign Hub, Stateless Renter protocol, skill runtime, realtime event plane and evidence system.
@@ -46,6 +46,8 @@ Tools / APIs / Domain Systems
 10. Newly discovered DNS properties remain `unwitnessed` until ownership and governance admission are validated.
 11. Availability, replication and synchronization MUST NOT be interpreted as authority.
 12. Mutating CRUD MUST NOT occur before invariant and POC/FOC governance has passed.
+13. Authentication establishes identity; privileged execution additionally requires a live, exact-scoped capability lease.
+14. Lease signing material and durable provider credentials MUST NOT be owned by a Stateless Renter or frontend.
 
 ## Control loops
 
@@ -79,15 +81,33 @@ CRUD mutates only admitted bounded state. SWFUS distributes/aligns the resulting
 
 See `progressive-updates/README.md` and `progressive-updates/progressive-update.schema.json`.
 
+### Capability authority
+
+```text
+authenticated identity
+  -> policy + governing specification
+  -> short-lived capability lease
+  -> exact tenant/domain/task/capability/resource check
+  -> sensitive operation nonce
+  -> execution
+  -> audit/evidence
+```
+
+The reference capability runtime is intentionally server-side. OIDC/JWT/session identity may exist upstream, but no identity token alone becomes ambient execution authority. Key rotation is resolved by the issuing authority through signed lease `kid` metadata; an Adaptive PWA does not need redeployment to rotate Sovereign Hub signing keys.
+
+See `security/CAPABILITY_LEASE.md`, `security/capability-lease.schema.json`, and `security/capability_lease.py`.
+
 ## Phase map
 
-- **Phase 0 — Truth and contracts:** fork assimilation, renter protocol, specification-first governance.
-- **Phase 1 — Governance substrate:** identity/capability leases, Sovereign Hub registry, evidence model.
+- **Phase 0 — Truth and contracts:** fork assimilation, renter protocol, specification-first governance. **Complete.**
+- **Phase 1 — Governance substrate:** identity/capability leases, Sovereign Hub registry, evidence model. **In progress.**
 - **Phase 2 — Runtime packages:** .NET domain adapter, skill runtime, realtime event plane.
 - **Phase 3 — Validation + human experience:** evaluation loop and Sovereign Everyday Mode.
 - **Phase 4 — Estate proof:** migrate one bounded low-risk workflow, prove rollback, then expand.
 
-## Phase 0 artifacts
+## Canonical artifacts
+
+### Phase 0 / shared substrate
 
 - `stateless-renter/PROTOCOL.md`
 - `stateless-renter/renter-envelope.schema.json`
@@ -100,6 +120,15 @@ See `progressive-updates/README.md` and `progressive-updates/progressive-update.
 - `task-contract/adapter.py`
 - `progressive-updates/README.md`
 - `progressive-updates/progressive-update.schema.json`
+
+### Phase 1 / governance substrate
+
+- `security/CAPABILITY_LEASE.md`
+- `security/capability-lease.schema.json`
+- `security/capability_lease.py`
+- `estate-registry/estate-registry.schema.json`
+- `estate-registry/estate.json`
+- `evidence/evidence-bundle.schema.json`
 
 ## Definition of done
 

--- a/governance/kpgs-vnext/security/CAPABILITY_LEASE.md
+++ b/governance/kpgs-vnext/security/CAPABILITY_LEASE.md
@@ -6,6 +6,8 @@ Issue: #42
 
 A capability lease is the temporary authority a Stateless Renter, domain adapter, skill or agent receives to perform a bounded action. Identity answers **who/what is acting**. The capability lease answers **what that actor may do, to which resource, for which tenant/domain/task, and until when**.
 
+The reference runtime is `capability_lease.py`. It is standard-library only and proves the lease semantics without requiring a frontend rewrite or placing signing authority inside a renter.
+
 ## Rules
 
 1. No privileged runtime receives ambient long-lived authority.
@@ -13,22 +15,51 @@ A capability lease is the temporary authority a Stateless Renter, domain adapter
 3. Lease scope is intersected with the governing specification and policy decision; it cannot broaden either.
 4. Expired or revoked leases fail closed.
 5. A lease may reference a secret provider or delegated credential, but MUST NOT embed durable plaintext secrets.
-6. Cross-tenant access is denied unless the lease explicitly names the additional tenant and policy permits it.
+6. Cross-tenant/domain/task access is denied when the requested scope does not exactly match the lease.
 7. Sensitive use of a lease emits audit/evidence records tied to the same correlation chain as the task.
+8. Each lease carries a unique lease nonce; each sensitive authorization requires a separate operation nonce so transport retries cannot silently duplicate side effects.
+9. Signing-key rotation changes the active server-side key while prior verification keys remain available only for already-issued live leases. Frontends do not own or rotate signing keys.
+10. Lease verification is not canonical business-state authority. It admits a bounded action to the next governed layer.
+
+## Identity boundary
+
+The compact reference token is a **KPGS lease envelope**, not a claim that KPGS has invented a new identity provider or a fully conformant JWT implementation.
+
+An upstream OIDC/JWT/session boundary may authenticate a subject. The Sovereign Hub/policy boundary then translates that authenticated identity plus policy/specification decision into a short-lived capability lease.
+
+```text
+OIDC / JWT / governed session identity
+        ↓
+policy + governing specification
+        ↓
+KPGS capability lease
+        ↓
+exact tenant/domain/task/resource authorization
+        ↓
+Stateless Renter / adapter / skill operation
+        ↓
+audit + evidence
+```
+
+The renter never receives the signing key ring.
 
 ## Required dimensions
 
-- subject: renter/adapter/skill/agent identity
+- subject: renter/adapter/skill/agent/human/service identity
 - tenant
 - domain
 - task
 - capabilities
-- resource scopes
+- exact resource scopes
 - issue/expiry timestamps
-- nonce or unique lease identifier
+- unique lease nonce
 - policy decision reference
 - governing specification reference
-- revocation status/reference
+- audit correlation + evidence reference
+- optional secret-provider references
+- revocation state managed by the issuing authority
+
+The JSON contract is `capability-lease.schema.json`.
 
 ## Capability examples
 
@@ -42,16 +73,108 @@ Bad capability scopes:
 
 - `admin`
 - `all-access`
+- `*`
+- wildcard resource scope `*`
 - a raw permanent API key exposed to the renter
+
+The reference runtime intentionally uses exact resource matches. Broader/pattern scope semantics require a separate policy decision rather than being inferred by the lease library.
+
+## Compact signed envelope
+
+The reference token has three URL-safe Base64 segments:
+
+```text
+<header>.<lease-payload>.<HMAC-SHA256 signature>
+```
+
+The protected header carries:
+
+- `typ=KPGS-LEASE`
+- `alg=HS256`
+- `kid=<server key id>`
+- `iss=<configured lease authority>`
+
+The payload is the machine-readable capability lease. The signature covers header + payload. Signature verification uses constant-time comparison.
+
+This format is intentionally small and auditable. Production deployments may replace the signing implementation with a hardware-backed/JWS/JWT-compatible service as long as the same KPGS scope, expiry, revocation, replay and evidence invariants remain intact.
+
+## Short-lived authority
+
+The reference authority enforces a maximum lease TTL before signing and verifies the same maximum again when consuming a token. A caller cannot extend a lease simply by editing the payload because the signature would fail.
+
+Time checks fail closed for:
+
+- expiration;
+- future/not-yet-active issuance;
+- non-positive lifetimes;
+- lifetimes exceeding configured KPGS policy.
+
+## Revocation
+
+The issuing authority maintains revocation state keyed by `lease_id`. Revocation requires a reason and evidence reference and emits a sanitized audit event.
+
+A revoked lease cannot authorize another action even if its cryptographic signature and expiry remain valid.
+
+## Replay resistance
+
+Two replay boundaries are separate:
+
+1. **Lease nonce** — unique identity material for the lease itself.
+2. **Operation nonce** — supplied for every sensitive authorization attempt and consumed only after tenant/domain/task/capability/resource checks pass.
+
+The same `(lease_id, operation_nonce)` pair cannot authorize twice.
+
+This protects side-effecting operations from duplicate transport delivery without pretending transport is authoritative state.
+
+## Key rotation
+
+`KeyRing.rotate(new_kid, new_key)` changes the key used for newly issued leases. Existing, non-expired leases continue to verify against their original `kid` while that old verification key remains in the ring.
+
+Operational rule:
+
+> Do not retire an old verification key until every lease signed by it has expired or been revoked.
+
+Because `kid` is inside the signed envelope header, a PWA/frontend does not require redeployment when the Sovereign Hub rotates signing keys.
+
+## Audit/evidence boundary
+
+Audit records contain reconstructable authorization metadata:
+
+- lease ID
+- subject ID/kind
+- tenant/domain/task
+- requested capability/resource
+- allow/deny outcome and reason class
+- correlation ID
+- evidence reference
+- signing key ID
+- timestamp
+
+They explicitly do **not** contain:
+
+- raw compact lease token
+- signing key bytes
+- secret-provider values
+- raw delegated credentials
+
+Secret provider fields in leases are URI-like references only, for example `vault://runtime/github-write`.
 
 ## Verification requirements
 
 A conformant implementation MUST prove:
 
+- valid exact-scope authorization;
 - expired lease rejection;
 - revoked lease rejection;
 - resource-scope enforcement;
-- tenant-scope enforcement;
+- tenant/domain/task-scope enforcement;
 - capability-scope enforcement;
+- signature-tamper rejection;
 - replay resistance for sensitive operations;
-- audit correlation without exposing secret material.
+- short-lived TTL enforcement;
+- ambient `admin`/`all-access`/wildcard rejection;
+- audit correlation without exposing secret material;
+- signing-key rotation while existing live leases remain verifiable;
+- retirement of an active key fails closed.
+
+These behaviors are exercised by `tests/test_capability_lease_runtime.py` and the KPGS vNext Contract Gate.

--- a/governance/kpgs-vnext/security/capability-lease.schema.json
+++ b/governance/kpgs-vnext/security/capability-lease.schema.json
@@ -13,8 +13,10 @@
     "capabilities",
     "issued_at",
     "expires_at",
+    "nonce",
     "policy_decision_ref",
-    "governing_spec_ref"
+    "governing_spec_ref",
+    "audit"
   ],
   "properties": {
     "lease_id": { "type": "string", "minLength": 8, "maxLength": 200 },
@@ -52,11 +54,17 @@
     "revocation_ref": { "type": "string", "minLength": 1 },
     "secret_provider_refs": {
       "type": "array",
-      "items": { "type": "string", "minLength": 1 }
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 5,
+        "pattern": "^[A-Za-z][A-Za-z0-9+.-]*://.+$"
+      }
     },
     "audit": {
       "type": "object",
       "additionalProperties": false,
+      "required": ["correlation_id", "evidence_ref"],
       "properties": {
         "correlation_id": { "type": "string", "minLength": 1 },
         "evidence_ref": { "type": "string", "minLength": 1 }

--- a/governance/kpgs-vnext/security/capability_lease.py
+++ b/governance/kpgs-vnext/security/capability_lease.py
@@ -1,0 +1,494 @@
+"""Reference KPGS capability-lease authority runtime.
+
+This module is intentionally standard-library only. It proves the governance
+semantics required by issue #42 without turning a Stateless Renter, frontend,
+or skill into a credential landlord.
+
+The compact token is a KPGS envelope, not a claim of JWT conformance. An
+OIDC/JWT identity boundary may translate an authenticated subject into this
+lease at the Sovereign Hub boundary. The signing key ring remains server-side.
+"""
+
+from __future__ import annotations
+
+from base64 import urlsafe_b64decode, urlsafe_b64encode
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+import hashlib
+import hmac
+import json
+import secrets
+from typing import Any, Callable, Iterable, Mapping
+
+TOKEN_TYPE = "KPGS-LEASE"
+TOKEN_ALG = "HS256"
+SUBJECT_KINDS = {"renter", "adapter", "skill", "agent", "human", "service"}
+FORBIDDEN_AMBIENT_CAPABILITIES = {"admin", "all-access", "*"}
+
+
+class LeaseError(Exception):
+    """Base class for fail-closed lease errors."""
+
+
+class LeaseSignatureError(LeaseError):
+    pass
+
+
+class LeaseExpired(LeaseError):
+    pass
+
+
+class LeaseRevoked(LeaseError):
+    pass
+
+
+class LeaseDenied(LeaseError):
+    pass
+
+
+class LeaseReplay(LeaseDenied):
+    pass
+
+
+@dataclass(frozen=True)
+class AuthorizationDecision:
+    lease_id: str
+    subject_id: str
+    subject_kind: str
+    tenant_id: str
+    domain_id: str
+    task_id: str
+    capability: str
+    resource_scope: str
+    correlation_id: str
+    key_id: str
+
+
+class KeyRing:
+    """Server-side signing/verification keys with explicit rotation.
+
+    Rotation switches the active signing key while retaining prior verification
+    keys until their leases have naturally expired. Frontends need no redeploy.
+    """
+
+    def __init__(self, keys: Mapping[str, bytes], active_key_id: str):
+        self._keys: dict[str, bytes] = {}
+        for key_id, key in keys.items():
+            self._validate_key(key_id, key)
+            self._keys[key_id] = bytes(key)
+        if active_key_id not in self._keys:
+            raise ValueError("active key id must exist in key ring")
+        self._active_key_id = active_key_id
+
+    @staticmethod
+    def _validate_key(key_id: str, key: bytes) -> None:
+        if not isinstance(key_id, str) or not key_id.strip():
+            raise ValueError("key id is required")
+        if not isinstance(key, (bytes, bytearray)) or len(key) < 32:
+            raise ValueError("signing keys must contain at least 32 bytes")
+
+    @property
+    def active_key_id(self) -> str:
+        return self._active_key_id
+
+    def rotate(self, key_id: str, key: bytes) -> None:
+        self._validate_key(key_id, key)
+        self._keys[key_id] = bytes(key)
+        self._active_key_id = key_id
+
+    def retire(self, key_id: str) -> None:
+        if key_id == self._active_key_id:
+            raise ValueError("active signing key cannot be retired")
+        self._keys.pop(key_id, None)
+
+    def sign(self, key_id: str, message: bytes) -> bytes:
+        key = self._keys.get(key_id)
+        if key is None:
+            raise LeaseSignatureError("unknown signing key")
+        return hmac.new(key, message, hashlib.sha256).digest()
+
+    def verify(self, key_id: str, message: bytes, signature: bytes) -> bool:
+        key = self._keys.get(key_id)
+        if key is None:
+            return False
+        expected = hmac.new(key, message, hashlib.sha256).digest()
+        return hmac.compare_digest(expected, signature)
+
+
+def _b64encode(value: bytes) -> str:
+    return urlsafe_b64encode(value).decode("ascii").rstrip("=")
+
+
+def _b64decode(value: str) -> bytes:
+    padding = "=" * (-len(value) % 4)
+    try:
+        return urlsafe_b64decode(value + padding)
+    except Exception as exc:
+        raise LeaseSignatureError("invalid compact-token encoding") from exc
+
+
+def _canonical_json(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+
+
+def _iso8601(value: datetime) -> str:
+    normalized = value.astimezone(timezone.utc).replace(microsecond=0)
+    return normalized.isoformat().replace("+00:00", "Z")
+
+
+def _parse_time(value: Any, field_name: str) -> datetime:
+    if not isinstance(value, str):
+        raise LeaseDenied(f"{field_name} must be an ISO-8601 timestamp")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise LeaseDenied(f"{field_name} is invalid") from exc
+    if parsed.tzinfo is None:
+        raise LeaseDenied(f"{field_name} must include timezone")
+    return parsed.astimezone(timezone.utc)
+
+
+class CapabilityLeaseAuthority:
+    """Issue, verify, revoke and authorize short-lived capability leases."""
+
+    def __init__(
+        self,
+        key_ring: KeyRing,
+        *,
+        issuer: str = "kpgs-sovereign-hub",
+        max_ttl_seconds: int = 900,
+        clock: Callable[[], datetime] | None = None,
+    ):
+        if max_ttl_seconds <= 0:
+            raise ValueError("max_ttl_seconds must be positive")
+        self.key_ring = key_ring
+        self.issuer = issuer
+        self.max_ttl_seconds = max_ttl_seconds
+        self._clock = clock or (lambda: datetime.now(timezone.utc))
+        self._revocations: dict[str, dict[str, str]] = {}
+        self._operation_nonces: set[tuple[str, str]] = set()
+        self._issued_nonces: set[str] = set()
+        self._audit_log: list[dict[str, Any]] = []
+
+    @staticmethod
+    def _validate_capabilities(capabilities: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
+        normalized: list[dict[str, Any]] = []
+        for item in capabilities:
+            name = item.get("name")
+            resource_scope = item.get("resource_scope")
+            constraints = item.get("constraints", [])
+            if not isinstance(name, str) or len(name.strip()) < 3:
+                raise LeaseDenied("capability name is required")
+            if name in FORBIDDEN_AMBIENT_CAPABILITIES:
+                raise LeaseDenied("ambient capability names are forbidden")
+            if not isinstance(resource_scope, str) or not resource_scope.strip():
+                raise LeaseDenied("resource scope is required")
+            if resource_scope.strip() == "*":
+                raise LeaseDenied("wildcard resource scope is forbidden")
+            if not isinstance(constraints, list) or not all(
+                isinstance(value, str) and value.strip() for value in constraints
+            ):
+                raise LeaseDenied("capability constraints must be non-empty strings")
+            normalized.append(
+                {
+                    "name": name.strip(),
+                    "resource_scope": resource_scope.strip(),
+                    "constraints": list(constraints),
+                }
+            )
+        if not normalized:
+            raise LeaseDenied("at least one capability is required")
+        return normalized
+
+    @staticmethod
+    def _validate_secret_provider_refs(refs: Iterable[str]) -> list[str]:
+        normalized: list[str] = []
+        for ref in refs:
+            if not isinstance(ref, str) or "://" not in ref:
+                raise LeaseDenied(
+                    "secret provider references must be URI-like references, not raw secret material"
+                )
+            normalized.append(ref)
+        return normalized
+
+    def _new_nonce(self) -> str:
+        while True:
+            nonce = secrets.token_urlsafe(18)
+            if nonce not in self._issued_nonces:
+                self._issued_nonces.add(nonce)
+                return nonce
+
+    def _record_audit(
+        self,
+        *,
+        event: str,
+        outcome: str,
+        reason: str,
+        lease: Mapping[str, Any] | None = None,
+        capability: str | None = None,
+        resource_scope: str | None = None,
+        correlation_id: str = "",
+        evidence_ref: str = "",
+        key_id: str = "",
+    ) -> None:
+        subject = lease.get("subject", {}) if lease else {}
+        self._audit_log.append(
+            {
+                "schema": "kpgs.capability-audit.v1",
+                "event": event,
+                "outcome": outcome,
+                "reason": reason,
+                "lease_id": lease.get("lease_id") if lease else None,
+                "subject_id": subject.get("id") if isinstance(subject, dict) else None,
+                "subject_kind": subject.get("kind") if isinstance(subject, dict) else None,
+                "tenant_id": lease.get("tenant_id") if lease else None,
+                "domain_id": lease.get("domain_id") if lease else None,
+                "task_id": lease.get("task_id") if lease else None,
+                "capability": capability,
+                "resource_scope": resource_scope,
+                "correlation_id": correlation_id,
+                "evidence_ref": evidence_ref,
+                "key_id": key_id,
+                "at": _iso8601(self._clock()),
+            }
+        )
+
+    def issue(
+        self,
+        *,
+        subject_id: str,
+        subject_kind: str,
+        tenant_id: str,
+        domain_id: str,
+        task_id: str,
+        capabilities: Iterable[Mapping[str, Any]],
+        policy_decision_ref: str,
+        governing_spec_ref: str,
+        ttl_seconds: int = 300,
+        secret_provider_refs: Iterable[str] = (),
+        correlation_id: str = "",
+        evidence_ref: str = "",
+    ) -> str:
+        if subject_kind not in SUBJECT_KINDS:
+            raise LeaseDenied("unsupported subject kind")
+        for label, value in {
+            "subject_id": subject_id,
+            "tenant_id": tenant_id,
+            "domain_id": domain_id,
+            "task_id": task_id,
+            "policy_decision_ref": policy_decision_ref,
+            "governing_spec_ref": governing_spec_ref,
+        }.items():
+            if not isinstance(value, str) or not value.strip():
+                raise LeaseDenied(f"{label} is required")
+        if ttl_seconds <= 0 or ttl_seconds > self.max_ttl_seconds:
+            raise LeaseDenied("lease TTL exceeds the short-lived authority boundary")
+
+        issued_at = self._clock().astimezone(timezone.utc)
+        expires_at = issued_at + timedelta(seconds=ttl_seconds)
+        lease_id = "lease_" + secrets.token_urlsafe(18)
+        nonce = self._new_nonce()
+        capability_list = self._validate_capabilities(capabilities)
+        provider_refs = self._validate_secret_provider_refs(secret_provider_refs)
+
+        payload: dict[str, Any] = {
+            "lease_id": lease_id,
+            "subject": {"id": subject_id, "kind": subject_kind},
+            "tenant_id": tenant_id,
+            "domain_id": domain_id,
+            "task_id": task_id,
+            "capabilities": capability_list,
+            "issued_at": _iso8601(issued_at),
+            "expires_at": _iso8601(expires_at),
+            "nonce": nonce,
+            "policy_decision_ref": policy_decision_ref,
+            "governing_spec_ref": governing_spec_ref,
+            "secret_provider_refs": provider_refs,
+            "audit": {
+                "correlation_id": correlation_id or f"corr:{lease_id}",
+                "evidence_ref": evidence_ref or f"evidence:{lease_id}",
+            },
+        }
+        token = self._encode(payload)
+        self._record_audit(
+            event="lease-issued",
+            outcome="allow",
+            reason="short-lived scoped lease issued",
+            lease=payload,
+            correlation_id=payload["audit"]["correlation_id"],
+            evidence_ref=payload["audit"]["evidence_ref"],
+            key_id=self.key_ring.active_key_id,
+        )
+        return token
+
+    def _encode(self, payload: Mapping[str, Any]) -> str:
+        header = {
+            "alg": TOKEN_ALG,
+            "typ": TOKEN_TYPE,
+            "kid": self.key_ring.active_key_id,
+            "iss": self.issuer,
+        }
+        encoded_header = _b64encode(_canonical_json(header))
+        encoded_payload = _b64encode(_canonical_json(payload))
+        signing_input = f"{encoded_header}.{encoded_payload}".encode("ascii")
+        signature = self.key_ring.sign(self.key_ring.active_key_id, signing_input)
+        return f"{encoded_header}.{encoded_payload}.{_b64encode(signature)}"
+
+    def verify(self, token: str) -> tuple[dict[str, Any], str]:
+        if not isinstance(token, str) or len(token) > 32_768:
+            raise LeaseSignatureError("invalid lease token")
+        parts = token.split(".")
+        if len(parts) != 3:
+            raise LeaseSignatureError("invalid compact lease token")
+        encoded_header, encoded_payload, encoded_signature = parts
+        try:
+            header = json.loads(_b64decode(encoded_header))
+            payload = json.loads(_b64decode(encoded_payload))
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            raise LeaseSignatureError("lease token JSON is invalid") from exc
+        if not isinstance(header, dict) or not isinstance(payload, dict):
+            raise LeaseSignatureError("lease token envelope is invalid")
+        if header.get("alg") != TOKEN_ALG or header.get("typ") != TOKEN_TYPE:
+            raise LeaseSignatureError("unsupported lease token algorithm/type")
+        if header.get("iss") != self.issuer:
+            raise LeaseSignatureError("lease issuer mismatch")
+        key_id = header.get("kid")
+        if not isinstance(key_id, str) or not key_id:
+            raise LeaseSignatureError("lease key id is missing")
+        signing_input = f"{encoded_header}.{encoded_payload}".encode("ascii")
+        signature = _b64decode(encoded_signature)
+        if not self.key_ring.verify(key_id, signing_input, signature):
+            raise LeaseSignatureError("lease signature verification failed")
+
+        issued_at = _parse_time(payload.get("issued_at"), "issued_at")
+        expires_at = _parse_time(payload.get("expires_at"), "expires_at")
+        now = self._clock().astimezone(timezone.utc)
+        ttl = (expires_at - issued_at).total_seconds()
+        if ttl <= 0 or ttl > self.max_ttl_seconds:
+            raise LeaseDenied("lease lifetime violates short-lived authority policy")
+        if now < issued_at:
+            raise LeaseDenied("lease is not active yet")
+        if now >= expires_at:
+            raise LeaseExpired("lease expired")
+
+        lease_id = payload.get("lease_id")
+        if not isinstance(lease_id, str) or not lease_id:
+            raise LeaseDenied("lease identity is missing")
+        if lease_id in self._revocations:
+            raise LeaseRevoked("lease revoked")
+        nonce = payload.get("nonce")
+        if not isinstance(nonce, str) or len(nonce) < 8:
+            raise LeaseDenied("lease nonce is missing")
+        return payload, key_id
+
+    def authorize(
+        self,
+        token: str,
+        *,
+        tenant_id: str,
+        domain_id: str,
+        task_id: str,
+        capability: str,
+        resource_scope: str,
+        operation_nonce: str,
+        correlation_id: str,
+    ) -> AuthorizationDecision:
+        lease: dict[str, Any] | None = None
+        key_id = ""
+        try:
+            lease, key_id = self.verify(token)
+            expected = {
+                "tenant_id": tenant_id,
+                "domain_id": domain_id,
+                "task_id": task_id,
+            }
+            for field_name, value in expected.items():
+                if lease.get(field_name) != value:
+                    raise LeaseDenied(f"{field_name} scope mismatch")
+
+            admitted = any(
+                item.get("name") == capability
+                and item.get("resource_scope") == resource_scope
+                for item in lease.get("capabilities", [])
+                if isinstance(item, dict)
+            )
+            if not admitted:
+                raise LeaseDenied("capability/resource scope denied")
+            if not isinstance(operation_nonce, str) or len(operation_nonce) < 8:
+                raise LeaseDenied("operation nonce is required")
+
+            replay_key = (lease["lease_id"], operation_nonce)
+            if replay_key in self._operation_nonces:
+                raise LeaseReplay("operation nonce replay detected")
+            self._operation_nonces.add(replay_key)
+
+            audit = lease.get("audit", {})
+            evidence_ref = audit.get("evidence_ref", "") if isinstance(audit, dict) else ""
+            self._record_audit(
+                event="capability-used",
+                outcome="allow",
+                reason="lease and exact resource scope admitted",
+                lease=lease,
+                capability=capability,
+                resource_scope=resource_scope,
+                correlation_id=correlation_id,
+                evidence_ref=evidence_ref,
+                key_id=key_id,
+            )
+            subject = lease["subject"]
+            return AuthorizationDecision(
+                lease_id=lease["lease_id"],
+                subject_id=subject["id"],
+                subject_kind=subject["kind"],
+                tenant_id=tenant_id,
+                domain_id=domain_id,
+                task_id=task_id,
+                capability=capability,
+                resource_scope=resource_scope,
+                correlation_id=correlation_id,
+                key_id=key_id,
+            )
+        except LeaseError as exc:
+            self._record_audit(
+                event="capability-used",
+                outcome="deny",
+                reason=type(exc).__name__,
+                lease=lease,
+                capability=capability,
+                resource_scope=resource_scope,
+                correlation_id=correlation_id,
+                key_id=key_id,
+            )
+            raise
+
+    def revoke(self, token_or_lease_id: str, *, reason: str, evidence_ref: str) -> str:
+        if not reason.strip() or not evidence_ref.strip():
+            raise LeaseDenied("revocation requires reason and evidence reference")
+        lease: dict[str, Any] | None = None
+        key_id = ""
+        lease_id = token_or_lease_id
+        if "." in token_or_lease_id:
+            lease, key_id = self.verify(token_or_lease_id)
+            lease_id = lease["lease_id"]
+        self._revocations[lease_id] = {
+            "reason": reason,
+            "evidence_ref": evidence_ref,
+            "revoked_at": _iso8601(self._clock()),
+        }
+        self._record_audit(
+            event="lease-revoked",
+            outcome="allow",
+            reason=reason,
+            lease=lease or {"lease_id": lease_id},
+            evidence_ref=evidence_ref,
+            key_id=key_id,
+        )
+        return lease_id
+
+    def audit_events(self) -> tuple[dict[str, Any], ...]:
+        return tuple(dict(event) for event in self._audit_log)

--- a/governance/kpgs-vnext/security/validate_capability_lease.py
+++ b/governance/kpgs-vnext/security/validate_capability_lease.py
@@ -1,0 +1,115 @@
+"""Dependency-free validator for the executable KPGS capability lease boundary."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import importlib.util
+import json
+from pathlib import Path
+import sys
+
+HERE = Path(__file__).resolve().parent
+SCHEMA = HERE / "capability-lease.schema.json"
+RUNTIME = HERE / "capability_lease.py"
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise SystemExit(f"KPGS-LEASE FAIL: {message}")
+
+
+def load_runtime():
+    spec = importlib.util.spec_from_file_location("kpgs_lease_validator_runtime", RUNTIME)
+    require(spec is not None and spec.loader is not None, "lease runtime cannot load")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def main() -> None:
+    schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+    required = set(schema.get("required", []))
+    require("nonce" in required, "lease nonce must be structurally required")
+    require("audit" in required, "lease audit correlation must be structurally required")
+    audit_required = set(schema["properties"]["audit"].get("required", []))
+    require(
+        {"correlation_id", "evidence_ref"} <= audit_required,
+        "audit must preserve correlation and evidence refs",
+    )
+    secret_pattern = schema["properties"]["secret_provider_refs"]["items"].get("pattern", "")
+    require("://" in secret_pattern, "secret provider refs must remain URI-like references")
+
+    runtime = load_runtime()
+    fixed_now = datetime(2026, 8, 18, 9, 0, tzinfo=timezone.utc)
+    ring = runtime.KeyRing({"validator-k1": b"k" * 32}, "validator-k1")
+    authority = runtime.CapabilityLeaseAuthority(
+        ring,
+        clock=lambda: fixed_now,
+        max_ttl_seconds=300,
+    )
+    token = authority.issue(
+        subject_id="renter:validator",
+        subject_kind="renter",
+        tenant_id="tenant:validator",
+        domain_id="KopanoLabs.com",
+        task_id="task:validator",
+        capabilities=[
+            {
+                "name": "estate.registry.read",
+                "resource_scope": "estate:kopano-labs",
+            }
+        ],
+        policy_decision_ref="policy://validator/allow",
+        governing_spec_ref="spec://validator/v1",
+        ttl_seconds=120,
+        secret_provider_refs=("vault://validator/reference",),
+        correlation_id="corr:validator",
+        evidence_ref="evidence://validator/lease",
+    )
+    decision = authority.authorize(
+        token,
+        tenant_id="tenant:validator",
+        domain_id="KopanoLabs.com",
+        task_id="task:validator",
+        capability="estate.registry.read",
+        resource_scope="estate:kopano-labs",
+        operation_nonce="validator-operation-001",
+        correlation_id="corr:validator-use",
+    )
+    require(decision.key_id == "validator-k1", "lease key id was not verified")
+
+    try:
+        authority.authorize(
+            token,
+            tenant_id="tenant:other",
+            domain_id="KopanoLabs.com",
+            task_id="task:validator",
+            capability="estate.registry.read",
+            resource_scope="estate:kopano-labs",
+            operation_nonce="validator-operation-002",
+            correlation_id="corr:validator-deny",
+        )
+    except runtime.LeaseDenied:
+        pass
+    else:
+        raise SystemExit("KPGS-LEASE FAIL: cross-tenant request was admitted")
+
+    audit_text = json.dumps(authority.audit_events(), sort_keys=True)
+    require(token not in audit_text, "raw lease token leaked into audit")
+    require("vault://validator/reference" not in audit_text, "secret-provider reference leaked into use audit")
+    require("kkkkkkkk" not in audit_text, "signing material leaked into audit")
+
+    ring.rotate("validator-k2", b"z" * 32)
+    old_payload, old_kid = authority.verify(token)
+    require(old_payload["lease_id"] == decision.lease_id, "old live lease changed after rotation")
+    require(old_kid == "validator-k1", "old live lease did not retain its original key id")
+
+    print(
+        "KPGS-LEASE PASS: short-lived signed authority is exact-scoped, "
+        "replay/revocation-ready, auditable and rotation-safe."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_capability_lease_runtime.py
+++ b/tests/test_capability_lease_runtime.py
@@ -1,0 +1,212 @@
+import importlib.util
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+import sys
+import unittest
+
+MODULE_PATH = (
+    Path(__file__).parents[1]
+    / "governance"
+    / "kpgs-vnext"
+    / "security"
+    / "capability_lease.py"
+)
+spec = importlib.util.spec_from_file_location("kpgs_capability_lease", MODULE_PATH)
+mod = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+sys.modules[spec.name] = mod
+spec.loader.exec_module(mod)
+
+
+class MutableClock:
+    def __init__(self):
+        self.now = datetime(2026, 8, 18, 9, 0, tzinfo=timezone.utc)
+
+    def __call__(self):
+        return self.now
+
+    def advance(self, seconds):
+        self.now += timedelta(seconds=seconds)
+
+
+class CapabilityLeaseRuntimeTests(unittest.TestCase):
+    def setUp(self):
+        self.clock = MutableClock()
+        self.keys = mod.KeyRing({"k1": b"a" * 32}, "k1")
+        self.authority = mod.CapabilityLeaseAuthority(
+            self.keys,
+            clock=self.clock,
+            max_ttl_seconds=600,
+        )
+
+    def issue(self, **overrides):
+        payload = dict(
+            subject_id="renter:alpha",
+            subject_kind="renter",
+            tenant_id="tenant:kopano",
+            domain_id="FivesArena.com",
+            task_id="task:weather-read",
+            capabilities=[
+                {
+                    "name": "estate.registry.read",
+                    "resource_scope": "estate:kopano-labs",
+                    "constraints": ["read-only"],
+                },
+                {
+                    "name": "domain.weather.read",
+                    "resource_scope": "FivesArena.com:province-context",
+                },
+            ],
+            policy_decision_ref="policy://kpgs/allow/001",
+            governing_spec_ref="spec://kpgs/task/weather-read/v1",
+            ttl_seconds=300,
+            secret_provider_refs=("vault://runtime/fivesarena-weather",),
+            correlation_id="corr:lease-test",
+            evidence_ref="evidence://lease/001",
+        )
+        payload.update(overrides)
+        return self.authority.issue(**payload)
+
+    def authorize(self, token, **overrides):
+        payload = dict(
+            tenant_id="tenant:kopano",
+            domain_id="FivesArena.com",
+            task_id="task:weather-read",
+            capability="estate.registry.read",
+            resource_scope="estate:kopano-labs",
+            operation_nonce="operation-001",
+            correlation_id="corr:use-001",
+        )
+        payload.update(overrides)
+        return self.authority.authorize(token, **payload)
+
+    def test_scoped_lease_authorizes_exact_capability_and_resource(self):
+        token = self.issue()
+        decision = self.authorize(token)
+        self.assertEqual(decision.subject_id, "renter:alpha")
+        self.assertEqual(decision.tenant_id, "tenant:kopano")
+        self.assertEqual(decision.capability, "estate.registry.read")
+        self.assertEqual(decision.resource_scope, "estate:kopano-labs")
+        self.assertEqual(decision.key_id, "k1")
+
+    def test_cross_tenant_domain_task_and_resource_mismatches_fail_closed(self):
+        cases = [
+            {"tenant_id": "tenant:other"},
+            {"domain_id": "KasiLink.com"},
+            {"task_id": "task:other"},
+            {"resource_scope": "estate:other"},
+            {"capability": "estate.registry.write"},
+        ]
+        for index, override in enumerate(cases):
+            token = self.issue()
+            with self.subTest(override=override):
+                with self.assertRaises(mod.LeaseDenied):
+                    self.authorize(
+                        token,
+                        operation_nonce=f"deny-{index:04d}",
+                        **override,
+                    )
+
+    def test_expired_lease_fails_closed(self):
+        token = self.issue(ttl_seconds=60)
+        self.clock.advance(61)
+        with self.assertRaises(mod.LeaseExpired):
+            self.authorize(token)
+
+    def test_revoked_lease_fails_closed(self):
+        token = self.issue()
+        lease_id = self.authority.revoke(
+            token,
+            reason="task cancelled",
+            evidence_ref="evidence://revocation/001",
+        )
+        self.assertTrue(lease_id.startswith("lease_"))
+        with self.assertRaises(mod.LeaseRevoked):
+            self.authorize(token)
+
+    def test_operation_nonce_replay_is_rejected_without_second_allow(self):
+        token = self.issue()
+        first = self.authorize(token, operation_nonce="same-operation")
+        self.assertEqual(first.capability, "estate.registry.read")
+        with self.assertRaises(mod.LeaseReplay):
+            self.authorize(token, operation_nonce="same-operation")
+        allowed = [
+            event
+            for event in self.authority.audit_events()
+            if event["event"] == "capability-used" and event["outcome"] == "allow"
+        ]
+        self.assertEqual(len(allowed), 1)
+
+    def test_signature_tamper_is_rejected(self):
+        token = self.issue()
+        parts = token.split(".")
+        replacement = "A" if parts[1][-1] != "A" else "B"
+        tampered = f"{parts[0]}.{parts[1][:-1]}{replacement}.{parts[2]}"
+        with self.assertRaises(mod.LeaseSignatureError):
+            self.authorize(tampered)
+
+    def test_key_rotation_needs_no_frontend_redeploy_and_preserves_live_old_lease(self):
+        old_token = self.issue()
+        self.keys.rotate("k2", b"b" * 32)
+        new_token = self.issue(task_id="task:weather-read")
+
+        old_decision = self.authorize(
+            old_token,
+            operation_nonce="old-key-use",
+        )
+        new_decision = self.authorize(
+            new_token,
+            operation_nonce="new-key-use",
+        )
+        self.assertEqual(old_decision.key_id, "k1")
+        self.assertEqual(new_decision.key_id, "k2")
+
+    def test_short_lived_boundary_and_ambient_scope_are_enforced(self):
+        with self.assertRaises(mod.LeaseDenied):
+            self.issue(ttl_seconds=601)
+        with self.assertRaises(mod.LeaseDenied):
+            self.issue(
+                capabilities=[
+                    {"name": "admin", "resource_scope": "estate:kopano-labs"}
+                ]
+            )
+        with self.assertRaises(mod.LeaseDenied):
+            self.issue(
+                capabilities=[
+                    {"name": "estate.registry.read", "resource_scope": "*"}
+                ]
+            )
+
+    def test_secret_provider_refs_are_references_not_raw_credentials(self):
+        with self.assertRaises(mod.LeaseDenied):
+            self.issue(secret_provider_refs=("sk-proj-this-is-not-a-reference",))
+        token = self.issue(secret_provider_refs=("vault://runtime/reference-only",))
+        lease, _ = self.authority.verify(token)
+        self.assertEqual(
+            lease["secret_provider_refs"],
+            ["vault://runtime/reference-only"],
+        )
+
+    def test_audit_reconstructs_sensitive_use_without_token_or_secret_material(self):
+        token = self.issue()
+        decision = self.authorize(token)
+        events = self.authority.audit_events()
+        use_event = next(
+            event
+            for event in events
+            if event["event"] == "capability-used" and event["outcome"] == "allow"
+        )
+        self.assertEqual(use_event["lease_id"], decision.lease_id)
+        self.assertEqual(use_event["tenant_id"], "tenant:kopano")
+        self.assertEqual(use_event["domain_id"], "FivesArena.com")
+        self.assertEqual(use_event["task_id"], "task:weather-read")
+        self.assertEqual(use_event["capability"], "estate.registry.read")
+        self.assertEqual(use_event["resource_scope"], "estate:kopano-labs")
+        serialized = repr(events)
+        self.assertNotIn(token, serialized)
+        self.assertNotIn("vault://runtime/fivesarena-weather", serialized)
+        self.assertNotIn("aaaaaaaa", serialized)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #42.

## Existing contract extended, not replaced
`governance/kpgs-vnext/security/capability-lease.schema.json` and `CAPABILITY_LEASE.md` already defined lease dimensions and policy. This PR supplies the missing executable authority runtime on top of canonical master, which includes the merged APU → CRUD → SWFUS substrate.

## Runtime
Adds standard-library `security/capability_lease.py`:
- short-lived signed KPGS compact lease envelope (HMAC-SHA256 reference implementation)
- server-side key ring with `kid` rotation
- exact tenant / domain / task binding
- exact capability + resource scope admission
- no ambient `admin`, `all-access` or wildcard resource authority
- lease nonce + per-sensitive-operation nonce replay protection
- expiry and not-yet-active checks
- explicit revocation with evidence reference
- URI-like secret-provider references only; no raw credentials
- sanitized audit/evidence chain without token, signing material or secret-provider values
- key rotation keeps already-issued live leases verifiable while old verification keys are intentionally retained until lease expiry/revocation

The compact envelope is **not represented as a new identity provider or full JWT implementation**. OIDC/JWT/session identity may authenticate a subject upstream; the Sovereign Hub/policy boundary translates that identity into the bounded KPGS lease.

## Machine-contract hardening
The capability lease schema structurally requires:
- `nonce`
- `audit`
- audit `correlation_id`
- audit `evidence_ref`
- URI-shaped `secret_provider_refs`

## Negative proof
`tests/test_capability_lease_runtime.py` proves exact-scope allow; cross-tenant/domain/task/resource/capability deny; expiry; revocation; operation replay rejection; signature tamper rejection; max-TTL boundary; ambient/wildcard deny; audit reconstruction without token/key/secret leakage; and signing-key rotation without frontend redeploy.

## Validation — current head `30e0cf817f4a2f01e849bd3a154b5dab4a5665c3`
- KPGS vNext Contract Gate `32119733885` — PASS
  - Phase 0 truth — PASS
  - governance substrate — PASS
  - licensing — PASS
  - APU/CRUD/SWFUS validator + tests — PASS
  - capability lease validator + runtime tests — PASS
  - governed runtime compilation — PASS
- CodeQL Advanced `32119733933` — PASS
- Kopano CI Pipeline `32119733796` — PASS
  - CLI package check — PASS
  - GUI lint/build — PASS
  - Agent build POC + KPEFS — PASS
  - Python 3.11 compile/ruff/pytest — PASS
  - Python 3.12 compile/ruff/pytest — PASS

## Authority law
A valid lease admits a bounded operation to the next governed layer. It does not itself become canonical business state, and no Stateless Renter or frontend receives the signing key ring.

## Merge posture
Validation complete; ready for canonical Phase‑1 promotion.