### PR TITLE
feat(hub): execute the Sovereign DNS estate registry control plane

### DIFF
--- a/.github/workflows/kpgs-vnext-phase0-gate.yml
+++ b/.github/workflows/kpgs-vnext-phase0-gate.yml
@@ -8,6 +8,7 @@ on:
       - "kopano-core/kopano/kessa_mmao_api.py"
       - "tests/test_swfus_progressive_updates.py"
       - "tests/test_capability_lease_runtime.py"
+      - "tests/test_sovereign_estate_registry.py"
       - "CONTRIBUTING.md"
       - "THIRD_PARTY_NOTICES.md"
       - "LICENSE"
@@ -19,6 +20,7 @@ on:
       - "kopano-core/kopano/kessa_mmao_api.py"
       - "tests/test_swfus_progressive_updates.py"
       - "tests/test_capability_lease_runtime.py"
+      - "tests/test_sovereign_estate_registry.py"
       - "CONTRIBUTING.md"
       - "THIRD_PARTY_NOTICES.md"
       - "LICENSE"
@@ -36,7 +38,7 @@ jobs:
   truth-contracts:
     name: Validate KPGS truth and governance contracts
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 6
 
     steps:
       - name: Checkout
@@ -68,6 +70,12 @@ jobs:
       - name: Prove capability lease runtime conformance
         run: python -m unittest discover -s tests -p 'test_capability_lease_runtime.py' -v
 
+      - name: Validate sovereign estate registry contract
+        run: python governance/kpgs-vnext/estate-registry/validate_registry.py
+
+      - name: Prove sovereign estate registry conformance
+        run: python -m unittest discover -s tests -p 'test_sovereign_estate_registry.py' -v
+
       - name: Compile validators and governed runtimes
         run: >-
           python -m py_compile
@@ -77,5 +85,7 @@ jobs:
           governance/kpgs-vnext/progressive-updates/validate.py
           governance/kpgs-vnext/security/validate_capability_lease.py
           governance/kpgs-vnext/security/capability_lease.py
+          governance/kpgs-vnext/estate-registry/validate_registry.py
+          governance/kpgs-vnext/estate-registry/registry.py
           kopano-core/kopano/swfus_engine.py
           kopano-core/kopano/kessa_mmao_api.py

--- a/governance/kpgs-vnext/estate-registry/README.md
+++ b/governance/kpgs-vnext/estate-registry/README.md
@@ -1,0 +1,166 @@
+# KPGS Sovereign Hub DNS Estate Registry
+
+Issue: #35
+
+The estate registry is canonical KPGS control-plane state for governed DNS properties. It does not discover authority by guessing, and it does not promote a repository, deployment or DNS name merely because a connector can see it.
+
+## Canonical workflow
+
+```text
+discover
+  -> unwitnessed review queue
+  -> witness
+  -> classify
+  -> register
+  -> adapt
+  -> verify
+  -> staging
+  -> production
+  -> observe
+  -> rollback | suspend | decommission
+```
+
+The reference runtime is `registry.py`.
+
+## Discovery law
+
+Unknown assets discovered through authorized sources become **candidates**, not registry properties.
+
+Accepted provenance kinds:
+
+- registrar
+- DNS
+- deployment
+- repository
+- domain-control
+- other explicitly governed evidence
+
+A candidate is deduplicated case-insensitively by DNS name while preserving multiple provenance observations. Duplicate discovery never creates multiple registry identities.
+
+Candidate states:
+
+```text
+unwitnessed -> witnessed -> classified -> registered
+       \                         
+        -> rejected
+```
+
+The machine contract is `discovery-candidate.schema.json`.
+
+## Initial estate truth
+
+`estate.json` intentionally keeps the six initial properties at `declared_pending_witness` until authoritative witness evidence is supplied:
+
+- `KasiLink.com`
+- `FivesArena.com`
+- `starfallsalvage.kopanolabs.com`
+- `crisisconnect.kopanolabs.com`
+- `KopanoLabs.com`
+- `KRRababalela.com`
+
+The runtime does not silently enrich or promote these records from memory, public search or unrelated connector visibility.
+
+## Capability-lease boundary
+
+Every mutation consumes the executable Phase‑1 capability lease runtime from issue #42. Typical capabilities are:
+
+- `estate.discovery.write` on `estate:<estate_id>`
+- `estate.registry.witness` on `dns:<domain>`
+- `estate.registry.classify` on `dns:<domain>`
+- `estate.registry.write` on `dns:<domain>`
+- `estate.release.transition` on `dns:<domain>`
+- `estate.release.rollback` on `dns:<domain>`
+
+Tenant, Hub domain, task, capability and resource scope must all match the lease. Each operation also requires a unique operation nonce.
+
+## Registration completeness
+
+A property cannot enter `registered` without:
+
+- ownership witness evidence;
+- owner reference;
+- at least one repository;
+- deployment provider + target;
+- adapter declaration;
+- Stateless Renter compatibility state;
+- governance policy, risk class and tier;
+- at least one granted capability;
+- at least one health/evidence endpoint;
+- secret-provider references represented as references only, never raw secrets.
+
+The registry schema also supports skills and named staging/production deployment environments.
+
+## Release state transitions
+
+General admitted transitions:
+
+```text
+registered -> staging | suspended | decommissioned
+staging    -> production | registered | suspended
+production -> staging | suspended
+suspended  -> registered | decommissioned
+decommissioned -> terminal
+```
+
+`declared_pending_witness -> witnessed` and `witnessed -> registered` use dedicated witness/registration operations so the runtime can enforce their stronger evidence requirements.
+
+### Production promotion
+
+Promotion from staging to production requires all of:
+
+- live release reference;
+- deployment/evidence reference;
+- rollback target reference;
+- rollback procedure reference.
+
+No release receipt means no production transition.
+
+### Rollback
+
+Rollback is an explicit governed action. A production property with a valid rollback target/procedure moves back to `staging` with its live reference set to the rollback target. It must be verified again before another production promotion.
+
+## Realtime / SWFUS relationship
+
+Registry mutation is canonical control-plane authority **after a valid capability lease admits the operation**.
+
+A registry event may then be emitted to the realtime plane / SWFUS for projection alignment. If that transport is unavailable:
+
+- the canonical registry commit remains valid;
+- the event records `distribution_status=unavailable`;
+- transport is explicitly marked `transport_grants_authority=false`.
+
+This preserves the vNext law:
+
+> **Availability and synchronization are not authority.**
+
+The event plane may later replay the missed projection from canonical registry/evidence state.
+
+## Plain-language Hub answers
+
+`explain_property(domain)` answers the operational questions without requiring an operator to inspect raw JSON:
+
+- what property is this and what lifecycle state is it in?
+- which repositories back it?
+- where is it deployed?
+- what adapter version is declared?
+- is it Stateless-Renter compatible?
+- which governance policy applies?
+- what live release is recorded?
+- what rollback target is available?
+
+Unknown values are stated as **not witnessed / not promoted / not recorded** rather than inferred.
+
+## Proof
+
+`tests/test_sovereign_estate_registry.py` proves:
+
+- all six initial DNS names remain present and conservatively unpromoted;
+- new discoveries enter an unwitnessed queue;
+- duplicate discoveries deduplicate while preserving provenance;
+- witness → classify → register ordering cannot be skipped;
+- cross-tenant mutation is rejected by the real capability-lease runtime;
+- declared properties cannot skip witness/registration;
+- production promotion requires evidence + rollback receipts;
+- rollback is an explicit state transition;
+- plain-language answers expose unknowns instead of guessing;
+- event-plane failure does not erase an authorized canonical registry commit.

--- a/governance/kpgs-vnext/estate-registry/discovery-candidate.schema.json
+++ b/governance/kpgs-vnext/estate-registry/discovery-candidate.schema.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kopanolabs.com/schemas/kpgs/estate-registry/discovery-candidate.schema.json",
+  "title": "KPGS Estate Discovery Candidate",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "candidate_id",
+    "domain",
+    "status",
+    "provenance",
+    "witness_evidence",
+    "classification",
+    "discovered_at",
+    "registered_at"
+  ],
+  "properties": {
+    "schema": { "const": "kpgs.estate-candidate.v1" },
+    "candidate_id": { "type": "string", "minLength": 8 },
+    "domain": { "type": "string", "minLength": 3 },
+    "status": {
+      "enum": ["unwitnessed", "witnessed", "classified", "rejected", "registered"]
+    },
+    "provenance": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["kind", "ref", "observed_at"],
+        "properties": {
+          "kind": {
+            "enum": ["registrar", "dns", "deployment", "repository", "domain-control", "other"]
+          },
+          "ref": { "type": "string", "minLength": 1 },
+          "observed_at": { "type": "string", "format": "date-time" }
+        }
+      }
+    },
+    "witness_evidence": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["kind", "ref", "verified_at"],
+        "properties": {
+          "kind": {
+            "enum": ["registrar", "dns", "deployment", "repository", "domain-control", "other"]
+          },
+          "ref": { "type": "string", "minLength": 1 },
+          "verified_at": { "type": ["string", "null"], "format": "date-time" }
+        }
+      }
+    },
+    "classification": {
+      "oneOf": [
+        { "type": "null" },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["owner_ref", "governance_tier", "risk_class"],
+          "properties": {
+            "owner_ref": { "type": "string", "minLength": 1 },
+            "governance_tier": { "type": "string", "minLength": 1 },
+            "risk_class": { "enum": ["R0", "R1", "R2", "R3"] }
+          }
+        }
+      ]
+    },
+    "discovered_at": { "type": "string", "format": "date-time" },
+    "registered_at": { "type": ["string", "null"], "format": "date-time" },
+    "rejection_reason": { "type": "string", "minLength": 1 }
+  }
+}

--- a/governance/kpgs-vnext/estate-registry/estate-registry.schema.json
+++ b/governance/kpgs-vnext/estate-registry/estate-registry.schema.json
@@ -41,6 +41,15 @@
               "decommissioned"
             ]
           },
+          "owner": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["ref", "kind"],
+            "properties": {
+              "ref": { "type": "string", "minLength": 1 },
+              "kind": { "type": "string", "minLength": 1 }
+            }
+          },
           "ownership_evidence": {
             "type": "array",
             "items": {
@@ -74,7 +83,20 @@
             "properties": {
               "provider": { "type": ["string", "null"] },
               "environment": { "type": ["string", "null"] },
-              "target": { "type": ["string", "null"] }
+              "target": { "type": ["string", "null"] },
+              "environments": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": ["name", "provider", "target"],
+                  "properties": {
+                    "name": { "type": "string", "minLength": 1 },
+                    "provider": { "type": "string", "minLength": 1 },
+                    "target": { "type": "string", "minLength": 1 }
+                  }
+                }
+              }
             }
           },
           "adapter": {
@@ -102,8 +124,31 @@
             "required": ["policy_ref", "risk_class"],
             "properties": {
               "policy_ref": { "type": ["string", "null"] },
-              "risk_class": { "type": ["string", "null"], "enum": ["R0", "R1", "R2", "R3", null] }
+              "risk_class": { "type": ["string", "null"], "enum": ["R0", "R1", "R2", "R3", null] },
+              "tier": { "type": ["string", "null"] }
             }
+          },
+          "skills": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": { "type": "string", "minLength": 1 }
+          },
+          "capabilities": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": { "type": "string", "minLength": 1 }
+          },
+          "secret_provider_refs": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "pattern": "^[A-Za-z][A-Za-z0-9+.-]*://.+$"
+            }
+          },
+          "health_endpoints": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 1 }
           },
           "release": {
             "type": "object",

--- a/governance/kpgs-vnext/estate-registry/registry.py
+++ b/governance/kpgs-vnext/estate-registry/registry.py
@@ -12,7 +12,7 @@ availability and synchronization remain separate from authority.
 from __future__ import annotations
 
 from copy import deepcopy
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from datetime import datetime, timezone
 import hashlib
 import json
@@ -42,7 +42,14 @@ ALLOWED_TRANSITIONS = {
     "suspended": {"registered", "decommissioned"},
     "decommissioned": set(),
 }
-SOURCE_KINDS = {"registrar", "dns", "deployment", "repository", "domain-control", "other"}
+SOURCE_KINDS = {
+    "registrar",
+    "dns",
+    "deployment",
+    "repository",
+    "domain-control",
+    "other",
+}
 RISK_CLASSES = {"R0", "R1", "R2", "R3"}
 
 
@@ -66,6 +73,25 @@ class MutationContext:
     task_id: str
     operation_nonce: str
     correlation_id: str
+
+
+def _parse_iso8601(value: Any, field_name: str) -> str:
+    """Validate and normalize an ISO-8601 timestamp to UTC text."""
+
+    if not isinstance(value, str) or not value.strip():
+        raise RegistryError(f"{field_name} is required")
+    try:
+        parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise RegistryError(f"{field_name} is not valid ISO-8601") from exc
+    if parsed.tzinfo is None:
+        raise RegistryError(f"{field_name} must include timezone")
+    return (
+        parsed.astimezone(timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
 
 
 class SovereignEstateRegistry:
@@ -97,8 +123,17 @@ class SovereignEstateRegistry:
         if not isinstance(domain, str):
             raise RegistryError("domain must be a string")
         cleaned = domain.strip().rstrip(".")
-        if len(cleaned) < 3 or "." not in cleaned or " " in cleaned:
+        if (
+            len(cleaned) < 3
+            or "." not in cleaned
+            or " " in cleaned
+            or cleaned.startswith(".")
+            or cleaned.endswith(".")
+        ):
             raise RegistryError("domain is invalid")
+        labels = cleaned.split(".")
+        if any(not label or len(label) > 63 for label in labels):
+            raise RegistryError("domain labels are invalid")
         return cleaned
 
     @staticmethod
@@ -125,7 +160,9 @@ class SovereignEstateRegistry:
                 raise RegistryConflict(f"duplicate domain: {domain}")
             seen.add(key)
             if record.get("status") not in PROPERTY_STATUSES:
-                raise RegistryError(f"invalid property status: {record.get('status')}")
+                raise RegistryError(
+                    f"invalid property status: {record.get('status')}"
+                )
 
     @property
     def estate_id(self) -> str:
@@ -172,9 +209,16 @@ class SovereignEstateRegistry:
             raise RegistryError("witness kind is invalid")
         if not isinstance(ref, str) or not ref.strip():
             raise RegistryError("witness ref is required")
-        if verified_at is not None and not isinstance(verified_at, str):
-            raise RegistryError("verified_at must be timestamp text or null")
-        return {"kind": kind, "ref": ref.strip(), "verified_at": verified_at}
+        normalized_time = (
+            None
+            if verified_at is None
+            else _parse_iso8601(verified_at, "verified_at")
+        )
+        return {
+            "kind": kind,
+            "ref": ref.strip(),
+            "verified_at": normalized_time,
+        }
 
     def _emit(
         self,
@@ -189,6 +233,9 @@ class SovereignEstateRegistry:
         evidence_refs: list[str] | None = None,
         details: Mapping[str, Any] | None = None,
     ) -> dict[str, Any]:
+        canonical_registry_changed = action.startswith("property-") or action in {
+            "candidate-registered"
+        }
         event = {
             "schema": "kpgs.estate-registry.event.v1",
             "event_id": "estate_evt_" + secrets.token_urlsafe(12),
@@ -202,8 +249,7 @@ class SovereignEstateRegistry:
             "correlation_id": correlation_id,
             "evidence_refs": list(evidence_refs or []),
             "details": deepcopy(dict(details or {})),
-            "canonical_registry_changed": action
-            not in {"candidate-discovered", "candidate-observed"},
+            "canonical_registry_changed": canonical_registry_changed,
             "transport_grants_authority": False,
             "distribution_status": "not-configured",
             "created_at": self._now(self._clock),
@@ -246,12 +292,10 @@ class SovereignEstateRegistry:
             raise RegistryError("discovery source kind is invalid")
         if not isinstance(source_ref, str) or not source_ref.strip():
             raise RegistryError("discovery source ref is required")
-        if not isinstance(observed_at, str) or not observed_at.strip():
-            raise RegistryError("discovery observed_at is required")
         source = {
             "kind": source_kind,
             "ref": source_ref.strip(),
-            "observed_at": observed_at,
+            "observed_at": _parse_iso8601(observed_at, "observed_at"),
         }
 
         existing_id = self._candidate_by_domain.get(key)
@@ -270,7 +314,10 @@ class SovereignEstateRegistry:
             )
             return deepcopy(candidate)
 
-        candidate_id = "candidate_" + hashlib.sha256(key.encode("utf-8")).hexdigest()[:20]
+        candidate_id = (
+            "candidate_"
+            + hashlib.sha256(key.encode("utf-8")).hexdigest()[:20]
+        )
         candidate = {
             "schema": "kpgs.estate-candidate.v1",
             "candidate_id": candidate_id,
@@ -310,7 +357,9 @@ class SovereignEstateRegistry:
             resource_scope=self._property_scope(candidate["domain"]),
         )
         if candidate["status"] not in {"unwitnessed", "witnessed"}:
-            raise RegistryTransitionDenied("candidate cannot be witnessed from current state")
+            raise RegistryTransitionDenied(
+                "candidate cannot be witnessed from current state"
+            )
         witness = self._witness(evidence)
         if witness not in candidate["witness_evidence"]:
             candidate["witness_evidence"].append(witness)
@@ -346,14 +395,18 @@ class SovereignEstateRegistry:
             resource_scope=self._property_scope(candidate["domain"]),
         )
         if candidate["status"] != "witnessed":
-            raise RegistryTransitionDenied("candidate must be witnessed before classification")
-        if not owner_ref.strip() or not governance_tier.strip():
-            raise RegistryError("owner and governance tier are required")
+            raise RegistryTransitionDenied(
+                "candidate must be witnessed before classification"
+            )
+        if not isinstance(owner_ref, str) or not owner_ref.strip():
+            raise RegistryError("owner reference is required")
+        if not isinstance(governance_tier, str) or not governance_tier.strip():
+            raise RegistryError("governance tier is required")
         if risk_class not in RISK_CLASSES:
             raise RegistryError("risk class is invalid")
         candidate["classification"] = {
-            "owner_ref": owner_ref,
-            "governance_tier": governance_tier,
+            "owner_ref": owner_ref.strip(),
+            "governance_tier": governance_tier.strip(),
             "risk_class": risk_class,
         }
         candidate["status"] = "classified"
@@ -371,19 +424,28 @@ class SovereignEstateRegistry:
 
     @staticmethod
     def _validate_registered_record(record: Mapping[str, Any]) -> None:
-        required_arrays = [
+        for field_name in (
             "ownership_evidence",
             "repositories",
             "capabilities",
             "health_endpoints",
-        ]
-        for field_name in required_arrays:
+        ):
             value = record.get(field_name)
             if not isinstance(value, list) or not value:
-                raise RegistryError(f"registered property requires {field_name}")
+                raise RegistryError(
+                    f"registered property requires {field_name}"
+                )
+
         deployment = record.get("deployment")
-        if not isinstance(deployment, dict) or not deployment.get("provider") or not deployment.get("target"):
-            raise RegistryError("registered property requires deployment provider and target")
+        if (
+            not isinstance(deployment, dict)
+            or not deployment.get("provider")
+            or not deployment.get("target")
+        ):
+            raise RegistryError(
+                "registered property requires deployment provider and target"
+            )
+
         governance = record.get("governance")
         if (
             not isinstance(governance, dict)
@@ -391,13 +453,54 @@ class SovereignEstateRegistry:
             or governance.get("risk_class") not in RISK_CLASSES
             or not governance.get("tier")
         ):
-            raise RegistryError("registered property requires governance policy, risk class and tier")
+            raise RegistryError(
+                "registered property requires governance policy, risk class and tier"
+            )
+
         owner = record.get("owner")
         if not isinstance(owner, dict) or not owner.get("ref"):
             raise RegistryError("registered property requires owner reference")
-        secret_refs = record.get("secret_provider_refs", [])
-        if any(not isinstance(ref, str) or "://" not in ref for ref in secret_refs):
-            raise RegistryError("secret provider entries must be references, never raw secrets")
+
+        for ref in record.get("secret_provider_refs", []):
+            if not isinstance(ref, str) or "://" not in ref:
+                raise RegistryError(
+                    "secret provider entries must be references, never raw secrets"
+                )
+
+    @staticmethod
+    def _apply_candidate_classification(
+        property_record: dict[str, Any],
+        classification: Mapping[str, Any],
+    ) -> None:
+        """Make witnessed classification authoritative over submitted metadata."""
+
+        supplied_owner = property_record.get("owner")
+        if (
+            isinstance(supplied_owner, dict)
+            and supplied_owner.get("ref")
+            and supplied_owner.get("ref") != classification["owner_ref"]
+        ):
+            raise RegistryConflict(
+                "registration owner conflicts with witnessed classification"
+            )
+        property_record["owner"] = {
+            "ref": classification["owner_ref"],
+            "kind": "classified-owner",
+        }
+
+        governance = property_record.setdefault("governance", {})
+        supplied_risk = governance.get("risk_class")
+        supplied_tier = governance.get("tier")
+        if supplied_risk not in {None, classification["risk_class"]}:
+            raise RegistryConflict(
+                "registration risk class conflicts with classification"
+            )
+        if supplied_tier not in {None, classification["governance_tier"]}:
+            raise RegistryConflict(
+                "registration governance tier conflicts with classification"
+            )
+        governance["risk_class"] = classification["risk_class"]
+        governance["tier"] = classification["governance_tier"]
 
     def register_candidate(
         self,
@@ -410,30 +513,46 @@ class SovereignEstateRegistry:
         if candidate is None:
             raise RegistryError("unknown discovery candidate")
         if candidate["status"] != "classified":
-            raise RegistryTransitionDenied("candidate must be classified before registration")
+            raise RegistryTransitionDenied(
+                "candidate must be classified before registration"
+            )
         decision = self._authorize(
             context,
             capability="estate.registry.write",
             resource_scope=self._property_scope(candidate["domain"]),
         )
         property_record = deepcopy(dict(record))
-        if self._domain_key(property_record.get("domain", "")) != self._domain_key(candidate["domain"]):
-            raise RegistryConflict("candidate and property domain must match")
+        if self._domain_key(property_record.get("domain", "")) != self._domain_key(
+            candidate["domain"]
+        ):
+            raise RegistryConflict(
+                "candidate and property domain must match"
+            )
         property_record["domain"] = candidate["domain"]
         property_record["status"] = "registered"
-        property_record["ownership_evidence"] = deepcopy(candidate["witness_evidence"])
-        classification = candidate["classification"]
-        property_record.setdefault("owner", {"ref": classification["owner_ref"], "kind": "declared-owner"})
-        governance = property_record.setdefault("governance", {})
-        governance.setdefault("risk_class", classification["risk_class"])
-        governance.setdefault("tier", classification["governance_tier"])
+        property_record["ownership_evidence"] = deepcopy(
+            candidate["witness_evidence"]
+        )
+        classification = candidate.get("classification")
+        if not isinstance(classification, dict):
+            raise RegistryTransitionDenied(
+                "candidate classification is missing"
+            )
+        self._apply_candidate_classification(
+            property_record,
+            classification,
+        )
         self._validate_registered_record(property_record)
+
         try:
             self._property(candidate["domain"])
         except RegistryError:
             pass
         else:
-            raise RegistryConflict("candidate domain already exists in registry")
+            raise RegistryConflict(
+                "candidate domain already exists in registry"
+            )
+
         self._document["properties"].append(property_record)
         candidate["status"] = "registered"
         candidate["registered_at"] = self._now(self._clock)
@@ -445,7 +564,9 @@ class SovereignEstateRegistry:
             candidate_id=candidate_id,
             before_status="classified",
             after_status="registered",
-            evidence_refs=[item["ref"] for item in candidate["witness_evidence"]],
+            evidence_refs=[
+                item["ref"] for item in candidate["witness_evidence"]
+            ],
         )
         return deepcopy(property_record)
 
@@ -462,8 +583,13 @@ class SovereignEstateRegistry:
             capability="estate.registry.witness",
             resource_scope=self._property_scope(record["domain"]),
         )
-        if record["status"] not in {"declared_pending_witness", "witnessed"}:
-            raise RegistryTransitionDenied("property cannot accept witness in current state")
+        if record["status"] not in {
+            "declared_pending_witness",
+            "witnessed",
+        }:
+            raise RegistryTransitionDenied(
+                "property cannot accept witness in current state"
+            )
         witness = self._witness(evidence)
         if witness not in record["ownership_evidence"]:
             record["ownership_evidence"].append(witness)
@@ -494,7 +620,9 @@ class SovereignEstateRegistry:
             resource_scope=self._property_scope(record["domain"]),
         )
         if record["status"] != "witnessed":
-            raise RegistryTransitionDenied("property must be witnessed before registration")
+            raise RegistryTransitionDenied(
+                "property must be witnessed before registration"
+            )
         before = deepcopy(record)
         preserved_evidence = deepcopy(record["ownership_evidence"])
         for key, value in metadata.items():
@@ -516,7 +644,9 @@ class SovereignEstateRegistry:
             domain=record["domain"],
             before_status="witnessed",
             after_status="registered",
-            evidence_refs=[item["ref"] for item in record["ownership_evidence"]],
+            evidence_refs=[
+                item["ref"] for item in record["ownership_evidence"]
+            ],
         )
         return deepcopy(record)
 
@@ -541,23 +671,42 @@ class SovereignEstateRegistry:
         if target_status not in PROPERTY_STATUSES:
             raise RegistryTransitionDenied("target status is invalid")
         if target_status not in ALLOWED_TRANSITIONS.get(current, set()):
-            raise RegistryTransitionDenied(f"transition {current} -> {target_status} is not admitted")
+            raise RegistryTransitionDenied(
+                f"transition {current} -> {target_status} is not admitted"
+            )
 
         if target_status == "production":
-            release_ref = release_ref or record.get("release", {}).get("live_ref")
-            evidence_ref = evidence_ref or record.get("release", {}).get("evidence_ref")
-            rollback_target_ref = rollback_target_ref or record.get("rollback", {}).get("target_ref")
-            rollback_procedure_ref = rollback_procedure_ref or record.get("rollback", {}).get("procedure_ref")
+            release_ref = release_ref or record.get("release", {}).get(
+                "live_ref"
+            )
+            evidence_ref = evidence_ref or record.get("release", {}).get(
+                "evidence_ref"
+            )
+            rollback_target_ref = rollback_target_ref or record.get(
+                "rollback", {}
+            ).get("target_ref")
+            rollback_procedure_ref = rollback_procedure_ref or record.get(
+                "rollback", {}
+            ).get("procedure_ref")
             if not all(
-                [release_ref, evidence_ref, rollback_target_ref, rollback_procedure_ref]
+                [
+                    release_ref,
+                    evidence_ref,
+                    rollback_target_ref,
+                    rollback_procedure_ref,
+                ]
             ):
                 raise RegistryTransitionDenied(
                     "production promotion requires live/evidence and rollback receipts"
                 )
             record.setdefault("release", {})["live_ref"] = release_ref
             record["release"]["evidence_ref"] = evidence_ref
-            record.setdefault("rollback", {})["target_ref"] = rollback_target_ref
-            record["rollback"]["procedure_ref"] = rollback_procedure_ref
+            record.setdefault("rollback", {})[
+                "target_ref"
+            ] = rollback_target_ref
+            record["rollback"][
+                "procedure_ref"
+            ] = rollback_procedure_ref
 
         record["status"] = target_status
         self._emit(
@@ -585,12 +734,16 @@ class SovereignEstateRegistry:
             resource_scope=self._property_scope(record["domain"]),
         )
         if record["status"] != "production":
-            raise RegistryTransitionDenied("rollback requires a production property")
+            raise RegistryTransitionDenied(
+                "rollback requires a production property"
+            )
         rollback = record.get("rollback", {})
         target = rollback.get("target_ref")
         procedure = rollback.get("procedure_ref")
         if not target or not procedure:
-            raise RegistryTransitionDenied("rollback target and procedure are required")
+            raise RegistryTransitionDenied(
+                "rollback target and procedure are required"
+            )
         previous_live = record.get("release", {}).get("live_ref")
         record.setdefault("release", {})["live_ref"] = target
         record["status"] = "staging"
@@ -602,7 +755,10 @@ class SovereignEstateRegistry:
             before_status="production",
             after_status="staging",
             evidence_refs=[procedure],
-            details={"from_live_ref": previous_live, "to_ref": target},
+            details={
+                "from_live_ref": previous_live,
+                "to_ref": target,
+            },
         )
         return deepcopy(record)
 
@@ -622,12 +778,14 @@ class SovereignEstateRegistry:
             resource_scope=self._property_scope(candidate["domain"]),
         )
         if candidate["status"] == "registered":
-            raise RegistryTransitionDenied("registered candidate cannot be rejected")
-        if not reason.strip():
+            raise RegistryTransitionDenied(
+                "registered candidate cannot be rejected"
+            )
+        if not isinstance(reason, str) or not reason.strip():
             raise RegistryError("rejection reason is required")
         before = candidate["status"]
         candidate["status"] = "rejected"
-        candidate["rejection_reason"] = reason
+        candidate["rejection_reason"] = reason.strip()
         self._emit(
             action="candidate-rejected",
             decision=decision,
@@ -636,12 +794,14 @@ class SovereignEstateRegistry:
             candidate_id=candidate_id,
             before_status=before,
             after_status="rejected",
-            details={"reason": reason},
+            details={"reason": reason.strip()},
         )
         return deepcopy(candidate)
 
     def candidates(self) -> tuple[dict[str, Any], ...]:
-        return tuple(deepcopy(item) for item in self._candidates.values())
+        return tuple(
+            deepcopy(item) for item in self._candidates.values()
+        )
 
     def events(self) -> tuple[dict[str, Any], ...]:
         return tuple(deepcopy(event) for event in self._events)
@@ -654,7 +814,12 @@ class SovereignEstateRegistry:
     def explain_property(self, domain: str) -> str:
         record = self._property(domain)
         repos = record.get("repositories", [])
-        repo_text = ", ".join(item.get("repository", "unknown") for item in repos) or "not witnessed"
+        repo_text = (
+            ", ".join(
+                item.get("repository", "unknown") for item in repos
+            )
+            or "not witnessed"
+        )
         deployment = record.get("deployment", {})
         deployment_text = (
             f"{deployment.get('provider')}:{deployment.get('target')}"
@@ -663,23 +828,45 @@ class SovereignEstateRegistry:
         )
         adapter = record.get("adapter", {})
         adapter_text = adapter.get("version") or (
-            "required / version unknown" if adapter.get("required") else "not required"
+            "required / version unknown"
+            if adapter.get("required")
+            else "not required"
         )
-        renter = record.get("renter_compatibility", {})
-        renter_text = renter.get("status", "unknown")
-        governance = record.get("governance", {})
-        governance_text = governance.get("policy_ref") or "not classified"
-        live_ref = record.get("release", {}).get("live_ref") or "not promoted"
-        rollback_ref = record.get("rollback", {}).get("target_ref") or "not recorded"
+        renter_text = record.get("renter_compatibility", {}).get(
+            "status", "unknown"
+        )
+        governance_text = record.get("governance", {}).get(
+            "policy_ref"
+        ) or "not classified"
+        capabilities = record.get("capabilities", [])
+        capability_text = ", ".join(capabilities) or "not granted"
+        health = record.get("health_endpoints", [])
+        health_text = ", ".join(health) or "not witnessed"
+        live_ref = record.get("release", {}).get(
+            "live_ref"
+        ) or "not promoted"
+        evidence_ref = record.get("release", {}).get(
+            "evidence_ref"
+        ) or "not recorded"
+        rollback_ref = record.get("rollback", {}).get(
+            "target_ref"
+        ) or "not recorded"
         return (
             f"{record['domain']} is {record['status']}. "
             f"Repositories: {repo_text}. Deployment: {deployment_text}. "
-            f"Adapter: {adapter_text}. Stateless Renter compatibility: {renter_text}. "
-            f"Governance policy: {governance_text}. Live version: {live_ref}. "
-            f"Rollback target: {rollback_ref}."
+            f"Adapter: {adapter_text}. Stateless Renter compatibility: "
+            f"{renter_text}. Governance policy: {governance_text}. "
+            f"Capabilities: {capability_text}. Health/evidence endpoints: "
+            f"{health_text}. Live version: {live_ref}. Release evidence: "
+            f"{evidence_ref}. Rollback target: {rollback_ref}."
         )
 
 
 def registry_digest(document: Mapping[str, Any]) -> str:
-    payload = json.dumps(document, sort_keys=True, separators=(",", ":"), default=str)
+    payload = json.dumps(
+        document,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    )
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()

--- a/governance/kpgs-vnext/estate-registry/registry.py
+++ b/governance/kpgs-vnext/estate-registry/registry.py
@@ -1,0 +1,685 @@
+"""Executable KPGS Sovereign DNS Estate Registry reference runtime.
+
+The registry is canonical control-plane state. Mutations require an injected
+KPGS capability-lease authority and an exact request context. Discovery never
+self-promotes: unknown domains first enter an unwitnessed review queue.
+
+Realtime/SWFUS distribution is optional projection alignment. A failed
+transport does not roll back an already-authorized canonical registry commit;
+availability and synchronization remain separate from authority.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+import hashlib
+import json
+import secrets
+from typing import Any, Callable, Mapping, MutableMapping
+
+PROPERTY_STATUSES = {
+    "declared_pending_witness",
+    "witnessed",
+    "registered",
+    "staging",
+    "production",
+    "suspended",
+    "decommissioned",
+}
+CANDIDATE_STATUSES = {
+    "unwitnessed",
+    "witnessed",
+    "classified",
+    "rejected",
+    "registered",
+}
+ALLOWED_TRANSITIONS = {
+    "registered": {"staging", "suspended", "decommissioned"},
+    "staging": {"production", "registered", "suspended"},
+    "production": {"staging", "suspended"},
+    "suspended": {"registered", "decommissioned"},
+    "decommissioned": set(),
+}
+SOURCE_KINDS = {"registrar", "dns", "deployment", "repository", "domain-control", "other"}
+RISK_CLASSES = {"R0", "R1", "R2", "R3"}
+
+
+class RegistryError(Exception):
+    pass
+
+
+class RegistryConflict(RegistryError):
+    pass
+
+
+class RegistryTransitionDenied(RegistryError):
+    pass
+
+
+@dataclass(frozen=True)
+class MutationContext:
+    token: str
+    tenant_id: str
+    domain_id: str
+    task_id: str
+    operation_nonce: str
+    correlation_id: str
+
+
+class SovereignEstateRegistry:
+    """Governed canonical registry plus explicit unwitnessed discovery queue."""
+
+    def __init__(
+        self,
+        registry_document: Mapping[str, Any],
+        lease_authority: Any,
+        *,
+        clock: Callable[[], datetime] | None = None,
+        distribution_sink: Callable[[dict[str, Any]], None] | None = None,
+    ):
+        self._document = deepcopy(dict(registry_document))
+        self.lease_authority = lease_authority
+        self._clock = clock or (lambda: datetime.now(timezone.utc))
+        self._distribution_sink = distribution_sink
+        self._candidates: MutableMapping[str, dict[str, Any]] = {}
+        self._candidate_by_domain: dict[str, str] = {}
+        self._events: list[dict[str, Any]] = []
+        self._validate_seed()
+
+    @staticmethod
+    def _domain_key(domain: str) -> str:
+        return domain.strip().rstrip(".").casefold()
+
+    @staticmethod
+    def _clean_domain(domain: str) -> str:
+        if not isinstance(domain, str):
+            raise RegistryError("domain must be a string")
+        cleaned = domain.strip().rstrip(".")
+        if len(cleaned) < 3 or "." not in cleaned or " " in cleaned:
+            raise RegistryError("domain is invalid")
+        return cleaned
+
+    @staticmethod
+    def _now(clock: Callable[[], datetime]) -> str:
+        return (
+            clock()
+            .astimezone(timezone.utc)
+            .replace(microsecond=0)
+            .isoformat()
+            .replace("+00:00", "Z")
+        )
+
+    def _validate_seed(self) -> None:
+        if not isinstance(self._document.get("estate_id"), str):
+            raise RegistryError("estate_id is required")
+        properties = self._document.get("properties")
+        if not isinstance(properties, list) or not properties:
+            raise RegistryError("registry requires properties")
+        seen: set[str] = set()
+        for record in properties:
+            domain = self._clean_domain(record.get("domain", ""))
+            key = self._domain_key(domain)
+            if key in seen:
+                raise RegistryConflict(f"duplicate domain: {domain}")
+            seen.add(key)
+            if record.get("status") not in PROPERTY_STATUSES:
+                raise RegistryError(f"invalid property status: {record.get('status')}")
+
+    @property
+    def estate_id(self) -> str:
+        return self._document["estate_id"]
+
+    def _estate_scope(self) -> str:
+        return f"estate:{self.estate_id}"
+
+    @staticmethod
+    def _property_scope(domain: str) -> str:
+        return f"dns:{domain}"
+
+    def _authorize(
+        self,
+        context: MutationContext,
+        *,
+        capability: str,
+        resource_scope: str,
+    ) -> Any:
+        return self.lease_authority.authorize(
+            context.token,
+            tenant_id=context.tenant_id,
+            domain_id=context.domain_id,
+            task_id=context.task_id,
+            capability=capability,
+            resource_scope=resource_scope,
+            operation_nonce=context.operation_nonce,
+            correlation_id=context.correlation_id,
+        )
+
+    def _property(self, domain: str) -> dict[str, Any]:
+        key = self._domain_key(self._clean_domain(domain))
+        for record in self._document["properties"]:
+            if self._domain_key(record["domain"]) == key:
+                return record
+        raise RegistryError(f"unknown property: {domain}")
+
+    @staticmethod
+    def _witness(evidence: Mapping[str, Any]) -> dict[str, Any]:
+        kind = evidence.get("kind")
+        ref = evidence.get("ref")
+        verified_at = evidence.get("verified_at")
+        if kind not in SOURCE_KINDS:
+            raise RegistryError("witness kind is invalid")
+        if not isinstance(ref, str) or not ref.strip():
+            raise RegistryError("witness ref is required")
+        if verified_at is not None and not isinstance(verified_at, str):
+            raise RegistryError("verified_at must be timestamp text or null")
+        return {"kind": kind, "ref": ref.strip(), "verified_at": verified_at}
+
+    def _emit(
+        self,
+        *,
+        action: str,
+        decision: Any,
+        correlation_id: str,
+        domain: str | None = None,
+        candidate_id: str | None = None,
+        before_status: str | None = None,
+        after_status: str | None = None,
+        evidence_refs: list[str] | None = None,
+        details: Mapping[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        event = {
+            "schema": "kpgs.estate-registry.event.v1",
+            "event_id": "estate_evt_" + secrets.token_urlsafe(12),
+            "estate_id": self.estate_id,
+            "action": action,
+            "domain": domain,
+            "candidate_id": candidate_id,
+            "before_status": before_status,
+            "after_status": after_status,
+            "lease_id": getattr(decision, "lease_id", None),
+            "correlation_id": correlation_id,
+            "evidence_refs": list(evidence_refs or []),
+            "details": deepcopy(dict(details or {})),
+            "canonical_registry_changed": action
+            not in {"candidate-discovered", "candidate-observed"},
+            "transport_grants_authority": False,
+            "distribution_status": "not-configured",
+            "created_at": self._now(self._clock),
+        }
+        if self._distribution_sink is not None:
+            try:
+                self._distribution_sink(deepcopy(event))
+                event["distribution_status"] = "distributed"
+            except Exception as exc:
+                event["distribution_status"] = "unavailable"
+                event["distribution_error"] = type(exc).__name__
+        self._events.append(event)
+        return deepcopy(event)
+
+    def discover_candidate(
+        self,
+        domain: str,
+        *,
+        provenance: Mapping[str, Any],
+        context: MutationContext,
+    ) -> dict[str, Any]:
+        decision = self._authorize(
+            context,
+            capability="estate.discovery.write",
+            resource_scope=self._estate_scope(),
+        )
+        cleaned = self._clean_domain(domain)
+        key = self._domain_key(cleaned)
+        try:
+            known = self._property(cleaned)
+        except RegistryError:
+            known = None
+        if known is not None:
+            raise RegistryConflict("domain already exists in canonical registry")
+
+        source_kind = provenance.get("kind")
+        source_ref = provenance.get("ref")
+        observed_at = provenance.get("observed_at")
+        if source_kind not in SOURCE_KINDS:
+            raise RegistryError("discovery source kind is invalid")
+        if not isinstance(source_ref, str) or not source_ref.strip():
+            raise RegistryError("discovery source ref is required")
+        if not isinstance(observed_at, str) or not observed_at.strip():
+            raise RegistryError("discovery observed_at is required")
+        source = {
+            "kind": source_kind,
+            "ref": source_ref.strip(),
+            "observed_at": observed_at,
+        }
+
+        existing_id = self._candidate_by_domain.get(key)
+        if existing_id:
+            candidate = self._candidates[existing_id]
+            if source not in candidate["provenance"]:
+                candidate["provenance"].append(source)
+            self._emit(
+                action="candidate-observed",
+                decision=decision,
+                correlation_id=context.correlation_id,
+                domain=candidate["domain"],
+                candidate_id=existing_id,
+                before_status=candidate["status"],
+                after_status=candidate["status"],
+            )
+            return deepcopy(candidate)
+
+        candidate_id = "candidate_" + hashlib.sha256(key.encode("utf-8")).hexdigest()[:20]
+        candidate = {
+            "schema": "kpgs.estate-candidate.v1",
+            "candidate_id": candidate_id,
+            "domain": cleaned,
+            "status": "unwitnessed",
+            "provenance": [source],
+            "witness_evidence": [],
+            "classification": None,
+            "discovered_at": self._now(self._clock),
+            "registered_at": None,
+        }
+        self._candidates[candidate_id] = candidate
+        self._candidate_by_domain[key] = candidate_id
+        self._emit(
+            action="candidate-discovered",
+            decision=decision,
+            correlation_id=context.correlation_id,
+            domain=cleaned,
+            candidate_id=candidate_id,
+            after_status="unwitnessed",
+        )
+        return deepcopy(candidate)
+
+    def witness_candidate(
+        self,
+        candidate_id: str,
+        evidence: Mapping[str, Any],
+        *,
+        context: MutationContext,
+    ) -> dict[str, Any]:
+        candidate = self._candidates.get(candidate_id)
+        if candidate is None:
+            raise RegistryError("unknown discovery candidate")
+        decision = self._authorize(
+            context,
+            capability="estate.registry.witness",
+            resource_scope=self._property_scope(candidate["domain"]),
+        )
+        if candidate["status"] not in {"unwitnessed", "witnessed"}:
+            raise RegistryTransitionDenied("candidate cannot be witnessed from current state")
+        witness = self._witness(evidence)
+        if witness not in candidate["witness_evidence"]:
+            candidate["witness_evidence"].append(witness)
+        before = candidate["status"]
+        candidate["status"] = "witnessed"
+        self._emit(
+            action="candidate-witnessed",
+            decision=decision,
+            correlation_id=context.correlation_id,
+            domain=candidate["domain"],
+            candidate_id=candidate_id,
+            before_status=before,
+            after_status="witnessed",
+            evidence_refs=[witness["ref"]],
+        )
+        return deepcopy(candidate)
+
+    def classify_candidate(
+        self,
+        candidate_id: str,
+        *,
+        owner_ref: str,
+        governance_tier: str,
+        risk_class: str,
+        context: MutationContext,
+    ) -> dict[str, Any]:
+        candidate = self._candidates.get(candidate_id)
+        if candidate is None:
+            raise RegistryError("unknown discovery candidate")
+        decision = self._authorize(
+            context,
+            capability="estate.registry.classify",
+            resource_scope=self._property_scope(candidate["domain"]),
+        )
+        if candidate["status"] != "witnessed":
+            raise RegistryTransitionDenied("candidate must be witnessed before classification")
+        if not owner_ref.strip() or not governance_tier.strip():
+            raise RegistryError("owner and governance tier are required")
+        if risk_class not in RISK_CLASSES:
+            raise RegistryError("risk class is invalid")
+        candidate["classification"] = {
+            "owner_ref": owner_ref,
+            "governance_tier": governance_tier,
+            "risk_class": risk_class,
+        }
+        candidate["status"] = "classified"
+        self._emit(
+            action="candidate-classified",
+            decision=decision,
+            correlation_id=context.correlation_id,
+            domain=candidate["domain"],
+            candidate_id=candidate_id,
+            before_status="witnessed",
+            after_status="classified",
+            details=candidate["classification"],
+        )
+        return deepcopy(candidate)
+
+    @staticmethod
+    def _validate_registered_record(record: Mapping[str, Any]) -> None:
+        required_arrays = [
+            "ownership_evidence",
+            "repositories",
+            "capabilities",
+            "health_endpoints",
+        ]
+        for field_name in required_arrays:
+            value = record.get(field_name)
+            if not isinstance(value, list) or not value:
+                raise RegistryError(f"registered property requires {field_name}")
+        deployment = record.get("deployment")
+        if not isinstance(deployment, dict) or not deployment.get("provider") or not deployment.get("target"):
+            raise RegistryError("registered property requires deployment provider and target")
+        governance = record.get("governance")
+        if (
+            not isinstance(governance, dict)
+            or not governance.get("policy_ref")
+            or governance.get("risk_class") not in RISK_CLASSES
+            or not governance.get("tier")
+        ):
+            raise RegistryError("registered property requires governance policy, risk class and tier")
+        owner = record.get("owner")
+        if not isinstance(owner, dict) or not owner.get("ref"):
+            raise RegistryError("registered property requires owner reference")
+        secret_refs = record.get("secret_provider_refs", [])
+        if any(not isinstance(ref, str) or "://" not in ref for ref in secret_refs):
+            raise RegistryError("secret provider entries must be references, never raw secrets")
+
+    def register_candidate(
+        self,
+        candidate_id: str,
+        record: Mapping[str, Any],
+        *,
+        context: MutationContext,
+    ) -> dict[str, Any]:
+        candidate = self._candidates.get(candidate_id)
+        if candidate is None:
+            raise RegistryError("unknown discovery candidate")
+        if candidate["status"] != "classified":
+            raise RegistryTransitionDenied("candidate must be classified before registration")
+        decision = self._authorize(
+            context,
+            capability="estate.registry.write",
+            resource_scope=self._property_scope(candidate["domain"]),
+        )
+        property_record = deepcopy(dict(record))
+        if self._domain_key(property_record.get("domain", "")) != self._domain_key(candidate["domain"]):
+            raise RegistryConflict("candidate and property domain must match")
+        property_record["domain"] = candidate["domain"]
+        property_record["status"] = "registered"
+        property_record["ownership_evidence"] = deepcopy(candidate["witness_evidence"])
+        classification = candidate["classification"]
+        property_record.setdefault("owner", {"ref": classification["owner_ref"], "kind": "declared-owner"})
+        governance = property_record.setdefault("governance", {})
+        governance.setdefault("risk_class", classification["risk_class"])
+        governance.setdefault("tier", classification["governance_tier"])
+        self._validate_registered_record(property_record)
+        try:
+            self._property(candidate["domain"])
+        except RegistryError:
+            pass
+        else:
+            raise RegistryConflict("candidate domain already exists in registry")
+        self._document["properties"].append(property_record)
+        candidate["status"] = "registered"
+        candidate["registered_at"] = self._now(self._clock)
+        self._emit(
+            action="candidate-registered",
+            decision=decision,
+            correlation_id=context.correlation_id,
+            domain=candidate["domain"],
+            candidate_id=candidate_id,
+            before_status="classified",
+            after_status="registered",
+            evidence_refs=[item["ref"] for item in candidate["witness_evidence"]],
+        )
+        return deepcopy(property_record)
+
+    def witness_property(
+        self,
+        domain: str,
+        evidence: Mapping[str, Any],
+        *,
+        context: MutationContext,
+    ) -> dict[str, Any]:
+        record = self._property(domain)
+        decision = self._authorize(
+            context,
+            capability="estate.registry.witness",
+            resource_scope=self._property_scope(record["domain"]),
+        )
+        if record["status"] not in {"declared_pending_witness", "witnessed"}:
+            raise RegistryTransitionDenied("property cannot accept witness in current state")
+        witness = self._witness(evidence)
+        if witness not in record["ownership_evidence"]:
+            record["ownership_evidence"].append(witness)
+        before = record["status"]
+        record["status"] = "witnessed"
+        self._emit(
+            action="property-witnessed",
+            decision=decision,
+            correlation_id=context.correlation_id,
+            domain=record["domain"],
+            before_status=before,
+            after_status="witnessed",
+            evidence_refs=[witness["ref"]],
+        )
+        return deepcopy(record)
+
+    def register_property(
+        self,
+        domain: str,
+        metadata: Mapping[str, Any],
+        *,
+        context: MutationContext,
+    ) -> dict[str, Any]:
+        record = self._property(domain)
+        decision = self._authorize(
+            context,
+            capability="estate.registry.write",
+            resource_scope=self._property_scope(record["domain"]),
+        )
+        if record["status"] != "witnessed":
+            raise RegistryTransitionDenied("property must be witnessed before registration")
+        before = deepcopy(record)
+        preserved_evidence = deepcopy(record["ownership_evidence"])
+        for key, value in metadata.items():
+            if key in {"domain", "status", "ownership_evidence"}:
+                continue
+            record[key] = deepcopy(value)
+        record["ownership_evidence"] = preserved_evidence
+        record["status"] = "registered"
+        try:
+            self._validate_registered_record(record)
+        except Exception:
+            record.clear()
+            record.update(before)
+            raise
+        self._emit(
+            action="property-registered",
+            decision=decision,
+            correlation_id=context.correlation_id,
+            domain=record["domain"],
+            before_status="witnessed",
+            after_status="registered",
+            evidence_refs=[item["ref"] for item in record["ownership_evidence"]],
+        )
+        return deepcopy(record)
+
+    def transition_property(
+        self,
+        domain: str,
+        target_status: str,
+        *,
+        context: MutationContext,
+        release_ref: str | None = None,
+        evidence_ref: str | None = None,
+        rollback_target_ref: str | None = None,
+        rollback_procedure_ref: str | None = None,
+    ) -> dict[str, Any]:
+        record = self._property(domain)
+        decision = self._authorize(
+            context,
+            capability="estate.release.transition",
+            resource_scope=self._property_scope(record["domain"]),
+        )
+        current = record["status"]
+        if target_status not in PROPERTY_STATUSES:
+            raise RegistryTransitionDenied("target status is invalid")
+        if target_status not in ALLOWED_TRANSITIONS.get(current, set()):
+            raise RegistryTransitionDenied(f"transition {current} -> {target_status} is not admitted")
+
+        if target_status == "production":
+            release_ref = release_ref or record.get("release", {}).get("live_ref")
+            evidence_ref = evidence_ref or record.get("release", {}).get("evidence_ref")
+            rollback_target_ref = rollback_target_ref or record.get("rollback", {}).get("target_ref")
+            rollback_procedure_ref = rollback_procedure_ref or record.get("rollback", {}).get("procedure_ref")
+            if not all(
+                [release_ref, evidence_ref, rollback_target_ref, rollback_procedure_ref]
+            ):
+                raise RegistryTransitionDenied(
+                    "production promotion requires live/evidence and rollback receipts"
+                )
+            record.setdefault("release", {})["live_ref"] = release_ref
+            record["release"]["evidence_ref"] = evidence_ref
+            record.setdefault("rollback", {})["target_ref"] = rollback_target_ref
+            record["rollback"]["procedure_ref"] = rollback_procedure_ref
+
+        record["status"] = target_status
+        self._emit(
+            action="property-transitioned",
+            decision=decision,
+            correlation_id=context.correlation_id,
+            domain=record["domain"],
+            before_status=current,
+            after_status=target_status,
+            evidence_refs=[evidence_ref] if evidence_ref else [],
+            details={"release_ref": release_ref} if release_ref else {},
+        )
+        return deepcopy(record)
+
+    def rollback_property(
+        self,
+        domain: str,
+        *,
+        context: MutationContext,
+    ) -> dict[str, Any]:
+        record = self._property(domain)
+        decision = self._authorize(
+            context,
+            capability="estate.release.rollback",
+            resource_scope=self._property_scope(record["domain"]),
+        )
+        if record["status"] != "production":
+            raise RegistryTransitionDenied("rollback requires a production property")
+        rollback = record.get("rollback", {})
+        target = rollback.get("target_ref")
+        procedure = rollback.get("procedure_ref")
+        if not target or not procedure:
+            raise RegistryTransitionDenied("rollback target and procedure are required")
+        previous_live = record.get("release", {}).get("live_ref")
+        record.setdefault("release", {})["live_ref"] = target
+        record["status"] = "staging"
+        self._emit(
+            action="property-rollback",
+            decision=decision,
+            correlation_id=context.correlation_id,
+            domain=record["domain"],
+            before_status="production",
+            after_status="staging",
+            evidence_refs=[procedure],
+            details={"from_live_ref": previous_live, "to_ref": target},
+        )
+        return deepcopy(record)
+
+    def reject_candidate(
+        self,
+        candidate_id: str,
+        *,
+        reason: str,
+        context: MutationContext,
+    ) -> dict[str, Any]:
+        candidate = self._candidates.get(candidate_id)
+        if candidate is None:
+            raise RegistryError("unknown discovery candidate")
+        decision = self._authorize(
+            context,
+            capability="estate.registry.classify",
+            resource_scope=self._property_scope(candidate["domain"]),
+        )
+        if candidate["status"] == "registered":
+            raise RegistryTransitionDenied("registered candidate cannot be rejected")
+        if not reason.strip():
+            raise RegistryError("rejection reason is required")
+        before = candidate["status"]
+        candidate["status"] = "rejected"
+        candidate["rejection_reason"] = reason
+        self._emit(
+            action="candidate-rejected",
+            decision=decision,
+            correlation_id=context.correlation_id,
+            domain=candidate["domain"],
+            candidate_id=candidate_id,
+            before_status=before,
+            after_status="rejected",
+            details={"reason": reason},
+        )
+        return deepcopy(candidate)
+
+    def candidates(self) -> tuple[dict[str, Any], ...]:
+        return tuple(deepcopy(item) for item in self._candidates.values())
+
+    def events(self) -> tuple[dict[str, Any], ...]:
+        return tuple(deepcopy(event) for event in self._events)
+
+    def snapshot(self) -> dict[str, Any]:
+        document = deepcopy(self._document)
+        document["generated_at"] = self._now(self._clock)
+        return document
+
+    def explain_property(self, domain: str) -> str:
+        record = self._property(domain)
+        repos = record.get("repositories", [])
+        repo_text = ", ".join(item.get("repository", "unknown") for item in repos) or "not witnessed"
+        deployment = record.get("deployment", {})
+        deployment_text = (
+            f"{deployment.get('provider')}:{deployment.get('target')}"
+            if deployment.get("provider") and deployment.get("target")
+            else "not witnessed"
+        )
+        adapter = record.get("adapter", {})
+        adapter_text = adapter.get("version") or (
+            "required / version unknown" if adapter.get("required") else "not required"
+        )
+        renter = record.get("renter_compatibility", {})
+        renter_text = renter.get("status", "unknown")
+        governance = record.get("governance", {})
+        governance_text = governance.get("policy_ref") or "not classified"
+        live_ref = record.get("release", {}).get("live_ref") or "not promoted"
+        rollback_ref = record.get("rollback", {}).get("target_ref") or "not recorded"
+        return (
+            f"{record['domain']} is {record['status']}. "
+            f"Repositories: {repo_text}. Deployment: {deployment_text}. "
+            f"Adapter: {adapter_text}. Stateless Renter compatibility: {renter_text}. "
+            f"Governance policy: {governance_text}. Live version: {live_ref}. "
+            f"Rollback target: {rollback_ref}."
+        )
+
+
+def registry_digest(document: Mapping[str, Any]) -> str:
+    payload = json.dumps(document, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()

--- a/governance/kpgs-vnext/estate-registry/validate_registry.py
+++ b/governance/kpgs-vnext/estate-registry/validate_registry.py
@@ -1,0 +1,191 @@
+"""Dependency-free validator for the KPGS Sovereign Estate Registry runtime."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import importlib.util
+import json
+from pathlib import Path
+import sys
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parents[2]
+ESTATE = HERE / "estate.json"
+REGISTRY_SCHEMA = HERE / "estate-registry.schema.json"
+CANDIDATE_SCHEMA = HERE / "discovery-candidate.schema.json"
+REGISTRY_RUNTIME = HERE / "registry.py"
+LEASE_RUNTIME = HERE.parent / "security" / "capability_lease.py"
+
+INITIAL_DOMAINS = {
+    "KasiLink.com",
+    "FivesArena.com",
+    "starfallsalvage.kopanolabs.com",
+    "crisisconnect.kopanolabs.com",
+    "KopanoLabs.com",
+    "KRRababalela.com",
+}
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise SystemExit(f"KPGS-ESTATE FAIL: {message}")
+
+
+def load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    require(spec is not None and spec.loader is not None, f"cannot load {path.name}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def main() -> None:
+    estate = json.loads(ESTATE.read_text(encoding="utf-8"))
+    registry_schema = json.loads(REGISTRY_SCHEMA.read_text(encoding="utf-8"))
+    candidate_schema = json.loads(CANDIDATE_SCHEMA.read_text(encoding="utf-8"))
+
+    domains = {item["domain"] for item in estate["properties"]}
+    require(domains == INITIAL_DOMAINS, "initial canonical DNS estate drifted")
+    require(
+        all(item["status"] == "declared_pending_witness" for item in estate["properties"]),
+        "unwitnessed initial property was silently promoted",
+    )
+
+    property_schema = registry_schema["properties"]["properties"]["items"]["properties"]
+    for required_link in (
+        "repositories",
+        "deployment",
+        "adapter",
+        "renter_compatibility",
+        "governance",
+        "capabilities",
+        "health_endpoints",
+        "release",
+        "rollback",
+    ):
+        require(required_link in property_schema, f"registry linkage missing {required_link}")
+    require(
+        "://" in property_schema["secret_provider_refs"]["items"]["pattern"],
+        "secret provider fields no longer require references",
+    )
+
+    candidate_states = set(candidate_schema["properties"]["status"]["enum"])
+    require(
+        candidate_states == {"unwitnessed", "witnessed", "classified", "rejected", "registered"},
+        "candidate review states drifted",
+    )
+
+    lease_mod = load_module("kpgs_estate_validator_lease", LEASE_RUNTIME)
+    registry_mod = load_module("kpgs_estate_validator_runtime", REGISTRY_RUNTIME)
+    fixed_now = datetime(2026, 8, 18, 9, 45, tzinfo=timezone.utc)
+    authority = lease_mod.CapabilityLeaseAuthority(
+        lease_mod.KeyRing({"estate-validator": b"v" * 32}, "estate-validator"),
+        clock=lambda: fixed_now,
+        max_ttl_seconds=600,
+    )
+    token = authority.issue(
+        subject_id="service:validator-hub",
+        subject_kind="service",
+        tenant_id="tenant:kopano",
+        domain_id="KopanoLabs.com",
+        task_id="task:estate-validator",
+        capabilities=[
+            {
+                "name": "estate.discovery.write",
+                "resource_scope": "estate:kopano-sovereign-estate",
+            },
+            {
+                "name": "estate.registry.witness",
+                "resource_scope": "dns:validator.example.org",
+            },
+            {
+                "name": "estate.registry.classify",
+                "resource_scope": "dns:validator.example.org",
+            },
+        ],
+        policy_decision_ref="policy://validator/estate",
+        governing_spec_ref="spec://validator/estate/v1",
+        ttl_seconds=300,
+        correlation_id="corr:estate-validator",
+        evidence_ref="evidence://estate-validator/lease",
+    )
+    registry = registry_mod.SovereignEstateRegistry(
+        estate,
+        authority,
+        clock=lambda: fixed_now,
+    )
+
+    def context(nonce: str):
+        return registry_mod.MutationContext(
+            token=token,
+            tenant_id="tenant:kopano",
+            domain_id="KopanoLabs.com",
+            task_id="task:estate-validator",
+            operation_nonce=nonce,
+            correlation_id=f"corr:{nonce}",
+        )
+
+    candidate = registry.discover_candidate(
+        "validator.example.org",
+        provenance={
+            "kind": "dns",
+            "ref": "dns://validator/observed",
+            "observed_at": "2026-08-18T09:44:00Z",
+        },
+        context=context("validator-discover"),
+    )
+    require(candidate["status"] == "unwitnessed", "discovery self-promoted")
+    require(
+        "validator.example.org" not in {item["domain"] for item in registry.snapshot()["properties"]},
+        "unwitnessed candidate entered canonical property registry",
+    )
+
+    witnessed = registry.witness_candidate(
+        candidate["candidate_id"],
+        {
+            "kind": "domain-control",
+            "ref": "witness://validator/control",
+            "verified_at": "2026-08-18T09:45:00+00:00",
+        },
+        context=context("validator-witness"),
+    )
+    require(witnessed["status"] == "witnessed", "candidate witness transition failed")
+    classified = registry.classify_candidate(
+        candidate["candidate_id"],
+        owner_ref="owner://validator",
+        governance_tier="T1",
+        risk_class="R1",
+        context=context("validator-classify"),
+    )
+    require(classified["status"] == "classified", "candidate classification failed")
+
+    pending_answer = registry.explain_property("FivesArena.com")
+    for phrase in (
+        "declared_pending_witness",
+        "Repositories: not witnessed",
+        "Capabilities: not granted",
+        "Live version: not promoted",
+        "Rollback target: not recorded",
+    ):
+        require(phrase in pending_answer, f"plain-language answer lost: {phrase}")
+
+    events = registry.events()
+    require(len(events) == 3, "review queue did not emit governed events")
+    require(
+        all(event["transport_grants_authority"] is False for event in events),
+        "event distribution widened authority",
+    )
+    require(
+        all(event["canonical_registry_changed"] is False for event in events),
+        "candidate review mutated canonical property registry",
+    )
+
+    print(
+        "KPGS-ESTATE PASS: discovery is unwitnessed-by-default, lease-scoped, "
+        "promotion-gated and plain-language queryable."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_sovereign_estate_registry.py
+++ b/tests/test_sovereign_estate_registry.py
@@ -6,9 +6,27 @@ import sys
 import unittest
 
 ROOT = Path(__file__).parents[1]
-LEASE_PATH = ROOT / "governance" / "kpgs-vnext" / "security" / "capability_lease.py"
-REGISTRY_PATH = ROOT / "governance" / "kpgs-vnext" / "estate-registry" / "registry.py"
-ESTATE_PATH = ROOT / "governance" / "kpgs-vnext" / "estate-registry" / "estate.json"
+LEASE_PATH = (
+    ROOT
+    / "governance"
+    / "kpgs-vnext"
+    / "security"
+    / "capability_lease.py"
+)
+REGISTRY_PATH = (
+    ROOT
+    / "governance"
+    / "kpgs-vnext"
+    / "estate-registry"
+    / "registry.py"
+)
+ESTATE_PATH = (
+    ROOT
+    / "governance"
+    / "kpgs-vnext"
+    / "estate-registry"
+    / "estate.json"
+)
 
 
 def load_module(name, path):
@@ -26,7 +44,14 @@ registry_mod = load_module("kpgs_estate_registry", REGISTRY_PATH)
 
 class FixedClock:
     def __init__(self):
-        self.now = datetime(2026, 8, 18, 9, 30, tzinfo=timezone.utc)
+        self.now = datetime(
+            2026,
+            8,
+            18,
+            9,
+            30,
+            tzinfo=timezone.utc,
+        )
 
     def __call__(self):
         return self.now
@@ -36,11 +61,16 @@ class SovereignEstateRegistryTests(unittest.TestCase):
     def setUp(self):
         self.clock = FixedClock()
         self.lease_authority = lease_mod.CapabilityLeaseAuthority(
-            lease_mod.KeyRing({"estate-k1": b"e" * 32}, "estate-k1"),
+            lease_mod.KeyRing(
+                {"estate-k1": b"e" * 32},
+                "estate-k1",
+            ),
             clock=self.clock,
             max_ttl_seconds=900,
         )
-        self.estate = json.loads(ESTATE_PATH.read_text(encoding="utf-8"))
+        self.estate = json.loads(
+            ESTATE_PATH.read_text(encoding="utf-8")
+        )
         self.token = self.lease_authority.issue(
             subject_id="service:sovereign-hub",
             subject_kind="service",
@@ -50,7 +80,9 @@ class SovereignEstateRegistryTests(unittest.TestCase):
             capabilities=[
                 {
                     "name": "estate.discovery.write",
-                    "resource_scope": "estate:kopano-sovereign-estate",
+                    "resource_scope": (
+                        "estate:kopano-sovereign-estate"
+                    ),
                 },
                 {
                     "name": "estate.registry.witness",
@@ -93,7 +125,12 @@ class SovereignEstateRegistryTests(unittest.TestCase):
             clock=self.clock,
         )
 
-    def context(self, nonce, *, tenant_id="tenant:kopano"):
+    def context(
+        self,
+        nonce,
+        *,
+        tenant_id="tenant:kopano",
+    ):
         return registry_mod.MutationContext(
             token=self.token,
             tenant_id=tenant_id,
@@ -104,12 +141,20 @@ class SovereignEstateRegistryTests(unittest.TestCase):
         )
 
     @staticmethod
-    def registered_metadata(domain):
+    def registered_metadata(
+        domain,
+        *,
+        owner_ref="owner://verified/001",
+        risk_class="R1",
+        tier="T1",
+    ):
         return {
             "domain": domain,
             "repositories": [
                 {
-                    "repository": "RobynAwesome/example-runtime",
+                    "repository": (
+                        "RobynAwesome/example-runtime"
+                    ),
                     "role": "primary",
                     "ref": "commit:abc123",
                 }
@@ -142,22 +187,78 @@ class SovereignEstateRegistryTests(unittest.TestCase):
             },
             "governance": {
                 "policy_ref": "policy://estate/property",
-                "risk_class": "R1",
-                "tier": "T1",
+                "risk_class": risk_class,
+                "tier": tier,
             },
-            "owner": {"ref": "owner://declared", "kind": "declared-owner"},
+            "owner": {
+                "ref": owner_ref,
+                "kind": "declared-owner",
+            },
             "skills": ["estate-observer"],
             "capabilities": ["domain.health.read"],
-            "secret_provider_refs": ["vault://estate/runtime-reference"],
+            "secret_provider_refs": [
+                "vault://estate/runtime-reference"
+            ],
             "health_endpoints": [f"https://{domain}/health"],
-            "release": {"live_ref": None, "evidence_ref": None},
-            "rollback": {"target_ref": None, "procedure_ref": None},
-            "notes": ["test fixture only; not ownership evidence"],
+            "release": {
+                "live_ref": None,
+                "evidence_ref": None,
+            },
+            "rollback": {
+                "target_ref": None,
+                "procedure_ref": None,
+            },
+            "notes": [
+                "test fixture only; not ownership evidence"
+            ],
         }
+
+    def discover(self, nonce="discover-001"):
+        return self.registry.discover_candidate(
+            "candidate.example.org",
+            provenance={
+                "kind": "dns",
+                "ref": (
+                    "dns://observed/candidate.example.org"
+                ),
+                "observed_at": "2026-08-18T09:30:00Z",
+            },
+            context=self.context(nonce),
+        )
+
+    def witness_candidate(
+        self,
+        candidate_id,
+        nonce="witness-candidate",
+    ):
+        return self.registry.witness_candidate(
+            candidate_id,
+            {
+                "kind": "domain-control",
+                "ref": "witness://domain-control/001",
+                "verified_at": "2026-08-18T09:32:00Z",
+            },
+            context=self.context(nonce),
+        )
+
+    def classify_candidate(
+        self,
+        candidate_id,
+        nonce="classify-candidate",
+    ):
+        return self.registry.classify_candidate(
+            candidate_id,
+            owner_ref="owner://verified/001",
+            governance_tier="T1",
+            risk_class="R1",
+            context=self.context(nonce),
+        )
 
     def test_initial_six_domains_remain_present_and_unpromoted(self):
         snapshot = self.registry.snapshot()
-        domains = {item["domain"] for item in snapshot["properties"]}
+        domains = {
+            item["domain"] for item in snapshot["properties"]
+        }
         self.assertEqual(
             domains,
             {
@@ -170,22 +271,21 @@ class SovereignEstateRegistryTests(unittest.TestCase):
             },
         )
         self.assertTrue(
-            all(item["status"] == "declared_pending_witness" for item in snapshot["properties"])
+            all(
+                item["status"]
+                == "declared_pending_witness"
+                for item in snapshot["properties"]
+            )
         )
 
     def test_discovery_enters_unwitnessed_queue_and_does_not_register_itself(self):
-        candidate = self.registry.discover_candidate(
-            "candidate.example.org",
-            provenance={
-                "kind": "dns",
-                "ref": "dns://observed/candidate.example.org",
-                "observed_at": "2026-08-18T09:30:00Z",
-            },
-            context=self.context("discover-001"),
-        )
+        candidate = self.discover()
         self.assertEqual(candidate["status"], "unwitnessed")
         self.assertEqual(len(self.registry.candidates()), 1)
-        domains = {item["domain"] for item in self.registry.snapshot()["properties"]}
+        domains = {
+            item["domain"]
+            for item in self.registry.snapshot()["properties"]
+        }
         self.assertNotIn("candidate.example.org", domains)
 
     def test_duplicate_discovery_deduplicates_candidate_but_preserves_provenance(self):
@@ -203,59 +303,114 @@ class SovereignEstateRegistryTests(unittest.TestCase):
             provenance={
                 "kind": "repository",
                 "ref": "github://second",
-                "observed_at": "2026-08-18T09:31:00Z",
+                "observed_at": "2026-08-18T09:31:00+00:00",
             },
             context=self.context("discover-003"),
         )
-        self.assertEqual(first["candidate_id"], second["candidate_id"])
+        self.assertEqual(
+            first["candidate_id"],
+            second["candidate_id"],
+        )
         self.assertEqual(len(second["provenance"]), 2)
         self.assertEqual(len(self.registry.candidates()), 1)
+        self.assertEqual(
+            second["provenance"][1]["observed_at"],
+            "2026-08-18T09:31:00Z",
+        )
+
+    def test_invalid_discovery_timestamp_fails_before_queue_mutation(self):
+        with self.assertRaises(registry_mod.RegistryError):
+            self.registry.discover_candidate(
+                "candidate.example.org",
+                provenance={
+                    "kind": "dns",
+                    "ref": "dns://candidate",
+                    "observed_at": "sometime-yesterday",
+                },
+                context=self.context("bad-time"),
+            )
+        self.assertEqual(self.registry.candidates(), ())
 
     def test_candidate_requires_witness_then_classification_then_registration(self):
-        candidate = self.registry.discover_candidate(
-            "candidate.example.org",
-            provenance={
-                "kind": "repository",
-                "ref": "github://candidate",
-                "observed_at": "2026-08-18T09:30:00Z",
-            },
-            context=self.context("discover-004"),
-        )
-        with self.assertRaises(registry_mod.RegistryTransitionDenied):
+        candidate = self.discover("discover-004")
+        with self.assertRaises(
+            registry_mod.RegistryTransitionDenied
+        ):
             self.registry.register_candidate(
                 candidate["candidate_id"],
-                self.registered_metadata("candidate.example.org"),
+                self.registered_metadata(
+                    "candidate.example.org"
+                ),
                 context=self.context("register-too-early"),
             )
 
-        witnessed = self.registry.witness_candidate(
-            candidate["candidate_id"],
-            {
-                "kind": "domain-control",
-                "ref": "witness://domain-control/001",
-                "verified_at": "2026-08-18T09:32:00Z",
-            },
-            context=self.context("witness-candidate"),
+        witnessed = self.witness_candidate(
+            candidate["candidate_id"]
         )
         self.assertEqual(witnessed["status"], "witnessed")
 
-        classified = self.registry.classify_candidate(
-            candidate["candidate_id"],
-            owner_ref="owner://verified/001",
-            governance_tier="T1",
-            risk_class="R1",
-            context=self.context("classify-candidate"),
+        classified = self.classify_candidate(
+            candidate["candidate_id"]
         )
         self.assertEqual(classified["status"], "classified")
 
         registered = self.registry.register_candidate(
             candidate["candidate_id"],
-            self.registered_metadata("candidate.example.org"),
+            self.registered_metadata(
+                "candidate.example.org"
+            ),
             context=self.context("register-candidate"),
         )
         self.assertEqual(registered["status"], "registered")
-        self.assertEqual(registered["owner"]["ref"], "owner://declared")
-        self.assertEqual(registered["ownership_evidence"][0]["kind"], "domain-control")
+        self.assertEqual(
+            registered["owner"]["ref"],
+            "owner://verified/001",
+        )
+        self.assertEqual(
+            registered["owner"]["kind"],
+            "classified-owner",
+        )
+        self.assertEqual(
+            registered["ownership_evidence"][0]["kind"],
+            "domain-control",
+        )
+
+    def test_registration_cannot_override_witnessed_classification(self):
+        candidate = self.discover("discover-classification")
+        self.witness_candidate(
+            candidate["candidate_id"],
+            "witness-classification",
+        )
+        self.classify_candidate(
+            candidate["candidate_id"],
+            "classify-authority",
+        )
+
+        with self.assertRaises(registry_mod.RegistryConflict):
+            self.registry.register_candidate(
+                candidate["candidate_id"],
+                self.registered_metadata(
+                    "candidate.example.org",
+                    owner_ref="owner://conflicting",
+                ),
+                context=self.context("register-owner-conflict"),
+            )
+        with self.assertRaises(registry_mod.RegistryConflict):
+            self.registry.register_candidate(
+                candidate["candidate_id"],
+                self.registered_metadata(
+                    "candidate.example.org",
+                    risk_class="R3",
+                ),
+                context=self.context("register-risk-conflict"),
+            )
+        self.assertNotIn(
+            "candidate.example.org",
+            {
+                item["domain"]
+                for item in self.registry.snapshot()["properties"]
+            },
+        )
 
     def test_cross_tenant_mutation_is_denied_by_capability_lease(self):
         with self.assertRaises(lease_mod.LeaseDenied):
@@ -266,12 +421,17 @@ class SovereignEstateRegistryTests(unittest.TestCase):
                     "ref": "dns://candidate",
                     "observed_at": "2026-08-18T09:30:00Z",
                 },
-                context=self.context("cross-tenant", tenant_id="tenant:other"),
+                context=self.context(
+                    "cross-tenant",
+                    tenant_id="tenant:other",
+                ),
             )
         self.assertEqual(self.registry.candidates(), ())
 
     def test_existing_declared_property_cannot_skip_witness_or_registration(self):
-        with self.assertRaises(registry_mod.RegistryTransitionDenied):
+        with self.assertRaises(
+            registry_mod.RegistryTransitionDenied
+        ):
             self.registry.transition_property(
                 "KasiLink.com",
                 "production",
@@ -316,11 +476,15 @@ class SovereignEstateRegistryTests(unittest.TestCase):
             "staging",
             context=self.context("stage-kasilink"),
         )
-        with self.assertRaises(registry_mod.RegistryTransitionDenied):
+        with self.assertRaises(
+            registry_mod.RegistryTransitionDenied
+        ):
             self.registry.transition_property(
                 "KasiLink.com",
                 "production",
-                context=self.context("promote-without-receipts"),
+                context=self.context(
+                    "promote-without-receipts"
+                ),
             )
 
         production = self.registry.transition_property(
@@ -329,27 +493,70 @@ class SovereignEstateRegistryTests(unittest.TestCase):
             release_ref="commit:live-002",
             evidence_ref="evidence://deploy/live-002",
             rollback_target_ref="commit:live-001",
-            rollback_procedure_ref="runbook://rollback/kasilink",
+            rollback_procedure_ref=(
+                "runbook://rollback/kasilink"
+            ),
             context=self.context("promote-kasilink"),
         )
         self.assertEqual(production["status"], "production")
-        self.assertEqual(production["release"]["live_ref"], "commit:live-002")
+        self.assertEqual(
+            production["release"]["live_ref"],
+            "commit:live-002",
+        )
 
         rolled_back = self.registry.rollback_property(
             "KasiLink.com",
             context=self.context("rollback-kasilink"),
         )
         self.assertEqual(rolled_back["status"], "staging")
-        self.assertEqual(rolled_back["release"]["live_ref"], "commit:live-001")
-        self.assertEqual(self.registry.events()[-1]["action"], "property-rollback")
+        self.assertEqual(
+            rolled_back["release"]["live_ref"],
+            "commit:live-001",
+        )
+        self.assertEqual(
+            self.registry.events()[-1]["action"],
+            "property-rollback",
+        )
 
-    def test_plain_language_answer_exposes_location_version_and_rollback_state(self):
-        text = self.registry.explain_property("FivesArena.com")
-        self.assertIn("FivesArena.com is declared_pending_witness", text)
-        self.assertIn("Repositories: not witnessed", text)
-        self.assertIn("Deployment: not witnessed", text)
-        self.assertIn("Live version: not promoted", text)
-        self.assertIn("Rollback target: not recorded", text)
+    def test_plain_language_answer_exposes_unknowns_and_capability_state(self):
+        pending = self.registry.explain_property(
+            "FivesArena.com"
+        )
+        self.assertIn(
+            "FivesArena.com is declared_pending_witness",
+            pending,
+        )
+        self.assertIn("Repositories: not witnessed", pending)
+        self.assertIn("Deployment: not witnessed", pending)
+        self.assertIn("Capabilities: not granted", pending)
+        self.assertIn("Live version: not promoted", pending)
+        self.assertIn("Rollback target: not recorded", pending)
+
+        self.registry.witness_property(
+            "KasiLink.com",
+            {
+                "kind": "domain-control",
+                "ref": "witness://kasilink/control",
+                "verified_at": "2026-08-18T09:30:00Z",
+            },
+            context=self.context("witness-explain"),
+        )
+        self.registry.register_property(
+            "KasiLink.com",
+            self.registered_metadata("KasiLink.com"),
+            context=self.context("register-explain"),
+        )
+        registered = self.registry.explain_property(
+            "KasiLink.com"
+        )
+        self.assertIn(
+            "Capabilities: domain.health.read",
+            registered,
+        )
+        self.assertIn(
+            "Health/evidence endpoints: https://KasiLink.com/health",
+            registered,
+        )
 
     def test_distribution_failure_does_not_erase_authorized_canonical_registry_commit(self):
         def fail_distribution(_event):
@@ -368,11 +575,16 @@ class SovereignEstateRegistryTests(unittest.TestCase):
                 "ref": "witness://kasilink/control",
                 "verified_at": "2026-08-18T09:30:00Z",
             },
-            context=self.context("witness-with-event-plane-down"),
+            context=self.context(
+                "witness-with-event-plane-down"
+            ),
         )
         self.assertEqual(result["status"], "witnessed")
         event = registry.events()[-1]
-        self.assertEqual(event["distribution_status"], "unavailable")
+        self.assertEqual(
+            event["distribution_status"],
+            "unavailable",
+        )
         self.assertFalse(event["transport_grants_authority"])
         self.assertTrue(event["canonical_registry_changed"])
 

--- a/tests/test_sovereign_estate_registry.py
+++ b/tests/test_sovereign_estate_registry.py
@@ -1,0 +1,381 @@
+import importlib.util
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+import sys
+import unittest
+
+ROOT = Path(__file__).parents[1]
+LEASE_PATH = ROOT / "governance" / "kpgs-vnext" / "security" / "capability_lease.py"
+REGISTRY_PATH = ROOT / "governance" / "kpgs-vnext" / "estate-registry" / "registry.py"
+ESTATE_PATH = ROOT / "governance" / "kpgs-vnext" / "estate-registry" / "estate.json"
+
+
+def load_module(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+lease_mod = load_module("kpgs_lease_for_registry", LEASE_PATH)
+registry_mod = load_module("kpgs_estate_registry", REGISTRY_PATH)
+
+
+class FixedClock:
+    def __init__(self):
+        self.now = datetime(2026, 8, 18, 9, 30, tzinfo=timezone.utc)
+
+    def __call__(self):
+        return self.now
+
+
+class SovereignEstateRegistryTests(unittest.TestCase):
+    def setUp(self):
+        self.clock = FixedClock()
+        self.lease_authority = lease_mod.CapabilityLeaseAuthority(
+            lease_mod.KeyRing({"estate-k1": b"e" * 32}, "estate-k1"),
+            clock=self.clock,
+            max_ttl_seconds=900,
+        )
+        self.estate = json.loads(ESTATE_PATH.read_text(encoding="utf-8"))
+        self.token = self.lease_authority.issue(
+            subject_id="service:sovereign-hub",
+            subject_kind="service",
+            tenant_id="tenant:kopano",
+            domain_id="KopanoLabs.com",
+            task_id="task:estate-governance",
+            capabilities=[
+                {
+                    "name": "estate.discovery.write",
+                    "resource_scope": "estate:kopano-sovereign-estate",
+                },
+                {
+                    "name": "estate.registry.witness",
+                    "resource_scope": "dns:candidate.example.org",
+                },
+                {
+                    "name": "estate.registry.classify",
+                    "resource_scope": "dns:candidate.example.org",
+                },
+                {
+                    "name": "estate.registry.write",
+                    "resource_scope": "dns:candidate.example.org",
+                },
+                {
+                    "name": "estate.registry.witness",
+                    "resource_scope": "dns:KasiLink.com",
+                },
+                {
+                    "name": "estate.registry.write",
+                    "resource_scope": "dns:KasiLink.com",
+                },
+                {
+                    "name": "estate.release.transition",
+                    "resource_scope": "dns:KasiLink.com",
+                },
+                {
+                    "name": "estate.release.rollback",
+                    "resource_scope": "dns:KasiLink.com",
+                },
+            ],
+            policy_decision_ref="policy://estate/control-plane",
+            governing_spec_ref="spec://kpgs/estate-registry/v1",
+            ttl_seconds=600,
+            correlation_id="corr:estate-lease",
+            evidence_ref="evidence://estate/lease",
+        )
+        self.registry = registry_mod.SovereignEstateRegistry(
+            self.estate,
+            self.lease_authority,
+            clock=self.clock,
+        )
+
+    def context(self, nonce, *, tenant_id="tenant:kopano"):
+        return registry_mod.MutationContext(
+            token=self.token,
+            tenant_id=tenant_id,
+            domain_id="KopanoLabs.com",
+            task_id="task:estate-governance",
+            operation_nonce=nonce,
+            correlation_id=f"corr:{nonce}",
+        )
+
+    @staticmethod
+    def registered_metadata(domain):
+        return {
+            "domain": domain,
+            "repositories": [
+                {
+                    "repository": "RobynAwesome/example-runtime",
+                    "role": "primary",
+                    "ref": "commit:abc123",
+                }
+            ],
+            "deployment": {
+                "provider": "vercel",
+                "environment": "staging",
+                "target": f"https://{domain}",
+                "environments": [
+                    {
+                        "name": "staging",
+                        "provider": "vercel",
+                        "target": f"https://staging.{domain}",
+                    },
+                    {
+                        "name": "production",
+                        "provider": "vercel",
+                        "target": f"https://{domain}",
+                    },
+                ],
+            },
+            "adapter": {
+                "required": True,
+                "implementation": "canonical-domain-adapter",
+                "version": "contract-v1",
+            },
+            "renter_compatibility": {
+                "status": "partial",
+                "protocol_version": "1.0",
+            },
+            "governance": {
+                "policy_ref": "policy://estate/property",
+                "risk_class": "R1",
+                "tier": "T1",
+            },
+            "owner": {"ref": "owner://declared", "kind": "declared-owner"},
+            "skills": ["estate-observer"],
+            "capabilities": ["domain.health.read"],
+            "secret_provider_refs": ["vault://estate/runtime-reference"],
+            "health_endpoints": [f"https://{domain}/health"],
+            "release": {"live_ref": None, "evidence_ref": None},
+            "rollback": {"target_ref": None, "procedure_ref": None},
+            "notes": ["test fixture only; not ownership evidence"],
+        }
+
+    def test_initial_six_domains_remain_present_and_unpromoted(self):
+        snapshot = self.registry.snapshot()
+        domains = {item["domain"] for item in snapshot["properties"]}
+        self.assertEqual(
+            domains,
+            {
+                "KasiLink.com",
+                "FivesArena.com",
+                "starfallsalvage.kopanolabs.com",
+                "crisisconnect.kopanolabs.com",
+                "KopanoLabs.com",
+                "KRRababalela.com",
+            },
+        )
+        self.assertTrue(
+            all(item["status"] == "declared_pending_witness" for item in snapshot["properties"])
+        )
+
+    def test_discovery_enters_unwitnessed_queue_and_does_not_register_itself(self):
+        candidate = self.registry.discover_candidate(
+            "candidate.example.org",
+            provenance={
+                "kind": "dns",
+                "ref": "dns://observed/candidate.example.org",
+                "observed_at": "2026-08-18T09:30:00Z",
+            },
+            context=self.context("discover-001"),
+        )
+        self.assertEqual(candidate["status"], "unwitnessed")
+        self.assertEqual(len(self.registry.candidates()), 1)
+        domains = {item["domain"] for item in self.registry.snapshot()["properties"]}
+        self.assertNotIn("candidate.example.org", domains)
+
+    def test_duplicate_discovery_deduplicates_candidate_but_preserves_provenance(self):
+        first = self.registry.discover_candidate(
+            "candidate.example.org",
+            provenance={
+                "kind": "dns",
+                "ref": "dns://first",
+                "observed_at": "2026-08-18T09:30:00Z",
+            },
+            context=self.context("discover-002"),
+        )
+        second = self.registry.discover_candidate(
+            "CANDIDATE.example.org.",
+            provenance={
+                "kind": "repository",
+                "ref": "github://second",
+                "observed_at": "2026-08-18T09:31:00Z",
+            },
+            context=self.context("discover-003"),
+        )
+        self.assertEqual(first["candidate_id"], second["candidate_id"])
+        self.assertEqual(len(second["provenance"]), 2)
+        self.assertEqual(len(self.registry.candidates()), 1)
+
+    def test_candidate_requires_witness_then_classification_then_registration(self):
+        candidate = self.registry.discover_candidate(
+            "candidate.example.org",
+            provenance={
+                "kind": "repository",
+                "ref": "github://candidate",
+                "observed_at": "2026-08-18T09:30:00Z",
+            },
+            context=self.context("discover-004"),
+        )
+        with self.assertRaises(registry_mod.RegistryTransitionDenied):
+            self.registry.register_candidate(
+                candidate["candidate_id"],
+                self.registered_metadata("candidate.example.org"),
+                context=self.context("register-too-early"),
+            )
+
+        witnessed = self.registry.witness_candidate(
+            candidate["candidate_id"],
+            {
+                "kind": "domain-control",
+                "ref": "witness://domain-control/001",
+                "verified_at": "2026-08-18T09:32:00Z",
+            },
+            context=self.context("witness-candidate"),
+        )
+        self.assertEqual(witnessed["status"], "witnessed")
+
+        classified = self.registry.classify_candidate(
+            candidate["candidate_id"],
+            owner_ref="owner://verified/001",
+            governance_tier="T1",
+            risk_class="R1",
+            context=self.context("classify-candidate"),
+        )
+        self.assertEqual(classified["status"], "classified")
+
+        registered = self.registry.register_candidate(
+            candidate["candidate_id"],
+            self.registered_metadata("candidate.example.org"),
+            context=self.context("register-candidate"),
+        )
+        self.assertEqual(registered["status"], "registered")
+        self.assertEqual(registered["owner"]["ref"], "owner://declared")
+        self.assertEqual(registered["ownership_evidence"][0]["kind"], "domain-control")
+
+    def test_cross_tenant_mutation_is_denied_by_capability_lease(self):
+        with self.assertRaises(lease_mod.LeaseDenied):
+            self.registry.discover_candidate(
+                "candidate.example.org",
+                provenance={
+                    "kind": "dns",
+                    "ref": "dns://candidate",
+                    "observed_at": "2026-08-18T09:30:00Z",
+                },
+                context=self.context("cross-tenant", tenant_id="tenant:other"),
+            )
+        self.assertEqual(self.registry.candidates(), ())
+
+    def test_existing_declared_property_cannot_skip_witness_or_registration(self):
+        with self.assertRaises(registry_mod.RegistryTransitionDenied):
+            self.registry.transition_property(
+                "KasiLink.com",
+                "production",
+                context=self.context("skip-to-production"),
+            )
+
+        witnessed = self.registry.witness_property(
+            "KasiLink.com",
+            {
+                "kind": "domain-control",
+                "ref": "witness://kasilink/control",
+                "verified_at": "2026-08-18T09:30:00Z",
+            },
+            context=self.context("witness-kasilink"),
+        )
+        self.assertEqual(witnessed["status"], "witnessed")
+
+        registered = self.registry.register_property(
+            "KasiLink.com",
+            self.registered_metadata("KasiLink.com"),
+            context=self.context("register-kasilink"),
+        )
+        self.assertEqual(registered["status"], "registered")
+
+    def test_promotion_requires_release_evidence_and_rollback_then_rollback_is_explicit(self):
+        self.registry.witness_property(
+            "KasiLink.com",
+            {
+                "kind": "domain-control",
+                "ref": "witness://kasilink/control",
+                "verified_at": "2026-08-18T09:30:00Z",
+            },
+            context=self.context("witness-kasilink-2"),
+        )
+        self.registry.register_property(
+            "KasiLink.com",
+            self.registered_metadata("KasiLink.com"),
+            context=self.context("register-kasilink-2"),
+        )
+        self.registry.transition_property(
+            "KasiLink.com",
+            "staging",
+            context=self.context("stage-kasilink"),
+        )
+        with self.assertRaises(registry_mod.RegistryTransitionDenied):
+            self.registry.transition_property(
+                "KasiLink.com",
+                "production",
+                context=self.context("promote-without-receipts"),
+            )
+
+        production = self.registry.transition_property(
+            "KasiLink.com",
+            "production",
+            release_ref="commit:live-002",
+            evidence_ref="evidence://deploy/live-002",
+            rollback_target_ref="commit:live-001",
+            rollback_procedure_ref="runbook://rollback/kasilink",
+            context=self.context("promote-kasilink"),
+        )
+        self.assertEqual(production["status"], "production")
+        self.assertEqual(production["release"]["live_ref"], "commit:live-002")
+
+        rolled_back = self.registry.rollback_property(
+            "KasiLink.com",
+            context=self.context("rollback-kasilink"),
+        )
+        self.assertEqual(rolled_back["status"], "staging")
+        self.assertEqual(rolled_back["release"]["live_ref"], "commit:live-001")
+        self.assertEqual(self.registry.events()[-1]["action"], "property-rollback")
+
+    def test_plain_language_answer_exposes_location_version_and_rollback_state(self):
+        text = self.registry.explain_property("FivesArena.com")
+        self.assertIn("FivesArena.com is declared_pending_witness", text)
+        self.assertIn("Repositories: not witnessed", text)
+        self.assertIn("Deployment: not witnessed", text)
+        self.assertIn("Live version: not promoted", text)
+        self.assertIn("Rollback target: not recorded", text)
+
+    def test_distribution_failure_does_not_erase_authorized_canonical_registry_commit(self):
+        def fail_distribution(_event):
+            raise RuntimeError("event plane unavailable")
+
+        registry = registry_mod.SovereignEstateRegistry(
+            self.estate,
+            self.lease_authority,
+            clock=self.clock,
+            distribution_sink=fail_distribution,
+        )
+        result = registry.witness_property(
+            "KasiLink.com",
+            {
+                "kind": "domain-control",
+                "ref": "witness://kasilink/control",
+                "verified_at": "2026-08-18T09:30:00Z",
+            },
+            context=self.context("witness-with-event-plane-down"),
+        )
+        self.assertEqual(result["status"], "witnessed")
+        event = registry.events()[-1]
+        self.assertEqual(event["distribution_status"], "unavailable")
+        self.assertFalse(event["transport_grants_authority"])
+        self.assertTrue(event["canonical_registry_changed"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #35.

## Canonical scope
This PR turns the existing estate schema + conservative six-record seed into an executable Sovereign Hub registry runtime. It consumes the canonical capability lease authority from merged #74; it does not introduce a parallel security model.

The six initial properties remain `declared_pending_witness` until authoritative witness evidence is actually admitted. This PR does **not** enrich them from memory, public search or unrelated connector visibility.

## Discovery review queue
Unknown authorized-source observations enter:
`discover -> unwitnessed -> witness -> classify -> register`

- case-insensitive DNS dedupe
- multiple provenance observations retained
- ISO-8601 provenance timestamps validated
- unwitnessed candidate never enters canonical property registry
- witnessed classification owner/risk/tier cannot be weakened by later registration metadata
- explicit reject path before registration

## Capability boundary
Every mutation consumes a short-lived KPGS capability lease with exact tenant/domain/task/resource scope and unique operation nonce.

## Registry linkage
Registered properties bind DNS to owner+witness evidence, repositories/refs, deployment+environments, adapter/version, Stateless Renter compatibility, governance policy/risk/tier, skills/capabilities, secret-provider references only, health/evidence endpoints, release evidence and rollback target/procedure.

Registration fails closed when required linkage is incomplete.

## Governed release lifecycle
Production promotion requires live release ref + deployment/evidence ref + rollback target + rollback procedure. Rollback is explicit and returns a production property to staging at its recorded rollback target for re-verification.

## Realtime / SWFUS boundary
An admitted registry mutation is canonical control-plane authority. Optional event-plane/SWFUS distribution follows it. Event-plane failure records `distribution_status=unavailable` but does not erase the authorized registry commit, and `transport_grants_authority=false` remains explicit.

## Plain-language Hub query
`explain_property(domain)` returns status, repositories, deployment, adapter version, renter compatibility, governance policy, granted capabilities, health/evidence endpoints, live version/evidence and rollback target. Unknowns are stated as `not witnessed`, `not granted`, `not promoted` or `not recorded`.

## Validation — head `63da10d7a3db4c5b3c39a9548829ab6351a49a6a`
- KPGS vNext Contract Gate `32120800436` — PASS
  - all prior Phase 0/SWFUS/capability contracts — PASS
  - sovereign estate validator — PASS
  - estate runtime conformance — PASS
  - governed runtime compilation — PASS
- CodeQL Advanced `32120800450` — PASS
- Kopano CI Pipeline `32120800676` — PASS
  - CLI — PASS
  - GUI lint/build — PASS
  - Agent build POC + KPEFS — PASS
  - Python 3.11 compile/ruff/pytest — PASS
  - Python 3.12 compile/ruff/pytest — PASS

## Proof surface
- `estate-registry/registry.py`
- `estate-registry/discovery-candidate.schema.json`
- expanded `estate-registry.schema.json`
- `estate-registry/README.md`
- dependency-free `estate-registry/validate_registry.py`
- `tests/test_sovereign_estate_registry.py`

## Merge posture
Validation complete; ready for canonical Phase‑1 promotion.