### PR TITLE
feat(evidence): execute canonical bundles governance scorecards and rollback signals

### DIFF
--- a/.github/workflows/kpgs-vnext-phase0-gate.yml
+++ b/.github/workflows/kpgs-vnext-phase0-gate.yml
@@ -9,6 +9,7 @@ on:
       - "tests/test_swfus_progressive_updates.py"
       - "tests/test_capability_lease_runtime.py"
       - "tests/test_sovereign_estate_registry.py"
+      - "tests/test_evidence_bundles.py"
       - "CONTRIBUTING.md"
       - "THIRD_PARTY_NOTICES.md"
       - "LICENSE"
@@ -21,6 +22,7 @@ on:
       - "tests/test_swfus_progressive_updates.py"
       - "tests/test_capability_lease_runtime.py"
       - "tests/test_sovereign_estate_registry.py"
+      - "tests/test_evidence_bundles.py"
       - "CONTRIBUTING.md"
       - "THIRD_PARTY_NOTICES.md"
       - "LICENSE"
@@ -38,7 +40,7 @@ jobs:
   truth-contracts:
     name: Validate KPGS truth and governance contracts
     runs-on: ubuntu-latest
-    timeout-minutes: 6
+    timeout-minutes: 7
 
     steps:
       - name: Checkout
@@ -76,6 +78,12 @@ jobs:
       - name: Prove sovereign estate registry conformance
         run: python -m unittest discover -s tests -p 'test_sovereign_estate_registry.py' -v
 
+      - name: Validate evidence bundle and scorecard contract
+        run: python governance/kpgs-vnext/evidence/validate_evidence.py
+
+      - name: Prove evidence bundle runtime conformance
+        run: python -m unittest discover -s tests -p 'test_evidence_bundles.py' -v
+
       - name: Compile validators and governed runtimes
         run: >-
           python -m py_compile
@@ -87,5 +95,7 @@ jobs:
           governance/kpgs-vnext/security/capability_lease.py
           governance/kpgs-vnext/estate-registry/validate_registry.py
           governance/kpgs-vnext/estate-registry/registry.py
+          governance/kpgs-vnext/evidence/validate_evidence.py
+          governance/kpgs-vnext/evidence/evidence.py
           kopano-core/kopano/swfus_engine.py
           kopano-core/kopano/kessa_mmao_api.py

--- a/governance/kpgs-vnext/README.md
+++ b/governance/kpgs-vnext/README.md
@@ -1,6 +1,6 @@
 # KPGS vNext — Sovereign Hub Re-engineering
 
-Status: **Phase 1 — Governance Substrate**
+Status: **Phase 1 — Governance Substrate / Evidence Completion**
 Epic: #46
 
 KPGS vNext makes `Introduction-to-MCP` the canonical specification and governance layer for the Kopano DNS estate. Existing frontends may remain React/Next/Vite/PWA or other appropriate stacks; the canonical integration boundary is a governed domain adapter, Sovereign Hub, Stateless Renter protocol, skill runtime, realtime event plane and evidence system.
@@ -48,6 +48,8 @@ Tools / APIs / Domain Systems
 12. Mutating CRUD MUST NOT occur before invariant and POC/FOC governance has passed.
 13. Authentication establishes identity; privileged execution additionally requires a live, exact-scoped capability lease.
 14. Lease signing material and durable provider credentials MUST NOT be owned by a Stateless Renter or frontend.
+15. Aggregate scores MUST NOT hide a failed hard governance or security gate.
+16. Production promotion MUST identify the exact release/commit and the canonical evidence bundle that justified it.
 
 ## Control loops
 
@@ -97,10 +99,47 @@ The reference capability runtime is intentionally server-side. OIDC/JWT/session 
 
 See `security/CAPABILITY_LEASE.md`, `security/capability-lease.schema.json`, and `security/capability_lease.py`.
 
+### Sovereign estate authority
+
+```text
+discover
+  -> unwitnessed queue
+  -> witness
+  -> classify
+  -> register
+  -> staging
+  -> production
+  -> observe
+  -> rollback | suspend | decommission
+```
+
+The estate registry is canonical control-plane state. Unknown properties never self-promote from connector visibility, public search or transport discovery. Production transitions require release evidence and rollback receipts, while realtime/SWFUS distribution remains non-authoritative projection alignment.
+
+See `estate-registry/README.md`, `estate-registry/registry.py`, `estate-registry/estate-registry.schema.json`, and `estate-registry/discovery-candidate.schema.json`.
+
+### Evidence and scorecards
+
+```text
+estate property
+  -> exact release + commit
+  -> adapter
+  -> renter
+  -> skill
+  -> task/session
+  -> verifier
+  -> governance decision
+  -> engineering scorecard
+  `-> everyday governance scorecard
+```
+
+One canonical evidence bundle feeds both scorecards. Hard gates remain independent from aggregate scores. Secret-bearing material is rejected from bundle metadata, retention/redaction policy references are mandatory, and rollback assessment can recommend—but never directly execute—a rollback without the separately governed rollback capability.
+
+See `evidence/EVIDENCE.md`, `evidence/evidence-bundle.schema.json`, and `evidence/evidence.py`.
+
 ## Phase map
 
 - **Phase 0 — Truth and contracts:** fork assimilation, renter protocol, specification-first governance. **Complete.**
-- **Phase 1 — Governance substrate:** identity/capability leases, Sovereign Hub registry, evidence model. **In progress.**
+- **Phase 1 — Governance substrate:** identity/capability leases, Sovereign Hub registry, evidence model. **Implementation complete on this branch; final evidence CI/promotion pending.**
 - **Phase 2 — Runtime packages:** .NET domain adapter, skill runtime, realtime event plane.
 - **Phase 3 — Validation + human experience:** evaluation loop and Sovereign Everyday Mode.
 - **Phase 4 — Estate proof:** migrate one bounded low-risk workflow, prove rollback, then expand.
@@ -126,9 +165,14 @@ See `security/CAPABILITY_LEASE.md`, `security/capability-lease.schema.json`, and
 - `security/CAPABILITY_LEASE.md`
 - `security/capability-lease.schema.json`
 - `security/capability_lease.py`
+- `estate-registry/README.md`
 - `estate-registry/estate-registry.schema.json`
+- `estate-registry/discovery-candidate.schema.json`
 - `estate-registry/estate.json`
+- `estate-registry/registry.py`
+- `evidence/EVIDENCE.md`
 - `evidence/evidence-bundle.schema.json`
+- `evidence/evidence.py`
 
 ## Definition of done
 

--- a/governance/kpgs-vnext/README.md
+++ b/governance/kpgs-vnext/README.md
@@ -1,6 +1,6 @@
 # KPGS vNext — Sovereign Hub Re-engineering
 
-Status: **Phase 1 — Governance Substrate / Evidence Completion**
+Status: **Phase 1 — Governance Substrate Complete**
 Epic: #46
 
 KPGS vNext makes `Introduction-to-MCP` the canonical specification and governance layer for the Kopano DNS estate. Existing frontends may remain React/Next/Vite/PWA or other appropriate stacks; the canonical integration boundary is a governed domain adapter, Sovereign Hub, Stateless Renter protocol, skill runtime, realtime event plane and evidence system.
@@ -139,7 +139,7 @@ See `evidence/EVIDENCE.md`, `evidence/evidence-bundle.schema.json`, and `evidenc
 ## Phase map
 
 - **Phase 0 — Truth and contracts:** fork assimilation, renter protocol, specification-first governance. **Complete.**
-- **Phase 1 — Governance substrate:** identity/capability leases, Sovereign Hub registry, evidence model. **Implementation complete on this branch; final evidence CI/promotion pending.**
+- **Phase 1 — Governance substrate:** identity/capability leases, Sovereign Hub registry, evidence model. **Complete.**
 - **Phase 2 — Runtime packages:** .NET domain adapter, skill runtime, realtime event plane.
 - **Phase 3 — Validation + human experience:** evaluation loop and Sovereign Everyday Mode.
 - **Phase 4 — Estate proof:** migrate one bounded low-risk workflow, prove rollback, then expand.

--- a/governance/kpgs-vnext/evidence/EVIDENCE.md
+++ b/governance/kpgs-vnext/evidence/EVIDENCE.md
@@ -6,11 +6,13 @@ Issue: #45
 
 Evidence is the bridge between execution and governance. A release, capability use, policy decision, evaluation or rollback is only inspectable when KPGS can correlate it to the exact domain, release, adapter, renter, skill, task and verifier involved.
 
+The executable reference is `evidence.py`. Both technical and plain-language scorecards are derived from the same finalized evidence bundle.
+
 ## Canonical correlation chain
 
 ```text
 estate property
-  -> release
+  -> exact release + commit
   -> adapter
   -> renter
   -> skill(s)
@@ -19,7 +21,19 @@ estate property
   -> governance decision
 ```
 
+For user-facing task evidence, trace hops additionally prove the request path across:
+
+```text
+PWA -> adapter -> Sovereign Hub -> renter -> skill -> verifier
+```
+
+Deployment promotion evidence also carries a deployment trace hop.
+
+A canonical bundle cannot substitute an aggregate score for a missing correlation link.
+
 ## Evidence classes
+
+Artifacts:
 
 - `specification`
 - `policy-decision`
@@ -33,17 +47,130 @@ estate property
 - `rollback`
 - `user-outcome`
 
+Metrics:
+
+- latency
+- realtime health
+- cost/usage where measurable
+- reliability/error/recovery rate
+- user task completion/abandonment
+- accessibility
+- mobile validation
+
+Every artifact and metric is a reference to inspectable evidence; raw credentials are never embedded.
+
+## Production promotion requirement
+
+A governance decision of `promote` requires:
+
+- exact release reference;
+- exact 40-character Git commit SHA;
+- adapter implementation/version;
+- renter identity/protocol version;
+- at least one named/versioned skill;
+- task + session + correlation identity;
+- capability lease reference;
+- complete user-task trace plus deployment trace;
+- verifier results;
+- core promotion artifact classes;
+- core latency/realtime/reliability/error/task/accessibility/mobile metrics;
+- explicit retention and redaction policy references.
+
+If a release cannot identify the evidence that justified its promotion, KPGS treats that release as outside canonical governance.
+
 ## Hard-gate rule
 
-Aggregate scores MUST NOT hide or average away a failed hard governance or security gate. Evidence bundles therefore carry both:
+Aggregate scores MUST NOT hide or average away a failed hard governance or security gate.
 
-- individual verifier results with `hard_gate` and `passed` state; and
-- optional aggregate scores for dimensions where aggregation is meaningful.
+The runtime therefore evaluates hard gates independently:
 
-## Redaction
+- failed hard gate + `promote` → reject bundle finalization;
+- failed hard gate + `allow` → reject bundle finalization;
+- failed hard gate + `hold | deny | rollback` → bundle may finalize so the failure remains inspectable and actionable;
+- engineering scorecard always exposes raw hard-gate failures independently of aggregate scores;
+- everyday scorecard renders hard-gate failure as `blocked` / high risk.
 
-Evidence may reference secret-provider operations and sensitive events, but MUST NOT store raw credentials or unredacted secrets. Retention and redaction policy must be explicit at the owning tenant/domain level.
+A score of `0.9999` cannot cancel one failed hard security criterion.
 
-## Release requirement
+## Scorecards
 
-A production release SHOULD carry an immutable evidence bundle reference. If a release cannot identify the evidence that justified its promotion, KPGS treats that release as outside canonical governance.
+### Engineering scorecard
+
+Derived directly from the canonical bundle and includes:
+
+- exact release/commit/correlation IDs;
+- raw verifier outputs;
+- hard-gate failures;
+- metrics;
+- aggregate scores;
+- trace hops;
+- artifacts;
+- governance decision;
+- retention/redaction references.
+
+### Everyday governance scorecard
+
+Derived from that same bundle and answers:
+
+- what property changed?
+- what release/commit is involved?
+- is it ready, active, attention-needed or blocked?
+- what risk state applies?
+- what decision was made?
+- why was it allowed/blocked?
+- which hard gates failed?
+- what should happen next?
+
+No separate “friendly” database or second scoring model exists.
+
+## Redaction rules
+
+Evidence MUST NOT store raw:
+
+- authorization headers;
+- passwords;
+- access/session/API tokens;
+- cookies;
+- provider credentials;
+- private keys;
+- known secret-token patterns.
+
+Trace metadata is recursively checked for secret-bearing key names and common credential patterns. Capability lease fields carry references such as `lease://...`, never compact signed tokens. Secret-provider evidence may be referenced through governed references (for example `vault://...`) but raw secret values are forbidden.
+
+Every finalized bundle MUST name a `redaction_policy_ref` so the owning tenant/domain can resolve the exact policy used.
+
+## Retention rules
+
+Every finalized bundle MUST name a `retention_policy_ref`.
+
+The referenced retention policy is responsible for defining, at minimum:
+
+- evidence owner / tenant / domain;
+- retention class;
+- expiry or retention duration;
+- legal/governance hold behavior where applicable;
+- deletion/archive procedure;
+- whether derived scorecards survive deletion of lower-level raw telemetry.
+
+KPGS deliberately does not invent one universal retention duration in this protocol. The bundle proves **which governed policy applies**, while the owning policy defines the duration.
+
+## Rollback support
+
+`rollback_recommendation(bundle, thresholds)` derives a machine-readable signal from canonical evidence.
+
+A failed hard gate always triggers a rollback recommendation. Optional caller-supplied numeric metric thresholds may also trigger it. The function **never executes rollback itself**.
+
+Execution still requires:
+
+- the recorded estate rollback target/procedure;
+- a valid `estate.release.rollback` capability lease;
+- a Sovereign Hub governance action.
+
+This keeps evidence observable and automatable without allowing telemetry to become ambient authority.
+
+## Machine contracts
+
+- `evidence-bundle.schema.json`
+- `evidence.py`
+- `validate_evidence.py`
+- `tests/test_evidence_bundles.py`

--- a/governance/kpgs-vnext/evidence/evidence-bundle.schema.json
+++ b/governance/kpgs-vnext/evidence/evidence-bundle.schema.json
@@ -9,17 +9,26 @@
     "created_at",
     "estate_property",
     "release_ref",
+    "commit_sha",
     "task_id",
     "correlation_id",
+    "trace_hops",
     "artifacts",
     "verifications",
-    "governance_decision"
+    "metrics",
+    "governance_decision",
+    "retention_policy_ref",
+    "redaction_policy_ref"
   ],
   "properties": {
     "bundle_id": { "type": "string", "minLength": 8 },
     "created_at": { "type": "string", "format": "date-time" },
     "estate_property": { "type": "string", "minLength": 3 },
     "release_ref": { "type": ["string", "null"] },
+    "commit_sha": {
+      "type": ["string", "null"],
+      "pattern": "^[a-fA-F0-9]{40}$"
+    },
     "adapter": {
       "type": ["object", "null"],
       "additionalProperties": false,
@@ -56,6 +65,46 @@
       "type": "array",
       "items": { "type": "string", "minLength": 1 }
     },
+    "trace_hops": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["layer", "ref", "status", "at"],
+        "properties": {
+          "layer": {
+            "enum": [
+              "pwa",
+              "adapter",
+              "sovereign-hub",
+              "renter",
+              "skill",
+              "verifier",
+              "deployment"
+            ]
+          },
+          "ref": { "type": "string", "minLength": 1 },
+          "status": {
+            "enum": [
+              "started",
+              "succeeded",
+              "failed",
+              "blocked",
+              "recovered",
+              "abandoned"
+            ]
+          },
+          "at": { "type": "string", "format": "date-time" },
+          "duration_ms": { "type": ["number", "null"], "minimum": 0 },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": {
+              "type": ["string", "number", "boolean", "null"]
+            }
+          }
+        }
+      }
+    },
     "artifacts": {
       "type": "array",
       "items": {
@@ -80,7 +129,10 @@
             ]
           },
           "ref": { "type": "string", "minLength": 1 },
-          "sha256": { "type": ["string", "null"], "pattern": "^[a-fA-F0-9]{64}$" }
+          "sha256": {
+            "type": ["string", "null"],
+            "pattern": "^[a-fA-F0-9]{64}$"
+          }
         }
       }
     },
@@ -89,17 +141,62 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["verifier_id", "criterion_id", "method", "hard_gate", "passed", "evidence_ref"],
+        "required": [
+          "verifier_id",
+          "criterion_id",
+          "method",
+          "hard_gate",
+          "passed",
+          "evidence_ref"
+        ],
         "properties": {
           "verifier_id": { "type": "string", "minLength": 1 },
           "criterion_id": { "type": "string", "minLength": 1 },
           "method": {
             "type": "string",
-            "enum": ["unit", "integration", "e2e", "schema", "security", "performance", "accessibility", "human-review", "model-eval"]
+            "enum": [
+              "unit",
+              "integration",
+              "e2e",
+              "schema",
+              "security",
+              "performance",
+              "accessibility",
+              "human-review",
+              "model-eval"
+            ]
           },
           "hard_gate": { "type": "boolean" },
           "passed": { "type": "boolean" },
           "score": { "type": ["number", "null"] },
+          "evidence_ref": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "metrics": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "value", "evidence_ref"],
+        "properties": {
+          "name": {
+            "enum": [
+              "latency",
+              "realtime-health",
+              "cost",
+              "usage",
+              "reliability",
+              "error-rate",
+              "recovery-rate",
+              "task-completion",
+              "task-abandonment",
+              "accessibility",
+              "mobile"
+            ]
+          },
+          "value": { "type": ["number", "string", "boolean"] },
+          "unit": { "type": ["string", "null"] },
           "evidence_ref": { "type": "string", "minLength": 1 }
         }
       }
@@ -113,14 +210,18 @@
       "additionalProperties": false,
       "required": ["decision", "reason", "decided_at"],
       "properties": {
-        "decision": { "type": "string", "enum": ["allow", "deny", "promote", "rollback", "hold"] },
+        "decision": {
+          "type": "string",
+          "enum": ["allow", "deny", "promote", "rollback", "hold"]
+        },
         "reason": { "type": "string", "minLength": 1 },
         "decided_at": { "type": "string", "format": "date-time" },
-        "decision_ref": { "type": ["string", "null"] }
+        "decision_ref": { "type": ["string", "null"] },
+        "next_action": { "type": ["string", "null"] }
       }
     },
-    "retention_policy_ref": { "type": ["string", "null"] },
-    "redaction_policy_ref": { "type": ["string", "null"] }
+    "retention_policy_ref": { "type": "string", "minLength": 1 },
+    "redaction_policy_ref": { "type": "string", "minLength": 1 }
   },
   "allOf": [
     {
@@ -128,7 +229,7 @@
         "properties": {
           "governance_decision": {
             "properties": {
-              "decision": { "const": "promote" }
+              "decision": { "enum": ["promote", "allow"] }
             }
           },
           "verifications": {
@@ -142,6 +243,47 @@
           }
         },
         "required": ["governance_decision", "verifications"]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "governance_decision": {
+            "properties": {
+              "decision": { "const": "promote" }
+            },
+            "required": ["decision"]
+          }
+        },
+        "required": ["governance_decision"]
+      },
+      "then": {
+        "properties": {
+          "release_ref": { "type": "string", "minLength": 1 },
+          "commit_sha": {
+            "type": "string",
+            "pattern": "^[a-fA-F0-9]{40}$"
+          },
+          "adapter": { "type": "object" },
+          "renter": { "type": "object" },
+          "skills": { "minItems": 1 },
+          "session_id": { "type": "string", "minLength": 1 },
+          "verifications": { "minItems": 1 },
+          "artifacts": {
+            "contains": {
+              "properties": { "kind": { "const": "deployment" } },
+              "required": ["kind"]
+            }
+          }
+        },
+        "required": [
+          "release_ref",
+          "commit_sha",
+          "adapter",
+          "renter",
+          "skills",
+          "session_id"
+        ]
       }
     }
   ]

--- a/governance/kpgs-vnext/evidence/evidence-bundle.schema.json
+++ b/governance/kpgs-vnext/evidence/evidence-bundle.schema.json
@@ -246,6 +246,22 @@
       }
     },
     {
+      "not": {
+        "properties": {
+          "verifications": {
+            "contains": {
+              "properties": {
+                "method": { "const": "security" },
+                "hard_gate": { "const": false }
+              },
+              "required": ["method", "hard_gate"]
+            }
+          }
+        },
+        "required": ["verifications"]
+      }
+    },
+    {
       "if": {
         "properties": {
           "governance_decision": {

--- a/governance/kpgs-vnext/evidence/evidence.py
+++ b/governance/kpgs-vnext/evidence/evidence.py
@@ -98,6 +98,9 @@ SECRET_VALUE_PATTERNS = (
     re.compile(r"\bsk-(?:proj-)?[A-Za-z0-9_-]{12,}"),
     re.compile(r"-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----"),
     re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+    re.compile(
+        r"\b[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b"
+    ),
 )
 
 
@@ -136,6 +139,7 @@ def _require_ref(value: str, field_name: str) -> str:
     cleaned = value.strip()
     if "://" not in cleaned:
         raise EvidenceError(f"{field_name} must be a governed reference")
+    _assert_secret_safe(cleaned, field_name)
     return cleaned
 
 
@@ -168,7 +172,10 @@ def hard_gate_failures(bundle: Mapping[str, Any]) -> list[dict[str, Any]]:
         deepcopy(item)
         for item in bundle.get("verifications", [])
         if isinstance(item, Mapping)
-        and item.get("hard_gate") is True
+        and (
+            item.get("hard_gate") is True
+            or item.get("method") == "security"
+        )
         and item.get("passed") is False
     ]
 
@@ -273,6 +280,7 @@ class EvidenceBundleBuilder:
             raise EvidenceCorrelationError("trace ref is required")
         if duration_ms is not None and duration_ms < 0:
             raise EvidenceCorrelationError("trace duration cannot be negative")
+        _assert_secret_safe(ref, f"trace.{layer}.ref")
         metadata_copy = deepcopy(dict(metadata or {}))
         _assert_secret_safe(metadata_copy, f"trace.{layer}.metadata")
         self._base["trace_hops"].append(
@@ -335,6 +343,9 @@ class EvidenceBundleBuilder:
             raise EvidenceError("unknown verification method")
         if not verifier_id.strip() or not criterion_id.strip() or not evidence_ref.strip():
             raise EvidenceError("verification identity, criterion and evidence are required")
+        if method == "security" and not hard_gate:
+            raise EvidenceError("security verification must be a hard gate")
+        _assert_secret_safe(evidence_ref, "verification.evidence_ref")
         self._base["verifications"].append(
             {
                 "verifier_id": verifier_id.strip(),
@@ -362,6 +373,7 @@ class EvidenceBundleBuilder:
             raise EvidenceError("metric value must be scalar")
         if not evidence_ref.strip():
             raise EvidenceError("metric evidence ref is required")
+        _assert_secret_safe(evidence_ref, f"metric.{name}.evidence_ref")
         self._base["metrics"].append(
             {
                 "name": name,

--- a/governance/kpgs-vnext/evidence/evidence.py
+++ b/governance/kpgs-vnext/evidence/evidence.py
@@ -1,0 +1,582 @@
+"""Executable KPGS evidence bundles and governance scorecards.
+
+One canonical evidence bundle feeds both engineering and everyday governance
+views. Hard policy/security gates are evaluated separately from aggregate
+scores and can never be averaged away.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import datetime, timezone
+import hashlib
+import json
+import re
+from typing import Any, Callable, Iterable, Mapping
+
+DECISIONS = {"allow", "deny", "promote", "rollback", "hold"}
+TRACE_LAYERS = {
+    "pwa",
+    "adapter",
+    "sovereign-hub",
+    "renter",
+    "skill",
+    "verifier",
+    "deployment",
+}
+REQUIRED_USER_TRACE_LAYERS = {
+    "pwa",
+    "adapter",
+    "sovereign-hub",
+    "renter",
+    "skill",
+    "verifier",
+}
+ARTIFACT_KINDS = {
+    "specification",
+    "policy-decision",
+    "capability-lease",
+    "execution",
+    "verification",
+    "security",
+    "performance",
+    "accessibility",
+    "deployment",
+    "rollback",
+    "user-outcome",
+}
+PROMOTION_ARTIFACT_KINDS = {
+    "specification",
+    "policy-decision",
+    "capability-lease",
+    "execution",
+    "verification",
+    "security",
+    "accessibility",
+    "deployment",
+    "user-outcome",
+}
+METRIC_NAMES = {
+    "latency",
+    "realtime-health",
+    "cost",
+    "usage",
+    "reliability",
+    "error-rate",
+    "recovery-rate",
+    "task-completion",
+    "task-abandonment",
+    "accessibility",
+    "mobile",
+}
+PROMOTION_METRICS = {
+    "latency",
+    "realtime-health",
+    "reliability",
+    "error-rate",
+    "task-completion",
+    "task-abandonment",
+    "accessibility",
+    "mobile",
+}
+FORBIDDEN_METADATA_KEYS = {
+    "authorization",
+    "password",
+    "passwd",
+    "secret",
+    "token",
+    "credential",
+    "credentials",
+    "cookie",
+    "api_key",
+    "apikey",
+    "access_key",
+    "private_key",
+}
+SECRET_VALUE_PATTERNS = (
+    re.compile(r"\bBearer\s+[A-Za-z0-9._~+/=-]{12,}", re.IGNORECASE),
+    re.compile(r"\bsk-(?:proj-)?[A-Za-z0-9_-]{12,}"),
+    re.compile(r"-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----"),
+    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+)
+
+
+class EvidenceError(Exception):
+    pass
+
+
+class EvidenceCorrelationError(EvidenceError):
+    pass
+
+
+class HardGateFailure(EvidenceError):
+    pass
+
+
+def _iso8601(value: datetime) -> str:
+    normalized = value.astimezone(timezone.utc).replace(microsecond=0)
+    return normalized.isoformat().replace("+00:00", "Z")
+
+
+def _parse_time(value: str, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise EvidenceError(f"{field_name} is required")
+    try:
+        parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise EvidenceError(f"{field_name} is invalid") from exc
+    if parsed.tzinfo is None:
+        raise EvidenceError(f"{field_name} must include timezone")
+    return _iso8601(parsed)
+
+
+def _require_ref(value: str, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise EvidenceError(f"{field_name} is required")
+    cleaned = value.strip()
+    if "://" not in cleaned:
+        raise EvidenceError(f"{field_name} must be a governed reference")
+    return cleaned
+
+
+def _assert_secret_safe(value: Any, path: str = "evidence") -> None:
+    if isinstance(value, Mapping):
+        for key, child in value.items():
+            normalized_key = str(key).strip().casefold().replace("-", "_")
+            if normalized_key in FORBIDDEN_METADATA_KEYS:
+                raise EvidenceError(f"secret-bearing field forbidden at {path}.{key}")
+            _assert_secret_safe(child, f"{path}.{key}")
+        return
+    if isinstance(value, (list, tuple)):
+        for index, child in enumerate(value):
+            _assert_secret_safe(child, f"{path}[{index}]")
+        return
+    if isinstance(value, str):
+        for pattern in SECRET_VALUE_PATTERNS:
+            if pattern.search(value):
+                raise EvidenceError(f"secret-like material forbidden at {path}")
+
+
+def _commit_sha(value: str) -> str:
+    if not isinstance(value, str) or not re.fullmatch(r"[a-fA-F0-9]{40}", value):
+        raise EvidenceCorrelationError("exact 40-character release commit SHA is required")
+    return value.lower()
+
+
+def hard_gate_failures(bundle: Mapping[str, Any]) -> list[dict[str, Any]]:
+    return [
+        deepcopy(item)
+        for item in bundle.get("verifications", [])
+        if isinstance(item, Mapping)
+        and item.get("hard_gate") is True
+        and item.get("passed") is False
+    ]
+
+
+class EvidenceBundleBuilder:
+    """Build one canonical, secret-safe correlation bundle."""
+
+    def __init__(
+        self,
+        *,
+        estate_property: str,
+        release_ref: str,
+        commit_sha: str,
+        adapter: Mapping[str, str],
+        renter: Mapping[str, str],
+        skills: Iterable[Mapping[str, str]],
+        task_id: str,
+        session_id: str,
+        correlation_id: str,
+        governing_spec_ref: str,
+        retention_policy_ref: str,
+        redaction_policy_ref: str,
+        clock: Callable[[], datetime] | None = None,
+    ):
+        for label, value in {
+            "estate_property": estate_property,
+            "release_ref": release_ref,
+            "task_id": task_id,
+            "session_id": session_id,
+            "correlation_id": correlation_id,
+        }.items():
+            if not isinstance(value, str) or not value.strip():
+                raise EvidenceCorrelationError(f"{label} is required")
+        if "." not in estate_property:
+            raise EvidenceCorrelationError("estate_property must be a DNS property")
+
+        adapter_copy = deepcopy(dict(adapter))
+        renter_copy = deepcopy(dict(renter))
+        skill_list = [deepcopy(dict(item)) for item in skills]
+        if not adapter_copy.get("implementation") or not adapter_copy.get("version"):
+            raise EvidenceCorrelationError("adapter implementation/version are required")
+        if not renter_copy.get("renter_id") or not renter_copy.get("protocol_version"):
+            raise EvidenceCorrelationError("renter identity/protocol are required")
+        if not skill_list or any(not item.get("name") or not item.get("version") for item in skill_list):
+            raise EvidenceCorrelationError("at least one named/versioned skill is required")
+
+        _assert_secret_safe(adapter_copy, "adapter")
+        _assert_secret_safe(renter_copy, "renter")
+        _assert_secret_safe(skill_list, "skills")
+
+        self._clock = clock or (lambda: datetime.now(timezone.utc))
+        self._base = {
+            "created_at": _iso8601(self._clock()),
+            "estate_property": estate_property.strip(),
+            "release_ref": release_ref.strip(),
+            "commit_sha": _commit_sha(commit_sha),
+            "adapter": adapter_copy,
+            "renter": renter_copy,
+            "skills": skill_list,
+            "task_id": task_id.strip(),
+            "session_id": session_id.strip(),
+            "correlation_id": correlation_id.strip(),
+            "governing_spec_ref": _require_ref(governing_spec_ref, "governing_spec_ref"),
+            "capability_lease_refs": [],
+            "trace_hops": [],
+            "artifacts": [],
+            "verifications": [],
+            "metrics": [],
+            "aggregate_scores": {},
+            "retention_policy_ref": _require_ref(retention_policy_ref, "retention_policy_ref"),
+            "redaction_policy_ref": _require_ref(redaction_policy_ref, "redaction_policy_ref"),
+        }
+
+    def add_capability_lease_ref(self, ref: str) -> "EvidenceBundleBuilder":
+        cleaned = _require_ref(ref, "capability_lease_ref")
+        if cleaned not in self._base["capability_lease_refs"]:
+            self._base["capability_lease_refs"].append(cleaned)
+        return self
+
+    def add_trace_hop(
+        self,
+        *,
+        layer: str,
+        ref: str,
+        status: str,
+        at: str,
+        duration_ms: float | None = None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> "EvidenceBundleBuilder":
+        if layer not in TRACE_LAYERS:
+            raise EvidenceCorrelationError("unknown trace layer")
+        if status not in {
+            "started",
+            "succeeded",
+            "failed",
+            "blocked",
+            "recovered",
+            "abandoned",
+        }:
+            raise EvidenceCorrelationError("unknown trace status")
+        if not isinstance(ref, str) or not ref.strip():
+            raise EvidenceCorrelationError("trace ref is required")
+        if duration_ms is not None and duration_ms < 0:
+            raise EvidenceCorrelationError("trace duration cannot be negative")
+        metadata_copy = deepcopy(dict(metadata or {}))
+        _assert_secret_safe(metadata_copy, f"trace.{layer}.metadata")
+        self._base["trace_hops"].append(
+            {
+                "layer": layer,
+                "ref": ref.strip(),
+                "status": status,
+                "at": _parse_time(at, "trace.at"),
+                "duration_ms": duration_ms,
+                "metadata": metadata_copy,
+            }
+        )
+        return self
+
+    def add_artifact(
+        self,
+        *,
+        kind: str,
+        ref: str,
+        sha256: str | None = None,
+    ) -> "EvidenceBundleBuilder":
+        if kind not in ARTIFACT_KINDS:
+            raise EvidenceError("unknown evidence artifact kind")
+        if not isinstance(ref, str) or not ref.strip():
+            raise EvidenceError("artifact ref is required")
+        if sha256 is not None and not re.fullmatch(r"[a-fA-F0-9]{64}", sha256):
+            raise EvidenceError("artifact sha256 must contain 64 hex characters")
+        _assert_secret_safe(ref, f"artifact.{kind}.ref")
+        self._base["artifacts"].append(
+            {
+                "kind": kind,
+                "ref": ref.strip(),
+                "sha256": sha256.lower() if sha256 else None,
+            }
+        )
+        return self
+
+    def add_verification(
+        self,
+        *,
+        verifier_id: str,
+        criterion_id: str,
+        method: str,
+        hard_gate: bool,
+        passed: bool,
+        evidence_ref: str,
+        score: float | None = None,
+    ) -> "EvidenceBundleBuilder":
+        if method not in {
+            "unit",
+            "integration",
+            "e2e",
+            "schema",
+            "security",
+            "performance",
+            "accessibility",
+            "human-review",
+            "model-eval",
+        }:
+            raise EvidenceError("unknown verification method")
+        if not verifier_id.strip() or not criterion_id.strip() or not evidence_ref.strip():
+            raise EvidenceError("verification identity, criterion and evidence are required")
+        self._base["verifications"].append(
+            {
+                "verifier_id": verifier_id.strip(),
+                "criterion_id": criterion_id.strip(),
+                "method": method,
+                "hard_gate": bool(hard_gate),
+                "passed": bool(passed),
+                "score": score,
+                "evidence_ref": evidence_ref.strip(),
+            }
+        )
+        return self
+
+    def add_metric(
+        self,
+        *,
+        name: str,
+        value: float | str | bool,
+        evidence_ref: str,
+        unit: str | None = None,
+    ) -> "EvidenceBundleBuilder":
+        if name not in METRIC_NAMES:
+            raise EvidenceError("unknown metric name")
+        if not isinstance(value, (int, float, str, bool)):
+            raise EvidenceError("metric value must be scalar")
+        if not evidence_ref.strip():
+            raise EvidenceError("metric evidence ref is required")
+        self._base["metrics"].append(
+            {
+                "name": name,
+                "value": value,
+                "unit": unit,
+                "evidence_ref": evidence_ref.strip(),
+            }
+        )
+        return self
+
+    def set_aggregate_score(self, dimension: str, score: float) -> "EvidenceBundleBuilder":
+        if not isinstance(dimension, str) or not dimension.strip():
+            raise EvidenceError("aggregate score dimension is required")
+        if not isinstance(score, (int, float)):
+            raise EvidenceError("aggregate score must be numeric")
+        self._base["aggregate_scores"][dimension.strip()] = float(score)
+        return self
+
+    def _validate_correlation(self) -> None:
+        if not self._base["capability_lease_refs"]:
+            raise EvidenceCorrelationError("capability lease correlation is required")
+        if not self._base["verifications"]:
+            raise EvidenceCorrelationError("at least one verifier result is required")
+        layers = {item["layer"] for item in self._base["trace_hops"]}
+        missing = REQUIRED_USER_TRACE_LAYERS - layers
+        if missing:
+            raise EvidenceCorrelationError(
+                "user-task trace is missing layers: " + ", ".join(sorted(missing))
+            )
+        verifier_ids = {item["verifier_id"] for item in self._base["verifications"]}
+        trace_verifiers = {
+            item["ref"]
+            for item in self._base["trace_hops"]
+            if item["layer"] == "verifier"
+        }
+        if verifier_ids.isdisjoint(trace_verifiers):
+            raise EvidenceCorrelationError("verifier trace does not match verifier evidence")
+
+    def _validate_promotion_evidence(self) -> None:
+        kinds = {item["kind"] for item in self._base["artifacts"]}
+        missing_artifacts = PROMOTION_ARTIFACT_KINDS - kinds
+        if missing_artifacts:
+            raise EvidenceCorrelationError(
+                "promotion evidence missing artifact kinds: "
+                + ", ".join(sorted(missing_artifacts))
+            )
+        metric_names = {item["name"] for item in self._base["metrics"]}
+        missing_metrics = PROMOTION_METRICS - metric_names
+        if missing_metrics:
+            raise EvidenceCorrelationError(
+                "promotion evidence missing metric classes: "
+                + ", ".join(sorted(missing_metrics))
+            )
+        if not any(item["layer"] == "deployment" for item in self._base["trace_hops"]):
+            raise EvidenceCorrelationError("promotion requires deployment trace hop")
+
+    def finalize(
+        self,
+        *,
+        decision: str,
+        reason: str,
+        decision_ref: str | None = None,
+        next_action: str | None = None,
+    ) -> dict[str, Any]:
+        if decision not in DECISIONS:
+            raise EvidenceError("unknown governance decision")
+        if not isinstance(reason, str) or not reason.strip():
+            raise EvidenceError("governance decision reason is required")
+        self._validate_correlation()
+        failures = hard_gate_failures(self._base)
+        if failures and decision in {"allow", "promote"}:
+            criteria = ", ".join(item["criterion_id"] for item in failures)
+            raise HardGateFailure(
+                f"{decision} forbidden while hard gates fail: {criteria}"
+            )
+        if decision == "promote":
+            self._validate_promotion_evidence()
+
+        bundle = deepcopy(self._base)
+        bundle["governance_decision"] = {
+            "decision": decision,
+            "reason": reason.strip(),
+            "decided_at": _iso8601(self._clock()),
+            "decision_ref": decision_ref,
+            "next_action": next_action,
+        }
+        _assert_secret_safe(bundle)
+        digest_input = json.dumps(
+            bundle,
+            sort_keys=True,
+            separators=(",", ":"),
+            default=str,
+        )
+        bundle["bundle_id"] = (
+            "evidence_"
+            + hashlib.sha256(digest_input.encode("utf-8")).hexdigest()[:24]
+        )
+        return bundle
+
+
+def engineering_scorecard(bundle: Mapping[str, Any]) -> dict[str, Any]:
+    failures = hard_gate_failures(bundle)
+    return {
+        "schema": "kpgs.engineering-scorecard.v1",
+        "bundle_id": bundle["bundle_id"],
+        "estate_property": bundle["estate_property"],
+        "release_ref": bundle["release_ref"],
+        "commit_sha": bundle["commit_sha"],
+        "correlation_id": bundle["correlation_id"],
+        "hard_gate_failures": failures,
+        "hard_gate_clear": not failures,
+        "verifications": deepcopy(bundle.get("verifications", [])),
+        "metrics": deepcopy(bundle.get("metrics", [])),
+        "aggregate_scores": deepcopy(bundle.get("aggregate_scores", {})),
+        "trace_hops": deepcopy(bundle.get("trace_hops", [])),
+        "artifacts": deepcopy(bundle.get("artifacts", [])),
+        "governance_decision": deepcopy(bundle["governance_decision"]),
+        "retention_policy_ref": bundle["retention_policy_ref"],
+        "redaction_policy_ref": bundle["redaction_policy_ref"],
+    }
+
+
+def everyday_scorecard(bundle: Mapping[str, Any]) -> dict[str, Any]:
+    failures = hard_gate_failures(bundle)
+    decision = bundle["governance_decision"]
+    decision_name = decision["decision"]
+    if failures:
+        health = "blocked"
+        risk = "high"
+    elif decision_name in {"deny", "hold", "rollback"}:
+        health = "attention"
+        risk = "elevated"
+    elif decision_name == "promote":
+        health = "ready"
+        risk = "governed"
+    else:
+        health = "active"
+        risk = "governed"
+
+    failure_text = [item["criterion_id"] for item in failures]
+    next_action = decision.get("next_action")
+    if not next_action:
+        if failures:
+            next_action = "Resolve failed hard gates before promotion or privileged continuation."
+        elif decision_name == "rollback":
+            next_action = "Execute the recorded rollback procedure and re-verify the release."
+        elif decision_name == "hold":
+            next_action = "Gather the missing evidence and request another governance decision."
+        else:
+            next_action = "Continue governed observation."
+
+    return {
+        "schema": "kpgs.everyday-governance-scorecard.v1",
+        "bundle_id": bundle["bundle_id"],
+        "property": bundle["estate_property"],
+        "status": health,
+        "risk": risk,
+        "what_changed": (
+            f"Release {bundle['release_ref']} at commit {bundle['commit_sha'][:12]}."
+        ),
+        "decision": decision_name,
+        "why": decision["reason"],
+        "hard_gate_failures": failure_text,
+        "next_action": next_action,
+        "correlation_id": bundle["correlation_id"],
+    }
+
+
+def rollback_recommendation(
+    bundle: Mapping[str, Any],
+    metric_thresholds: Mapping[str, Mapping[str, float | str]] | None = None,
+) -> dict[str, Any]:
+    """Derive a rollback signal without silently performing rollback.
+
+    Hard-gate failure always triggers a recommendation. Optional numeric metric
+    thresholds may add reasons. The caller/Sovereign Hub still needs an exact
+    rollback capability lease and recorded rollback target to execute it.
+    """
+
+    reasons = [
+        f"hard gate failed: {item['criterion_id']}"
+        for item in hard_gate_failures(bundle)
+    ]
+    thresholds = metric_thresholds or {}
+    for metric in bundle.get("metrics", []):
+        rule = thresholds.get(metric.get("name"))
+        value = metric.get("value")
+        if not rule or not isinstance(value, (int, float)) or isinstance(value, bool):
+            continue
+        operator = rule.get("operator")
+        threshold = rule.get("value")
+        if not isinstance(threshold, (int, float)):
+            raise EvidenceError("metric threshold value must be numeric")
+        triggered = (
+            operator == "gt" and value > threshold
+        ) or (
+            operator == "gte" and value >= threshold
+        ) or (
+            operator == "lt" and value < threshold
+        ) or (
+            operator == "lte" and value <= threshold
+        )
+        if operator not in {"gt", "gte", "lt", "lte"}:
+            raise EvidenceError("unknown metric threshold operator")
+        if triggered:
+            reasons.append(
+                f"metric {metric['name']} {operator} threshold {threshold}"
+            )
+
+    return {
+        "schema": "kpgs.rollback-recommendation.v1",
+        "bundle_id": bundle["bundle_id"],
+        "triggered": bool(reasons),
+        "reasons": reasons,
+        "automatic_execution": False,
+        "required_capability": "estate.release.rollback",
+        "correlation_id": bundle["correlation_id"],
+    }

--- a/governance/kpgs-vnext/evidence/validate_evidence.py
+++ b/governance/kpgs-vnext/evidence/validate_evidence.py
@@ -1,0 +1,152 @@
+"""Dependency-free validator for KPGS evidence bundles and scorecards."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import importlib.util
+import json
+from pathlib import Path
+import sys
+
+HERE = Path(__file__).resolve().parent
+SCHEMA = HERE / "evidence-bundle.schema.json"
+RUNTIME = HERE / "evidence.py"
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise SystemExit(f"KPGS-EVIDENCE FAIL: {message}")
+
+
+def load_runtime():
+    spec = importlib.util.spec_from_file_location("kpgs_evidence_validator_runtime", RUNTIME)
+    require(spec is not None and spec.loader is not None, "evidence runtime cannot load")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def main() -> None:
+    schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+    required = set(schema.get("required", []))
+    for field_name in (
+        "commit_sha",
+        "trace_hops",
+        "metrics",
+        "retention_policy_ref",
+        "redaction_policy_ref",
+    ):
+        require(field_name in required, f"bundle contract lost {field_name}")
+
+    trace_layers = set(
+        schema["properties"]["trace_hops"]["items"]["properties"]["layer"]["enum"]
+    )
+    require(
+        {"pwa", "adapter", "sovereign-hub", "renter", "skill", "verifier", "deployment"}
+        <= trace_layers,
+        "cross-layer trace vocabulary is incomplete",
+    )
+    decision_enum = set(
+        schema["properties"]["governance_decision"]["properties"]["decision"]["enum"]
+    )
+    require(
+        {"allow", "deny", "promote", "rollback", "hold"} == decision_enum,
+        "governance decision vocabulary drifted",
+    )
+
+    runtime = load_runtime()
+    fixed_now = datetime(2026, 8, 18, 10, 15, tzinfo=timezone.utc)
+    builder = runtime.EvidenceBundleBuilder(
+        estate_property="FivesArena.com",
+        release_ref="release://validator/fivesarena",
+        commit_sha="b" * 40,
+        adapter={"implementation": "canonical-domain-adapter", "version": "v1"},
+        renter={"renter_id": "renter:validator", "protocol_version": "1.0"},
+        skills=[{"name": "validator-skill", "version": "1.0.0"}],
+        task_id="task:validator",
+        session_id="session:validator",
+        correlation_id="corr:validator",
+        governing_spec_ref="spec://validator/evidence/v1",
+        retention_policy_ref="retention://validator/release/v1",
+        redaction_policy_ref="redaction://validator/no-secrets/v1",
+        clock=lambda: fixed_now,
+    )
+    builder.add_capability_lease_ref("lease://validator/001")
+    for index, layer in enumerate(
+        ["pwa", "adapter", "sovereign-hub", "renter", "skill"]
+    ):
+        builder.add_trace_hop(
+            layer=layer,
+            ref=f"{layer}://validator/{index}",
+            status="succeeded",
+            at=f"2026-08-18T10:15:0{index}Z",
+        )
+    builder.add_trace_hop(
+        layer="verifier",
+        ref="verifier:validator",
+        status="succeeded",
+        at="2026-08-18T10:15:06Z",
+    )
+    builder.add_trace_hop(
+        layer="deployment",
+        ref="deployment://validator/001",
+        status="succeeded",
+        at="2026-08-18T10:15:07Z",
+    )
+    for kind in runtime.PROMOTION_ARTIFACT_KINDS:
+        builder.add_artifact(kind=kind, ref=f"evidence://validator/{kind}")
+    metric_values = {
+        "latency": 100.0,
+        "realtime-health": True,
+        "reliability": 0.999,
+        "error-rate": 0.001,
+        "task-completion": 0.95,
+        "task-abandonment": 0.05,
+        "accessibility": True,
+        "mobile": True,
+    }
+    for name, value in metric_values.items():
+        builder.add_metric(
+            name=name,
+            value=value,
+            evidence_ref=f"metric://validator/{name}",
+        )
+    builder.add_verification(
+        verifier_id="verifier:validator",
+        criterion_id="release-hard-gate",
+        method="security",
+        hard_gate=True,
+        passed=True,
+        evidence_ref="verification://validator/hard-gate",
+        score=1.0,
+    )
+    bundle = builder.finalize(
+        decision="promote",
+        reason="Validator evidence surface is complete and hard gates pass.",
+        decision_ref="decision://validator/promote",
+    )
+    require(bundle["commit_sha"] == "b" * 40, "exact commit provenance drifted")
+    engineering = runtime.engineering_scorecard(bundle)
+    everyday = runtime.everyday_scorecard(bundle)
+    require(
+        engineering["bundle_id"] == everyday["bundle_id"] == bundle["bundle_id"],
+        "scorecards do not derive from one canonical bundle",
+    )
+    require(engineering["hard_gate_clear"] is True, "passing hard gate was lost")
+    require(everyday["status"] == "ready", "plain governance view drifted")
+    recommendation = runtime.rollback_recommendation(bundle)
+    require(not recommendation["triggered"], "clean release triggered rollback")
+    require(
+        recommendation["automatic_execution"] is False,
+        "evidence runtime gained rollback execution authority",
+    )
+
+    print(
+        "KPGS-EVIDENCE PASS: exact release correlation, secret-safe evidence, "
+        "non-averaged hard gates and shared scorecards are executable."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_evidence_bundles.py
+++ b/tests/test_evidence_bundles.py
@@ -238,6 +238,18 @@ class EvidenceBundleTests(unittest.TestCase):
         self.assertEqual(everyday["status"], "blocked")
         self.assertIn("tenant-isolation", everyday["hard_gate_failures"])
 
+    def test_security_verification_cannot_be_downgraded_to_soft_gate(self):
+        builder = self.builder()
+        with self.assertRaises(mod.EvidenceError):
+            builder.add_verification(
+                verifier_id="verifier:security",
+                criterion_id="tenant-isolation",
+                method="security",
+                hard_gate=False,
+                passed=False,
+                evidence_ref="verification://security/softened",
+            )
+
     def test_trace_must_cover_pwa_adapter_hub_renter_skill_and_verifier(self):
         builder = self.builder()
         builder.add_capability_lease_ref("lease://kpgs/001")
@@ -315,6 +327,10 @@ class EvidenceBundleTests(unittest.TestCase):
             builder.add_artifact(
                 kind="security",
                 ref="log://contains/sk-proj-abcdefghijklmnop",
+            )
+        with self.assertRaises(mod.EvidenceError):
+            builder.add_capability_lease_ref(
+                "lease://eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyLTEyMyJ9.signature12345678"
             )
 
     def test_policy_and_lease_fields_must_be_references_not_embedded_values(self):

--- a/tests/test_evidence_bundles.py
+++ b/tests/test_evidence_bundles.py
@@ -1,0 +1,383 @@
+import importlib.util
+from datetime import datetime, timezone
+from pathlib import Path
+import sys
+import unittest
+
+ROOT = Path(__file__).parents[1]
+MODULE_PATH = (
+    ROOT
+    / "governance"
+    / "kpgs-vnext"
+    / "evidence"
+    / "evidence.py"
+)
+spec = importlib.util.spec_from_file_location(
+    "kpgs_evidence_runtime",
+    MODULE_PATH,
+)
+mod = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+sys.modules[spec.name] = mod
+spec.loader.exec_module(mod)
+
+
+class FixedClock:
+    def __init__(self):
+        self.now = datetime(
+            2026,
+            8,
+            18,
+            10,
+            0,
+            tzinfo=timezone.utc,
+        )
+
+    def __call__(self):
+        return self.now
+
+
+class EvidenceBundleTests(unittest.TestCase):
+    def setUp(self):
+        self.clock = FixedClock()
+
+    def builder(self, **overrides):
+        payload = dict(
+            estate_property="FivesArena.com",
+            release_ref="release://fivesarena/2026-08-18",
+            commit_sha="a" * 40,
+            adapter={
+                "implementation": "canonical-domain-adapter",
+                "version": "contract-v1",
+            },
+            renter={
+                "renter_id": "renter:fivesarena:001",
+                "protocol_version": "1.0",
+            },
+            skills=[
+                {
+                    "name": "arena-weather-context",
+                    "version": "1.0.0",
+                }
+            ],
+            task_id="task:article-focus-weather",
+            session_id="session:user-001",
+            correlation_id="corr:evidence-001",
+            governing_spec_ref="spec://fivesarena/focus-weather/v1",
+            retention_policy_ref="retention://kopano/release-evidence/v1",
+            redaction_policy_ref="redaction://kopano/no-secrets/v1",
+            clock=self.clock,
+        )
+        payload.update(overrides)
+        return mod.EvidenceBundleBuilder(**payload)
+
+    @staticmethod
+    def add_trace(builder):
+        for index, layer in enumerate(
+            [
+                "pwa",
+                "adapter",
+                "sovereign-hub",
+                "renter",
+                "skill",
+            ]
+        ):
+            builder.add_trace_hop(
+                layer=layer,
+                ref=f"{layer}://trace/{index}",
+                status="succeeded",
+                at=f"2026-08-18T10:00:0{index}Z",
+                duration_ms=10 + index,
+                metadata={"attempt": 1},
+            )
+        builder.add_trace_hop(
+            layer="verifier",
+            ref="verifier:release-gate",
+            status="succeeded",
+            at="2026-08-18T10:00:06Z",
+            duration_ms=21,
+        )
+        builder.add_trace_hop(
+            layer="deployment",
+            ref="deployment://vercel/fivesarena",
+            status="succeeded",
+            at="2026-08-18T10:00:07Z",
+            duration_ms=33,
+        )
+        return builder
+
+    @staticmethod
+    def add_promotion_artifacts(builder):
+        kinds = [
+            "specification",
+            "policy-decision",
+            "capability-lease",
+            "execution",
+            "verification",
+            "security",
+            "accessibility",
+            "deployment",
+            "user-outcome",
+        ]
+        for index, kind in enumerate(kinds):
+            builder.add_artifact(
+                kind=kind,
+                ref=f"evidence://artifact/{kind}/{index}",
+                sha256=(f"{index:x}" * 64)[:64],
+            )
+        return builder
+
+    @staticmethod
+    def add_promotion_metrics(builder):
+        values = {
+            "latency": (120.0, "ms"),
+            "realtime-health": (True, None),
+            "reliability": (0.999, "ratio"),
+            "error-rate": (0.001, "ratio"),
+            "task-completion": (0.94, "ratio"),
+            "task-abandonment": (0.06, "ratio"),
+            "accessibility": (True, None),
+            "mobile": (True, None),
+        }
+        for name, (value, unit) in values.items():
+            builder.add_metric(
+                name=name,
+                value=value,
+                unit=unit,
+                evidence_ref=f"metric://{name}/001",
+            )
+        return builder
+
+    def complete_builder(self):
+        builder = self.builder()
+        builder.add_capability_lease_ref(
+            "lease://kpgs/fivesarena/001"
+        )
+        self.add_trace(builder)
+        self.add_promotion_artifacts(builder)
+        self.add_promotion_metrics(builder)
+        builder.add_verification(
+            verifier_id="verifier:release-gate",
+            criterion_id="security-hard-gate",
+            method="security",
+            hard_gate=True,
+            passed=True,
+            score=1.0,
+            evidence_ref="verification://security/001",
+        )
+        builder.add_verification(
+            verifier_id="verifier:quality",
+            criterion_id="mobile-quality",
+            method="e2e",
+            hard_gate=False,
+            passed=True,
+            score=0.93,
+            evidence_ref="verification://mobile/001",
+        )
+        builder.set_aggregate_score("quality", 0.97)
+        return builder
+
+    def test_valid_production_bundle_has_exact_release_commit_and_shared_scorecards(self):
+        bundle = self.complete_builder().finalize(
+            decision="promote",
+            reason="All hard gates and required release evidence passed.",
+            decision_ref="decision://release/allow/001",
+            next_action="Observe production health and retain rollback readiness.",
+        )
+        self.assertTrue(bundle["bundle_id"].startswith("evidence_"))
+        self.assertEqual(bundle["release_ref"], "release://fivesarena/2026-08-18")
+        self.assertEqual(bundle["commit_sha"], "a" * 40)
+        self.assertEqual(bundle["governance_decision"]["decision"], "promote")
+
+        engineering = mod.engineering_scorecard(bundle)
+        everyday = mod.everyday_scorecard(bundle)
+        self.assertEqual(engineering["bundle_id"], bundle["bundle_id"])
+        self.assertEqual(everyday["bundle_id"], bundle["bundle_id"])
+        self.assertEqual(engineering["correlation_id"], everyday["correlation_id"])
+        self.assertTrue(engineering["hard_gate_clear"])
+        self.assertEqual(everyday["status"], "ready")
+        self.assertEqual(everyday["risk"], "governed")
+        self.assertIn("aaaaaaaaaaaa", everyday["what_changed"])
+
+    def test_failed_hard_gate_cannot_be_hidden_by_high_aggregate_score(self):
+        builder = self.complete_builder()
+        builder.add_verification(
+            verifier_id="verifier:release-gate",
+            criterion_id="tenant-isolation",
+            method="security",
+            hard_gate=True,
+            passed=False,
+            score=0.0,
+            evidence_ref="verification://security/fail",
+        )
+        builder.set_aggregate_score("health", 0.9999)
+        with self.assertRaises(mod.HardGateFailure):
+            builder.finalize(
+                decision="promote",
+                reason="Aggregate score is high.",
+            )
+        with self.assertRaises(mod.HardGateFailure):
+            builder.finalize(
+                decision="allow",
+                reason="Aggregate score is high.",
+            )
+
+        held = builder.finalize(
+            decision="hold",
+            reason="Tenant isolation hard gate failed.",
+            next_action="Repair tenant isolation and re-run verification.",
+        )
+        engineering = mod.engineering_scorecard(held)
+        everyday = mod.everyday_scorecard(held)
+        self.assertEqual(engineering["aggregate_scores"]["health"], 0.9999)
+        self.assertFalse(engineering["hard_gate_clear"])
+        self.assertEqual(
+            engineering["hard_gate_failures"][0]["criterion_id"],
+            "tenant-isolation",
+        )
+        self.assertEqual(everyday["status"], "blocked")
+        self.assertIn("tenant-isolation", everyday["hard_gate_failures"])
+
+    def test_trace_must_cover_pwa_adapter_hub_renter_skill_and_verifier(self):
+        builder = self.builder()
+        builder.add_capability_lease_ref("lease://kpgs/001")
+        for layer in ["pwa", "adapter", "renter", "skill"]:
+            builder.add_trace_hop(
+                layer=layer,
+                ref=f"{layer}://trace",
+                status="succeeded",
+                at="2026-08-18T10:00:00Z",
+            )
+        builder.add_verification(
+            verifier_id="verifier:release-gate",
+            criterion_id="criterion",
+            method="unit",
+            hard_gate=False,
+            passed=True,
+            evidence_ref="verification://criterion",
+        )
+        with self.assertRaises(mod.EvidenceCorrelationError) as captured:
+            builder.finalize(decision="hold", reason="Trace incomplete")
+        self.assertIn("sovereign-hub", str(captured.exception))
+        self.assertIn("verifier", str(captured.exception))
+
+    def test_verifier_trace_must_correlate_to_real_verification(self):
+        builder = self.builder()
+        builder.add_capability_lease_ref("lease://kpgs/001")
+        self.add_trace(builder)
+        builder.add_verification(
+            verifier_id="verifier:different",
+            criterion_id="criterion",
+            method="unit",
+            hard_gate=False,
+            passed=True,
+            evidence_ref="verification://criterion",
+        )
+        with self.assertRaises(mod.EvidenceCorrelationError):
+            builder.finalize(decision="hold", reason="Verifier mismatch")
+
+    def test_promotion_requires_complete_artifact_and_metric_surface(self):
+        builder = self.builder()
+        builder.add_capability_lease_ref("lease://kpgs/001")
+        self.add_trace(builder)
+        builder.add_verification(
+            verifier_id="verifier:release-gate",
+            criterion_id="release-gate",
+            method="security",
+            hard_gate=True,
+            passed=True,
+            evidence_ref="verification://release",
+        )
+        builder.add_artifact(
+            kind="deployment",
+            ref="deployment://only",
+        )
+        builder.add_metric(
+            name="latency",
+            value=100.0,
+            unit="ms",
+            evidence_ref="metric://latency",
+        )
+        with self.assertRaises(mod.EvidenceCorrelationError):
+            builder.finalize(decision="promote", reason="Evidence incomplete")
+
+    def test_secret_like_material_is_rejected_from_trace_and_artifacts(self):
+        builder = self.builder()
+        with self.assertRaises(mod.EvidenceError):
+            builder.add_trace_hop(
+                layer="pwa",
+                ref="pwa://trace",
+                status="started",
+                at="2026-08-18T10:00:00Z",
+                metadata={"authorization": "Bearer abcdefghijklmnop"},
+            )
+        with self.assertRaises(mod.EvidenceError):
+            builder.add_artifact(
+                kind="security",
+                ref="log://contains/sk-proj-abcdefghijklmnop",
+            )
+
+    def test_policy_and_lease_fields_must_be_references_not_embedded_values(self):
+        with self.assertRaises(mod.EvidenceError):
+            self.builder(retention_policy_ref="thirty-days")
+        builder = self.builder()
+        with self.assertRaises(mod.EvidenceError):
+            builder.add_capability_lease_ref(
+                "eyJhbGciOiJIUzI1NiJ9.payload.signature"
+            )
+
+    def test_commit_sha_is_exact_release_provenance(self):
+        with self.assertRaises(mod.EvidenceCorrelationError):
+            self.builder(commit_sha="main")
+        with self.assertRaises(mod.EvidenceCorrelationError):
+            self.builder(commit_sha="abc123")
+
+    def test_rollback_recommendation_never_executes_rollback_itself(self):
+        builder = self.complete_builder()
+        bundle = builder.finalize(
+            decision="hold",
+            reason="Observe reliability before promotion.",
+        )
+        recommendation = mod.rollback_recommendation(
+            bundle,
+            metric_thresholds={
+                "error-rate": {
+                    "operator": "gt",
+                    "value": 0.0005,
+                }
+            },
+        )
+        self.assertTrue(recommendation["triggered"])
+        self.assertFalse(recommendation["automatic_execution"])
+        self.assertEqual(
+            recommendation["required_capability"],
+            "estate.release.rollback",
+        )
+        self.assertTrue(
+            any("error-rate" in reason for reason in recommendation["reasons"])
+        )
+
+    def test_hard_failure_alone_triggers_rollback_recommendation(self):
+        builder = self.complete_builder()
+        builder.add_verification(
+            verifier_id="verifier:release-gate",
+            criterion_id="security-regression",
+            method="security",
+            hard_gate=True,
+            passed=False,
+            evidence_ref="verification://security/regression",
+        )
+        bundle = builder.finalize(
+            decision="rollback",
+            reason="Security regression detected after release.",
+        )
+        recommendation = mod.rollback_recommendation(bundle)
+        self.assertTrue(recommendation["triggered"])
+        self.assertIn(
+            "hard gate failed: security-regression",
+            recommendation["reasons"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #45 when current-head validation proves the evidence contract.

## Canonical dependency
Based on canonical `master`, which now contains merged #73 APU→CRUD→SWFUS, #74 executable capability leases, and #75 Sovereign DNS estate registry. This PR adds only the evidence/scorecard layer.

## Existing contract extended, not replaced
The repository already had `EVIDENCE.md` and `evidence-bundle.schema.json`, including the rule that aggregate scores cannot hide a failed hard gate. This PR supplies the executable bundle builder, correlation checks, scorecards and rollback recommendation path.

## Canonical correlation
A finalized bundle binds:
`estate property -> exact release+commit -> adapter -> renter -> skill -> task/session -> verifier -> governance decision`

User-facing trace hops prove:
`PWA -> adapter -> Sovereign Hub -> renter -> skill -> verifier`

Promotion additionally requires a deployment trace.

## Production evidence
A `promote` decision requires exact release ref + 40-character Git commit SHA, adapter/renter/skill identities, task/session/correlation IDs, capability lease reference(s), complete user-task + deployment traces, verifier results, core specification/policy/lease/execution/verification/security/accessibility/deployment/user-outcome artifacts, core latency/realtime/reliability/error/task completion+abandonment/accessibility/mobile metrics, and explicit retention/redaction policy references.

Cost/usage/recovery metrics remain supported where measurable rather than being fabricated when unavailable.

## Hard-gate law
- failed hard gate + `promote` -> reject
- failed hard gate + `allow` -> reject
- failed hard gate + `hold|deny|rollback` -> bundle can finalize so the failure remains inspectable/actionable

Engineering scorecards expose raw hard failures even if aggregate score is 0.9999. Everyday scorecards derive from the same bundle and render the failure as blocked/high risk.

## Secret-safe evidence
The builder recursively rejects secret-bearing metadata fields and common raw credential patterns. Capability leases are recorded as references (`lease://...`), never signed compact tokens. Every finalized bundle requires explicit `retention_policy_ref` and `redaction_policy_ref`.

The protocol deliberately does not invent one universal retention duration; the referenced tenant/domain policy owns duration, legal hold and deletion/archive behavior.

## Shared scorecards
`engineering_scorecard(bundle)` and `everyday_scorecard(bundle)` derive from the same bundle ID/correlation chain. There is no separate friendly-state database.

## Rollback support
`rollback_recommendation(bundle, thresholds)` always triggers on hard-gate failure, may trigger on caller-supplied numeric metric thresholds, never executes rollback itself, and declares required capability `estate.release.rollback`. Actual rollback remains governed by the estate registry's recorded rollback target/procedure + capability lease.

## Proof
- `evidence/evidence-bundle.schema.json`
- `evidence/evidence.py`
- `evidence/EVIDENCE.md`
- `evidence/validate_evidence.py`
- `tests/test_evidence_bundles.py`
- KPGS vNext workflow integration + compile gate

Negative tests prove hard-gate non-masking, missing trace rejection, verifier mismatch rejection, incomplete promotion evidence rejection, secret/token rejection, invalid policy/lease refs, exact commit provenance and rollback recommendation authority boundaries.

## Merge posture
Draft until focused validation, CodeQL and full repository CI are green on the exact master-targeted head.