### PR TITLE
feat(realtime): execute persistent SWFUS progressive event plane

### DIFF
--- a/governance/kpgs-vnext/realtime/EVENT_PLANE.md
+++ b/governance/kpgs-vnext/realtime/EVENT_PLANE.md
@@ -49,6 +49,34 @@ The renter event envelope in `../stateless-renter/renter-envelope.schema.json` i
 - evidence references;
 - failure/recovery classification.
 
+## Runtime mapping
+
+The canonical runtime implementation is intentionally layered rather than duplicated:
+
+- `kopano-core/kopano/realtime_event_plane.py` owns the persistent replay journal, server cursor, duplicate handling, scoped subscriptions and bounded live queues. It owns **observable event history only**, never business truth.
+- `kopano-core/kopano/swfus_realtime_bridge.py` is a one-way SWFUS distribution sink. The chain remains `Adaptive PU -> Progressive Update -> CRUD -> SWFUS -> realtime observation`; realtime delivery cannot call back into CRUD.
+- `kopano-core/kopano/kasilink_realtime.py` adapts the existing KasiLink gig-match workflow to the event plane and exposes WebSocket-first delivery plus governed polling fallback.
+- `kopano-core/kopano/kasilink_api.py` keeps the existing `/api/kasilink/match` surface and only adds optional session/task/correlation identifiers and realtime metadata. A realtime-journal fault does not block the existing business operation.
+
+A subscriber is registered before replay is read. This intentionally permits a racing event to appear once in replay and once in the live queue; the transport suppresses that duplicate frame. Registering after replay would create an event-loss window and is forbidden.
+
+Slow subscribers never block an authoritative producer. Non-critical progress may be dropped from a saturated live queue because it remains replayable from the persistent journal. Saturation on critical events forces reconnect/resume rather than pretending delivery occurred.
+
+### Legacy broadcast surfaces
+
+The older `/ws/live`, `/ws/neural-link`, `/ws/kasilink/live`, `/broadcast` and destructive shared `/updates` paths in the historical control-plane API are compatibility surfaces, **not** the canonical vNext realtime contract. New PWA/domain work must use the scoped event plane. They should be removed only after dependent legacy clients have migrated; their existence must not be used as proof that issue #40 reliability guarantees are present.
+
+## SWFUS boundary
+
+When the realtime journal is explicitly injected as a SWFUS `distribution_sink`, durable journal persistence is part of SWFUS distribution acceptance. If that persistence call fails, existing SWFUS fail-closed behavior holds/rolls back its non-authoritative projection. WebSocket disconnects and slow subscribers cannot trigger this rollback because subscriber fan-out is bounded and non-blocking.
+
+This distinction is important:
+
+- **journal persistence failure at the governed SWFUS distribution boundary** -> fail closed;
+- **socket/polling delivery failure after persistence** -> business state remains untouched and the client resumes by cursor.
+
 ## Approval actions
 
 A user approval is a governed command, not a UI click effect. Approval messages must carry an idempotency key and be re-checked against current policy/capability state at the server boundary before any external side effect occurs.
+
+The realtime WebSocket accepts transport-control messages only (`auth`, `reauth`, `ack`, `ping`). Unknown or business-mutation messages are rejected and must be sent through a governed command endpoint. This keeps transport capability separate from mutation authority.

--- a/kopano-core/kopano/kasilink_api.py
+++ b/kopano-core/kopano/kasilink_api.py
@@ -7,6 +7,12 @@ from typing import Any, Dict, List, Optional
 from .bridge import bridge
 from .config import settings
 from .database import get_db_connection
+from .kasilink_realtime import (
+    begin_match,
+    complete_match,
+    fail_match,
+    router as realtime_router,
+)
 from .tools.gig_matcher import match_gig
 from .tools.loadshedding import get_loadshedding_status, is_gig_safe
 
@@ -19,6 +25,9 @@ class GigMatchRequest(BaseModel):
     category: str
     skills: List[str] = Field(default_factory=list)
     providers: List[Dict[str, Any]] = Field(default_factory=list)
+    session_id: Optional[str] = None
+    task_id: Optional[str] = None
+    correlation_id: Optional[str] = None
 
 
 class SentimentRequest(BaseModel):
@@ -54,14 +63,68 @@ def health() -> dict:
     return {
         "status": "ok",
         "service": "kasilink-cassy",
-        "features": ["match", "sentiment", "forecast", "loadshedding", "moderate", "dashboard", "notify"],
+        "features": [
+            "match",
+            "sentiment",
+            "forecast",
+            "loadshedding",
+            "moderate",
+            "dashboard",
+            "notify",
+            "realtime",
+        ],
     }
 
 
 @router.post("/match")
-def gig_match(request: GigMatchRequest, authorization: Optional[str] = Header(default=None)) -> dict:
+def gig_match(
+    request: GigMatchRequest,
+    authorization: Optional[str] = Header(default=None),
+) -> dict:
     _require_bridge_auth(authorization)
-    return match_gig(request.description, request.location, request.category, request.skills, request.providers)
+
+    live = None
+    try:
+        live = begin_match(
+            request.session_id,
+            request.task_id,
+            request.correlation_id,
+        )
+    except Exception:
+        # Realtime is an observable read plane, not business authority.
+        # A journal/transport fault cannot prevent the existing match workflow.
+        live = None
+
+    try:
+        result = match_gig(
+            request.description,
+            request.location,
+            request.category,
+            request.skills,
+            request.providers,
+        )
+    except Exception as exc:
+        if live is not None:
+            try:
+                fail_match(live, exc)
+            except Exception:
+                pass
+        raise
+
+    response = dict(result)
+    if live is not None:
+        try:
+            response["realtime"] = complete_match(live, response)
+        except Exception:
+            response["realtime"] = {
+                "session_id": live["session_id"],
+                "task_id": live["task_id"],
+                "correlation_id": live["correlation_id"],
+                "resume_cursor": live["resume_cursor"],
+                "state": "degraded",
+                "transport_authority": "none",
+            }
+    return response
 
 
 @router.post("/sentiment")
@@ -127,7 +190,7 @@ def dashboard() -> dict:
     return {
         "ai": "transparent",
         "status": "ready",
-        "features": ["match", "sentiment", "forecast", "loadshedding", "moderate", "notify"],
+        "features": ["match", "sentiment", "forecast", "loadshedding", "moderate", "notify", "realtime"],
         "metrics": {
             "discussions": discussions,
             "audit_logs": audit_logs,
@@ -147,5 +210,7 @@ async def notify(request: NotifyRequest, authorization: Optional[str] = Header(d
         success = await bridge.send_message(request.message or "KasiLink notification", request.recipient)
     return {"sent": success}
 
+
+router.include_router(realtime_router)
+
 # merge: dev 2026-06-22
- 

--- a/kopano-core/kopano/kasilink_realtime.py
+++ b/kopano-core/kopano/kasilink_realtime.py
@@ -1,0 +1,331 @@
+"""KasiLink adapter for the canonical KPGS realtime event plane.
+
+This module makes the existing domain workflow observable. It does not own
+KasiLink business state and cannot authorize business mutations.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+import uuid
+from typing import Any
+
+from fastapi import APIRouter, Header, HTTPException, WebSocket, WebSocketDisconnect
+
+from .operator_auth import resolve_bearer
+from .realtime_event_plane import (
+    CursorExpired,
+    EventScope,
+    RealtimeEventError,
+    RealtimeEventPlane,
+    UnauthorizedScope,
+    make_event,
+)
+
+router = APIRouter()
+
+realtime_event_plane = RealtimeEventPlane(
+    Path(os.environ.get("KPGS_REALTIME_DB", ".orch_data/realtime-events.db")),
+    max_events_per_stream=int(os.environ.get("KPGS_REALTIME_HISTORY", "1000")),
+    queue_limit=int(os.environ.get("KPGS_REALTIME_QUEUE_LIMIT", "64")),
+)
+
+
+def _principal(authorization: str | None) -> dict[str, Any]:
+    user = resolve_bearer(authorization)
+    if not user:
+        raise HTTPException(
+            status_code=401,
+            detail="A valid Kopano session is required for realtime state.",
+        )
+    principal = dict(user)
+    principal.update(
+        tenant_id="kopano",
+        domain_id="kasilink",
+        allowed_domains=("kasilink",),
+    )
+    return principal
+
+
+def _publish(
+    *,
+    kind: str,
+    ids: dict[str, str],
+    suffix: str,
+    payload: dict[str, Any],
+    **canonical_fields: Any,
+):
+    return realtime_event_plane.publish(
+        make_event(
+            event_id=f"kasilink-{ids['task_id']}-{suffix}",
+            event_kind=kind,
+            tenant_id="kopano",
+            domain_id="kasilink",
+            session_id=ids["session_id"],
+            task_id=ids["task_id"],
+            correlation_id=ids["correlation_id"],
+            renter_id="kasilink.domain-adapter",
+            lease_id="lease:kasilink-domain-adapter",
+            idempotency_key=f"{ids['task_id']}:{suffix}",
+            payload=payload,
+            governing_spec_ref="governance/kpgs-vnext/realtime/EVENT_PLANE.md",
+            **canonical_fields,
+        )
+    )
+
+
+def begin_match(
+    session_id: str | None = None,
+    task_id: str | None = None,
+    correlation_id: str | None = None,
+) -> dict[str, Any]:
+    """Start observable state for the existing KasiLink gig-match workflow."""
+
+    ids = {
+        "session_id": session_id or f"session-{uuid.uuid4().hex}",
+        "task_id": task_id or f"match-{uuid.uuid4().hex}",
+        "correlation_id": correlation_id or f"corr-{uuid.uuid4().hex}",
+    }
+    accepted = _publish(
+        kind="task.accepted",
+        ids=ids,
+        suffix="accepted",
+        payload={"state": "working", "workflow": "gig-match"},
+    )
+    _publish(
+        kind="task.started",
+        ids=ids,
+        suffix="started",
+        payload={"state": "working", "workflow": "gig-match"},
+    )
+    return {**ids, "resume_cursor": accepted.cursor}
+
+
+def complete_match(ids: dict[str, Any], result: dict[str, Any]) -> dict[str, Any]:
+    completed = _publish(
+        kind="task.completed",
+        ids=ids,
+        suffix="completed",
+        payload={"state": "done", "workflow": "gig-match", "result": result},
+    )
+    return {
+        "session_id": ids["session_id"],
+        "task_id": ids["task_id"],
+        "correlation_id": ids["correlation_id"],
+        "resume_cursor": completed.cursor,
+        "transport_authority": "none",
+    }
+
+
+def fail_match(ids: dict[str, Any], exc: Exception) -> None:
+    _publish(
+        kind="task.failed",
+        ids=ids,
+        suffix="failed",
+        payload={"state": "failed", "workflow": "gig-match"},
+        failure={
+            "code": "execution_failed",
+            "recoverability": "retry",
+            "message": type(exc).__name__,
+        },
+    )
+
+
+@router.get("/events")
+def polling_fallback(
+    session_id: str,
+    task_id: str | None = None,
+    after_cursor: int = 0,
+    limit: int = 200,
+    authorization: str | None = Header(default=None),
+) -> dict[str, Any]:
+    scope = EventScope("kopano", "kasilink", session_id, task_id)
+    try:
+        return realtime_event_plane.polling_fallback(
+            _principal(authorization),
+            scope,
+            after_cursor=after_cursor,
+            limit=limit,
+        )
+    except UnauthorizedScope as exc:
+        raise HTTPException(status_code=403, detail=str(exc)) from exc
+    except CursorExpired as exc:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "code": "resume_cursor_expired",
+                "oldest_cursor": exc.oldest_cursor,
+                "canonical_snapshot_required": True,
+                "next_action": "refresh the domain workflow before resuming deltas",
+            },
+        ) from exc
+    except RealtimeEventError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.websocket("/events/ws")
+async def websocket_events(websocket: WebSocket) -> None:
+    """WebSocket-first stream with first-message auth, replay and heartbeat."""
+
+    session_id = websocket.query_params.get("session_id", "").strip()
+    task_id = websocket.query_params.get("task_id")
+    try:
+        after_cursor = int(websocket.query_params.get("after_cursor", "0"))
+    except ValueError:
+        await websocket.close(code=4400)
+        return
+    if not session_id:
+        await websocket.close(code=4400)
+        return
+
+    await websocket.accept()
+    try:
+        auth = await asyncio.wait_for(websocket.receive_json(), timeout=8)
+    except (asyncio.TimeoutError, WebSocketDisconnect):
+        await websocket.close(code=4401)
+        return
+    if auth.get("type") != "auth":
+        await websocket.close(code=4401)
+        return
+
+    user = resolve_bearer(f"Bearer {str(auth.get('access_token', ''))}")
+    if not user:
+        await websocket.send_json({"type": "auth_failed", "state": "offline"})
+        await websocket.close(code=4401)
+        return
+    principal = dict(user)
+    principal.update(
+        tenant_id="kopano",
+        domain_id="kasilink",
+        allowed_domains=("kasilink",),
+    )
+    scope = EventScope("kopano", "kasilink", session_id, task_id)
+    subscription_id = f"ws-{uuid.uuid4().hex}"
+
+    try:
+        subscription, replay = realtime_event_plane.subscribe(
+            principal,
+            scope,
+            after_cursor=after_cursor,
+            subscription_id=subscription_id,
+        )
+    except UnauthorizedScope:
+        await websocket.send_json({"type": "scope_denied", "state": "offline"})
+        await websocket.close(code=4403)
+        return
+    except CursorExpired as exc:
+        await websocket.send_json(
+            {
+                "type": "snapshot_required",
+                "state": "reconnecting",
+                "oldest_cursor": exc.oldest_cursor,
+            }
+        )
+        await websocket.close(code=4409)
+        return
+
+    highwater = after_cursor
+    for event in replay:
+        await websocket.send_json({"type": "event", "event": event.as_dict()})
+        highwater = max(highwater, event.cursor)
+    await websocket.send_json(
+        {
+            "type": "ready",
+            "state": "ready",
+            "resume_cursor": highwater,
+            "transport": "websocket",
+        }
+    )
+
+    receive_task = asyncio.create_task(websocket.receive_json())
+    event_task = asyncio.create_task(subscription.queue.get())
+    try:
+        while True:
+            if subscription.overflowed:
+                await websocket.send_json(
+                    {
+                        "type": "reconnect_required",
+                        "state": "reconnecting",
+                        "reason": "backpressure",
+                        "resume_cursor": subscription.last_cursor,
+                    }
+                )
+                await websocket.close(code=1013)
+                return
+
+            done, _ = await asyncio.wait(
+                {receive_task, event_task},
+                timeout=20,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if not done:
+                await websocket.send_json(
+                    {
+                        "type": "heartbeat",
+                        "state": "ready",
+                        "resume_cursor": subscription.last_cursor,
+                    }
+                )
+                continue
+
+            if receive_task in done:
+                try:
+                    message = receive_task.result()
+                except WebSocketDisconnect:
+                    return
+                receive_task = asyncio.create_task(websocket.receive_json())
+                kind = message.get("type")
+                if kind == "ack":
+                    try:
+                        realtime_event_plane.acknowledge(
+                            subscription, int(message.get("cursor", -1))
+                        )
+                    except (RealtimeEventError, TypeError, ValueError) as exc:
+                        await websocket.send_json(
+                            {"type": "ack_rejected", "reason": str(exc)}
+                        )
+                elif kind == "reauth":
+                    refreshed = resolve_bearer(
+                        f"Bearer {str(message.get('access_token', ''))}"
+                    )
+                    if not refreshed:
+                        await websocket.close(code=4401)
+                        return
+                    check = dict(refreshed)
+                    check.update(
+                        tenant_id="kopano",
+                        domain_id="kasilink",
+                        allowed_domains=("kasilink",),
+                    )
+                    if not realtime_event_plane.authorizer(check, scope):
+                        await websocket.close(code=4403)
+                        return
+                    await websocket.send_json(
+                        {"type": "reauthenticated", "state": "ready"}
+                    )
+                elif kind == "ping":
+                    await websocket.send_json(
+                        {"type": "pong", "state": "ready"}
+                    )
+                else:
+                    await websocket.send_json(
+                        {
+                            "type": "command_rejected",
+                            "reason": "business mutations require a governed command endpoint",
+                        }
+                    )
+
+            if event_task in done:
+                event = event_task.result()
+                event_task = asyncio.create_task(subscription.queue.get())
+                if event.cursor <= highwater:
+                    continue
+                await websocket.send_json(
+                    {"type": "event", "event": event.as_dict()}
+                )
+    finally:
+        receive_task.cancel()
+        event_task.cancel()
+        realtime_event_plane.unsubscribe(subscription_id)

--- a/kopano-core/kopano/kasilink_realtime.py
+++ b/kopano-core/kopano/kasilink_realtime.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import os
 from pathlib import Path
+import threading
 import uuid
 from typing import Any
 
@@ -25,12 +26,32 @@ from .realtime_event_plane import (
 )
 
 router = APIRouter()
+_plane_instance: RealtimeEventPlane | None = None
+_plane_lock = threading.Lock()
 
-realtime_event_plane = RealtimeEventPlane(
-    Path(os.environ.get("KPGS_REALTIME_DB", ".orch_data/realtime-events.db")),
-    max_events_per_stream=int(os.environ.get("KPGS_REALTIME_HISTORY", "1000")),
-    queue_limit=int(os.environ.get("KPGS_REALTIME_QUEUE_LIMIT", "64")),
-)
+
+def _event_plane() -> RealtimeEventPlane:
+    """Lazily initialize the journal so optional realtime cannot break startup."""
+
+    global _plane_instance
+    if _plane_instance is not None:
+        return _plane_instance
+    with _plane_lock:
+        if _plane_instance is None:
+            _plane_instance = RealtimeEventPlane(
+                Path(
+                    os.environ.get(
+                        "KPGS_REALTIME_DB", ".orch_data/realtime-events.db"
+                    )
+                ),
+                max_events_per_stream=int(
+                    os.environ.get("KPGS_REALTIME_HISTORY", "1000")
+                ),
+                queue_limit=int(
+                    os.environ.get("KPGS_REALTIME_QUEUE_LIMIT", "64")
+                ),
+            )
+    return _plane_instance
 
 
 def _principal(authorization: str | None) -> dict[str, Any]:
@@ -52,20 +73,20 @@ def _principal(authorization: str | None) -> dict[str, Any]:
 def _publish(
     *,
     kind: str,
-    ids: dict[str, str],
+    ids: dict[str, Any],
     suffix: str,
     payload: dict[str, Any],
     **canonical_fields: Any,
 ):
-    return realtime_event_plane.publish(
+    return _event_plane().publish(
         make_event(
             event_id=f"kasilink-{ids['task_id']}-{suffix}",
             event_kind=kind,
             tenant_id="kopano",
             domain_id="kasilink",
-            session_id=ids["session_id"],
-            task_id=ids["task_id"],
-            correlation_id=ids["correlation_id"],
+            session_id=str(ids["session_id"]),
+            task_id=str(ids["task_id"]),
+            correlation_id=str(ids["correlation_id"]),
             renter_id="kasilink.domain-adapter",
             lease_id="lease:kasilink-domain-adapter",
             idempotency_key=f"{ids['task_id']}:{suffix}",
@@ -83,7 +104,7 @@ def begin_match(
 ) -> dict[str, Any]:
     """Start observable state for the existing KasiLink gig-match workflow."""
 
-    ids = {
+    ids: dict[str, Any] = {
         "session_id": session_id or f"session-{uuid.uuid4().hex}",
         "task_id": task_id or f"match-{uuid.uuid4().hex}",
         "correlation_id": correlation_id or f"corr-{uuid.uuid4().hex}",
@@ -94,13 +115,21 @@ def begin_match(
         suffix="accepted",
         payload={"state": "working", "workflow": "gig-match"},
     )
-    _publish(
-        kind="task.started",
-        ids=ids,
-        suffix="started",
-        payload={"state": "working", "workflow": "gig-match"},
-    )
-    return {**ids, "resume_cursor": accepted.cursor}
+    ids["resume_cursor"] = accepted.cursor
+    ids["realtime_state"] = "ready"
+    try:
+        started = _publish(
+            kind="task.started",
+            ids=ids,
+            suffix="started",
+            payload={"state": "working", "workflow": "gig-match"},
+        )
+        ids["resume_cursor"] = started.cursor
+    except Exception:
+        # accepted is already durable, so preserve the identity and let the
+        # domain workflow continue. Completion may later restore the stream.
+        ids["realtime_state"] = "degraded"
+    return ids
 
 
 def complete_match(ids: dict[str, Any], result: dict[str, Any]) -> dict[str, Any]:
@@ -115,6 +144,7 @@ def complete_match(ids: dict[str, Any], result: dict[str, Any]) -> dict[str, Any
         "task_id": ids["task_id"],
         "correlation_id": ids["correlation_id"],
         "resume_cursor": completed.cursor,
+        "state": "done",
         "transport_authority": "none",
     }
 
@@ -133,6 +163,20 @@ def fail_match(ids: dict[str, Any], exc: Exception) -> None:
     )
 
 
+def _http_plane() -> RealtimeEventPlane:
+    try:
+        return _event_plane()
+    except Exception as exc:
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "code": "realtime_unavailable",
+                "state": "offline",
+                "canonical_business_state_affected": False,
+            },
+        ) from exc
+
+
 @router.get("/events")
 def polling_fallback(
     session_id: str,
@@ -143,7 +187,7 @@ def polling_fallback(
 ) -> dict[str, Any]:
     scope = EventScope("kopano", "kasilink", session_id, task_id)
     try:
-        return realtime_event_plane.polling_fallback(
+        return _http_plane().polling_fallback(
             _principal(authorization),
             scope,
             after_cursor=after_cursor,
@@ -180,6 +224,12 @@ async def websocket_events(websocket: WebSocket) -> None:
         await websocket.close(code=4400)
         return
 
+    try:
+        plane = _event_plane()
+    except Exception:
+        await websocket.close(code=1013)
+        return
+
     await websocket.accept()
     try:
         auth = await asyncio.wait_for(websocket.receive_json(), timeout=8)
@@ -205,7 +255,7 @@ async def websocket_events(websocket: WebSocket) -> None:
     subscription_id = f"ws-{uuid.uuid4().hex}"
 
     try:
-        subscription, replay = realtime_event_plane.subscribe(
+        subscription, replay = plane.subscribe(
             principal,
             scope,
             after_cursor=after_cursor,
@@ -226,22 +276,24 @@ async def websocket_events(websocket: WebSocket) -> None:
         await websocket.close(code=4409)
         return
 
+    receive_task: asyncio.Task[Any] | None = None
+    event_task: asyncio.Task[Any] | None = None
     highwater = after_cursor
-    for event in replay:
-        await websocket.send_json({"type": "event", "event": event.as_dict()})
-        highwater = max(highwater, event.cursor)
-    await websocket.send_json(
-        {
-            "type": "ready",
-            "state": "ready",
-            "resume_cursor": highwater,
-            "transport": "websocket",
-        }
-    )
-
-    receive_task = asyncio.create_task(websocket.receive_json())
-    event_task = asyncio.create_task(subscription.queue.get())
     try:
+        for event in replay:
+            await websocket.send_json({"type": "event", "event": event.as_dict()})
+            highwater = max(highwater, event.cursor)
+        await websocket.send_json(
+            {
+                "type": "ready",
+                "state": "ready",
+                "resume_cursor": highwater,
+                "transport": "websocket",
+            }
+        )
+
+        receive_task = asyncio.create_task(websocket.receive_json())
+        event_task = asyncio.create_task(subscription.queue.get())
         while True:
             if subscription.overflowed:
                 await websocket.send_json(
@@ -279,7 +331,7 @@ async def websocket_events(websocket: WebSocket) -> None:
                 kind = message.get("type")
                 if kind == "ack":
                     try:
-                        realtime_event_plane.acknowledge(
+                        plane.acknowledge(
                             subscription, int(message.get("cursor", -1))
                         )
                     except (RealtimeEventError, TypeError, ValueError) as exc:
@@ -299,7 +351,7 @@ async def websocket_events(websocket: WebSocket) -> None:
                         domain_id="kasilink",
                         allowed_domains=("kasilink",),
                     )
-                    if not realtime_event_plane.authorizer(check, scope):
+                    if not plane.authorizer(check, scope):
                         await websocket.close(code=4403)
                         return
                     await websocket.send_json(
@@ -320,12 +372,17 @@ async def websocket_events(websocket: WebSocket) -> None:
             if event_task in done:
                 event = event_task.result()
                 event_task = asyncio.create_task(subscription.queue.get())
+                # subscribe-before-replay intentionally tolerates a racing
+                # duplicate. Suppress only the duplicate frame, never state.
                 if event.cursor <= highwater:
                     continue
                 await websocket.send_json(
                     {"type": "event", "event": event.as_dict()}
                 )
+                highwater = event.cursor
     finally:
-        receive_task.cancel()
-        event_task.cancel()
-        realtime_event_plane.unsubscribe(subscription_id)
+        if receive_task is not None:
+            receive_task.cancel()
+        if event_task is not None:
+            event_task.cancel()
+        plane.unsubscribe(subscription_id)

--- a/kopano-core/kopano/realtime_event_plane.py
+++ b/kopano-core/kopano/realtime_event_plane.py
@@ -1,0 +1,636 @@
+"""Persistent, transport-neutral KPGS realtime event plane.
+
+The event plane is a read/distribution surface. It never owns canonical business
+state and never retries authoritative CRUD mutations. Events are persisted so a
+socket disconnect can be recovered with a server-issued cursor.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import asyncio
+import hashlib
+import json
+from pathlib import Path
+import sqlite3
+import threading
+from typing import Any, Callable, Iterable, Mapping
+
+
+class RealtimeEventError(ValueError):
+    """Base event-plane contract error."""
+
+
+class UnauthorizedScope(RealtimeEventError):
+    """Raised when a principal requests a scope it is not allowed to observe."""
+
+
+class EventConflict(RealtimeEventError):
+    """Raised when an event/idempotency key is reused for different content."""
+
+
+class CursorExpired(RealtimeEventError):
+    """Raised when a resume cursor predates retained replay history."""
+
+    def __init__(self, oldest_cursor: int):
+        super().__init__(
+            f"resume cursor expired; oldest available cursor is {oldest_cursor}"
+        )
+        self.oldest_cursor = oldest_cursor
+
+
+@dataclass(frozen=True)
+class EventScope:
+    tenant_id: str
+    domain_id: str
+    session_id: str
+    task_id: str | None = None
+
+    def validate(self) -> None:
+        for name in ("tenant_id", "domain_id", "session_id"):
+            if not str(getattr(self, name)).strip():
+                raise RealtimeEventError(f"{name} is required")
+        if self.task_id is not None and not str(self.task_id).strip():
+            raise RealtimeEventError("task_id cannot be blank")
+
+
+@dataclass(frozen=True)
+class PersistedEvent:
+    cursor: int
+    event_id: str
+    event_kind: str
+    tenant_id: str
+    domain_id: str
+    session_id: str
+    task_id: str
+    correlation_id: str
+    renter_id: str
+    lease_id: str
+    issued_at: str
+    payload: Mapping[str, Any]
+    idempotency_key: str | None = None
+    source_sequence: int | None = None
+    checkpoint_ref: str | None = None
+    evidence: tuple[Mapping[str, Any], ...] = ()
+    extras: Mapping[str, Any] | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "protocol_version": "1.0",
+            "event_id": self.event_id,
+            "event_kind": self.event_kind,
+            "tenant_id": self.tenant_id,
+            "domain_id": self.domain_id,
+            "session_id": self.session_id,
+            "task_id": self.task_id,
+            "renter_id": self.renter_id,
+            "correlation_id": self.correlation_id,
+            "lease_id": self.lease_id,
+            "issued_at": self.issued_at,
+            "payload": dict(self.payload),
+            "cursor": self.cursor,
+            "sequence": (
+                self.source_sequence
+                if self.source_sequence is not None
+                else self.cursor
+            ),
+        }
+        if self.idempotency_key:
+            data["idempotency_key"] = self.idempotency_key
+        if self.checkpoint_ref:
+            data["checkpoint_ref"] = self.checkpoint_ref
+        if self.evidence:
+            data["evidence"] = [dict(item) for item in self.evidence]
+        if self.extras:
+            for key, value in self.extras.items():
+                if key not in data and key != "cursor":
+                    data[key] = value
+        return data
+
+
+@dataclass
+class Subscription:
+    subscription_id: str
+    scope: EventScope
+    queue: asyncio.Queue[PersistedEvent]
+    last_cursor: int
+    overflowed: bool = False
+    dropped_noncritical: int = 0
+
+
+Authorizer = Callable[[Mapping[str, Any], EventScope], bool]
+
+
+def default_scope_authorizer(
+    principal: Mapping[str, Any], scope: EventScope
+) -> bool:
+    """Fail-closed default scope authorization.
+
+    Admin/God principals may observe all domains. Other principals must carry a
+    matching tenant and either an exact domain or an allowed_domains grant.
+    """
+
+    if not principal or not principal.get("is_active", True):
+        return False
+    if principal.get("god_mode") or principal.get("role") == "admin":
+        return True
+    if principal.get("tenant_id") != scope.tenant_id:
+        return False
+    allowed = principal.get("allowed_domains", ())
+    return (
+        principal.get("domain_id") == scope.domain_id
+        or "*" in allowed
+        or scope.domain_id in allowed
+    )
+
+
+class RealtimeEventPlane:
+    """SQLite-backed replay journal with bounded live subscribers."""
+
+    NONCRITICAL_EVENT_KINDS = {"task.progress", "presence", "domain.health"}
+    REQUIRED_FIELDS = (
+        "event_id",
+        "event_kind",
+        "tenant_id",
+        "domain_id",
+        "session_id",
+        "task_id",
+        "renter_id",
+        "correlation_id",
+        "lease_id",
+        "payload",
+    )
+
+    def __init__(
+        self,
+        database_path: str | Path = ":memory:",
+        *,
+        max_events_per_stream: int = 1000,
+        queue_limit: int = 64,
+        authorizer: Authorizer = default_scope_authorizer,
+    ) -> None:
+        if max_events_per_stream < 1:
+            raise ValueError("max_events_per_stream must be >= 1")
+        if queue_limit < 1:
+            raise ValueError("queue_limit must be >= 1")
+        self.database_path = str(database_path)
+        if self.database_path != ":memory:":
+            Path(self.database_path).expanduser().resolve().parent.mkdir(
+                parents=True, exist_ok=True
+            )
+        self.max_events_per_stream = max_events_per_stream
+        self.queue_limit = queue_limit
+        self.authorizer = authorizer
+        self._lock = threading.RLock()
+        self._subscribers: dict[str, Subscription] = {}
+        self._connection = sqlite3.connect(
+            self.database_path, check_same_thread=False
+        )
+        self._connection.row_factory = sqlite3.Row
+        self._init_db()
+
+    def close(self) -> None:
+        with self._lock:
+            self._connection.close()
+
+    def _init_db(self) -> None:
+        with self._lock:
+            self._connection.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS realtime_events (
+                    tenant_id TEXT NOT NULL,
+                    domain_id TEXT NOT NULL,
+                    session_id TEXT NOT NULL,
+                    task_id TEXT NOT NULL,
+                    cursor INTEGER NOT NULL,
+                    event_id TEXT NOT NULL UNIQUE,
+                    idempotency_key TEXT,
+                    fingerprint TEXT NOT NULL,
+                    event_json TEXT NOT NULL,
+                    PRIMARY KEY (tenant_id, domain_id, session_id, cursor)
+                );
+                CREATE UNIQUE INDEX IF NOT EXISTS ux_realtime_idempotency
+                    ON realtime_events(
+                        tenant_id, domain_id, session_id, idempotency_key
+                    )
+                    WHERE idempotency_key IS NOT NULL;
+                CREATE INDEX IF NOT EXISTS ix_realtime_stream
+                    ON realtime_events(
+                        tenant_id, domain_id, session_id, cursor
+                    );
+                CREATE INDEX IF NOT EXISTS ix_realtime_task_stream
+                    ON realtime_events(
+                        tenant_id, domain_id, session_id, task_id, cursor
+                    );
+                """
+            )
+            self._connection.commit()
+
+    @staticmethod
+    def _fingerprint(envelope: Mapping[str, Any]) -> str:
+        canonical = dict(envelope)
+        canonical.pop("cursor", None)
+        encoded = json.dumps(
+            canonical,
+            sort_keys=True,
+            separators=(",", ":"),
+            default=str,
+        ).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()
+
+    @classmethod
+    def _validate_envelope(cls, envelope: Mapping[str, Any]) -> None:
+        missing = [
+            field for field in cls.REQUIRED_FIELDS if field not in envelope
+        ]
+        if missing:
+            raise RealtimeEventError(
+                f"missing required event fields: {', '.join(missing)}"
+            )
+        for field in cls.REQUIRED_FIELDS[:-1]:
+            if not str(envelope[field]).strip():
+                raise RealtimeEventError(f"{field} cannot be blank")
+        if not isinstance(envelope["payload"], Mapping):
+            raise RealtimeEventError("payload must be an object")
+
+    @staticmethod
+    def _stream_params(scope: EventScope) -> tuple[str, str, str]:
+        scope.validate()
+        return scope.tenant_id, scope.domain_id, scope.session_id
+
+    def publish(self, envelope: Mapping[str, Any]) -> PersistedEvent:
+        """Persist one observation and fan it out without blocking producer work."""
+
+        self._validate_envelope(envelope)
+        scope = EventScope(
+            str(envelope["tenant_id"]),
+            str(envelope["domain_id"]),
+            str(envelope["session_id"]),
+        )
+        stream = self._stream_params(scope)
+        fingerprint = self._fingerprint(envelope)
+        idempotency_key = envelope.get("idempotency_key")
+
+        with self._lock:
+            existing = self._connection.execute(
+                "SELECT fingerprint, event_json FROM realtime_events "
+                "WHERE event_id = ?",
+                (str(envelope["event_id"]),),
+            ).fetchone()
+            if existing is None and idempotency_key:
+                existing = self._connection.execute(
+                    """SELECT fingerprint, event_json FROM realtime_events
+                       WHERE tenant_id = ? AND domain_id = ? AND session_id = ?
+                         AND idempotency_key = ?""",
+                    (*stream, str(idempotency_key)),
+                ).fetchone()
+            if existing is not None:
+                if existing["fingerprint"] != fingerprint:
+                    raise EventConflict(
+                        "event or idempotency key was reused with different content"
+                    )
+                return self._event_from_json(existing["event_json"])
+
+            next_cursor = int(
+                self._connection.execute(
+                    """SELECT COALESCE(MAX(cursor), 0) + 1 AS next_cursor
+                       FROM realtime_events
+                       WHERE tenant_id = ? AND domain_id = ? AND session_id = ?""",
+                    stream,
+                ).fetchone()["next_cursor"]
+            )
+            issued_at = str(
+                envelope.get("issued_at")
+                or datetime.now(timezone.utc).isoformat()
+            )
+            event = PersistedEvent(
+                cursor=next_cursor,
+                event_id=str(envelope["event_id"]),
+                event_kind=str(envelope["event_kind"]),
+                tenant_id=scope.tenant_id,
+                domain_id=scope.domain_id,
+                session_id=scope.session_id,
+                task_id=str(envelope["task_id"]),
+                renter_id=str(envelope["renter_id"]),
+                correlation_id=str(envelope["correlation_id"]),
+                lease_id=str(envelope["lease_id"]),
+                issued_at=issued_at,
+                payload=dict(envelope["payload"]),
+                idempotency_key=(
+                    str(idempotency_key) if idempotency_key else None
+                ),
+                source_sequence=(
+                    int(envelope["sequence"])
+                    if envelope.get("sequence") is not None
+                    else None
+                ),
+                checkpoint_ref=(
+                    str(envelope["checkpoint_ref"])
+                    if envelope.get("checkpoint_ref")
+                    else None
+                ),
+                evidence=tuple(
+                    dict(item)
+                    for item in envelope.get("evidence", ())
+                    if isinstance(item, Mapping)
+                ),
+                extras={
+                    key: value
+                    for key, value in envelope.items()
+                    if key
+                    not in {
+                        "protocol_version",
+                        "event_id",
+                        "event_kind",
+                        "tenant_id",
+                        "domain_id",
+                        "session_id",
+                        "task_id",
+                        "renter_id",
+                        "correlation_id",
+                        "lease_id",
+                        "issued_at",
+                        "payload",
+                        "idempotency_key",
+                        "sequence",
+                        "checkpoint_ref",
+                        "evidence",
+                        "cursor",
+                    }
+                },
+            )
+            event_json = json.dumps(
+                event.as_dict(), sort_keys=True, separators=(",", ":")
+            )
+            self._connection.execute(
+                """INSERT INTO realtime_events
+                   (tenant_id, domain_id, session_id, task_id, cursor,
+                    event_id, idempotency_key, fingerprint, event_json)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    *stream,
+                    event.task_id,
+                    next_cursor,
+                    event.event_id,
+                    event.idempotency_key,
+                    fingerprint,
+                    event_json,
+                ),
+            )
+            self._connection.execute(
+                """DELETE FROM realtime_events
+                   WHERE tenant_id = ? AND domain_id = ? AND session_id = ?
+                     AND cursor <= (
+                       SELECT COALESCE(MAX(cursor), 0) - ?
+                       FROM realtime_events
+                       WHERE tenant_id = ? AND domain_id = ? AND session_id = ?
+                     )""",
+                (*stream, self.max_events_per_stream, *stream),
+            )
+            self._connection.commit()
+            subscribers = tuple(self._subscribers.values())
+
+        for subscription in subscribers:
+            if not self._matches(subscription.scope, event):
+                continue
+            try:
+                subscription.queue.put_nowait(event)
+            except asyncio.QueueFull:
+                if event.event_kind in self.NONCRITICAL_EVENT_KINDS:
+                    subscription.dropped_noncritical += 1
+                else:
+                    # Never block an authoritative producer. A slow consumer
+                    # reconnects and replays from its last acknowledged cursor.
+                    subscription.overflowed = True
+        return event
+
+    @staticmethod
+    def _matches(scope: EventScope, event: PersistedEvent) -> bool:
+        return (
+            scope.tenant_id == event.tenant_id
+            and scope.domain_id == event.domain_id
+            and scope.session_id == event.session_id
+            and (scope.task_id is None or scope.task_id == event.task_id)
+        )
+
+    @staticmethod
+    def _event_from_json(raw: str) -> PersistedEvent:
+        data = json.loads(raw)
+        known = {
+            "protocol_version",
+            "event_id",
+            "event_kind",
+            "tenant_id",
+            "domain_id",
+            "session_id",
+            "task_id",
+            "renter_id",
+            "correlation_id",
+            "lease_id",
+            "issued_at",
+            "payload",
+            "idempotency_key",
+            "sequence",
+            "checkpoint_ref",
+            "evidence",
+            "cursor",
+        }
+        return PersistedEvent(
+            cursor=int(data["cursor"]),
+            event_id=data["event_id"],
+            event_kind=data["event_kind"],
+            tenant_id=data["tenant_id"],
+            domain_id=data["domain_id"],
+            session_id=data["session_id"],
+            task_id=data["task_id"],
+            renter_id=data["renter_id"],
+            correlation_id=data["correlation_id"],
+            lease_id=data["lease_id"],
+            issued_at=data["issued_at"],
+            payload=data.get("payload", {}),
+            idempotency_key=data.get("idempotency_key"),
+            source_sequence=data.get("sequence"),
+            checkpoint_ref=data.get("checkpoint_ref"),
+            evidence=tuple(data.get("evidence", ())),
+            extras={key: value for key, value in data.items() if key not in known},
+        )
+
+    def replay(
+        self,
+        scope: EventScope,
+        *,
+        after_cursor: int = 0,
+        limit: int = 200,
+    ) -> list[PersistedEvent]:
+        """Replay retained observations after a server-issued cursor."""
+
+        stream = self._stream_params(scope)
+        if after_cursor < 0:
+            raise RealtimeEventError("after_cursor must be >= 0")
+        if limit < 1 or limit > 1000:
+            raise RealtimeEventError("limit must be between 1 and 1000")
+        with self._lock:
+            bounds = self._connection.execute(
+                """SELECT MIN(cursor) AS oldest, MAX(cursor) AS newest
+                   FROM realtime_events
+                   WHERE tenant_id = ? AND domain_id = ? AND session_id = ?""",
+                stream,
+            ).fetchone()
+            oldest = bounds["oldest"]
+            if (
+                oldest is not None
+                and after_cursor > 0
+                and after_cursor < int(oldest) - 1
+            ):
+                raise CursorExpired(int(oldest))
+            if scope.task_id is None:
+                rows = self._connection.execute(
+                    """SELECT event_json FROM realtime_events
+                       WHERE tenant_id = ? AND domain_id = ? AND session_id = ?
+                         AND cursor > ?
+                       ORDER BY cursor ASC LIMIT ?""",
+                    (*stream, after_cursor, limit),
+                ).fetchall()
+            else:
+                rows = self._connection.execute(
+                    """SELECT event_json FROM realtime_events
+                       WHERE tenant_id = ? AND domain_id = ? AND session_id = ?
+                         AND task_id = ? AND cursor > ?
+                       ORDER BY cursor ASC LIMIT ?""",
+                    (*stream, scope.task_id, after_cursor, limit),
+                ).fetchall()
+        return [self._event_from_json(row["event_json"]) for row in rows]
+
+    def latest_cursor(self, scope: EventScope) -> int:
+        stream = self._stream_params(scope)
+        with self._lock:
+            if scope.task_id is None:
+                row = self._connection.execute(
+                    """SELECT COALESCE(MAX(cursor), 0) AS cursor
+                       FROM realtime_events
+                       WHERE tenant_id = ? AND domain_id = ? AND session_id = ?""",
+                    stream,
+                ).fetchone()
+            else:
+                row = self._connection.execute(
+                    """SELECT COALESCE(MAX(cursor), 0) AS cursor
+                       FROM realtime_events
+                       WHERE tenant_id = ? AND domain_id = ? AND session_id = ?
+                         AND task_id = ?""",
+                    (*stream, scope.task_id),
+                ).fetchone()
+        return int(row["cursor"])
+
+    def subscribe(
+        self,
+        principal: Mapping[str, Any],
+        scope: EventScope,
+        *,
+        after_cursor: int = 0,
+        subscription_id: str,
+    ) -> tuple[Subscription, list[PersistedEvent]]:
+        scope.validate()
+        if not self.authorizer(principal, scope):
+            raise UnauthorizedScope(
+                "principal is not authorized for requested realtime scope"
+            )
+        if not subscription_id.strip():
+            raise RealtimeEventError("subscription_id is required")
+
+        # Register first. A concurrent publish may then be both in replay and
+        # the live queue, but duplicates are safe; registering after replay
+        # would create a loss window, which is not acceptable.
+        subscription = Subscription(
+            subscription_id=subscription_id,
+            scope=scope,
+            queue=asyncio.Queue(maxsize=self.queue_limit),
+            last_cursor=after_cursor,
+        )
+        with self._lock:
+            self._subscribers[subscription_id] = subscription
+        try:
+            replay = self.replay(scope, after_cursor=after_cursor)
+        except Exception:
+            self.unsubscribe(subscription_id)
+            raise
+        return subscription, replay
+
+    def unsubscribe(self, subscription_id: str) -> None:
+        with self._lock:
+            self._subscribers.pop(subscription_id, None)
+
+    def acknowledge(self, subscription: Subscription, cursor: int) -> None:
+        if cursor < subscription.last_cursor:
+            raise RealtimeEventError(
+                "acknowledged cursor cannot move backwards"
+            )
+        if cursor > self.latest_cursor(subscription.scope):
+            raise RealtimeEventError(
+                "acknowledged cursor is ahead of the server stream"
+            )
+        subscription.last_cursor = cursor
+
+    def polling_fallback(
+        self,
+        principal: Mapping[str, Any],
+        scope: EventScope,
+        *,
+        after_cursor: int = 0,
+        limit: int = 200,
+    ) -> dict[str, Any]:
+        if not self.authorizer(principal, scope):
+            raise UnauthorizedScope(
+                "principal is not authorized for requested realtime scope"
+            )
+        events = self.replay(scope, after_cursor=after_cursor, limit=limit)
+        latest = self.latest_cursor(scope)
+        resume_cursor = events[-1].cursor if events else after_cursor
+        return {
+            "transport": "polling",
+            "events": [event.as_dict() for event in events],
+            "resume_cursor": resume_cursor,
+            "latest_cursor": latest,
+            "caught_up": resume_cursor >= latest,
+        }
+
+
+def make_event(
+    *,
+    event_id: str,
+    event_kind: str,
+    tenant_id: str,
+    domain_id: str,
+    session_id: str,
+    task_id: str,
+    correlation_id: str,
+    payload: Mapping[str, Any],
+    renter_id: str = "kpgs.control-plane",
+    lease_id: str = "lease:local-control-plane",
+    idempotency_key: str | None = None,
+    evidence: Iterable[Mapping[str, Any]] = (),
+    **canonical_fields: Any,
+) -> dict[str, Any]:
+    """Construct a renter-compatible event without claiming provider execution."""
+
+    event: dict[str, Any] = {
+        "protocol_version": "1.0",
+        "event_id": event_id,
+        "event_kind": event_kind,
+        "tenant_id": tenant_id,
+        "domain_id": domain_id,
+        "session_id": session_id,
+        "task_id": task_id,
+        "renter_id": renter_id,
+        "correlation_id": correlation_id,
+        "lease_id": lease_id,
+        "issued_at": datetime.now(timezone.utc).isoformat(),
+        "payload": dict(payload),
+        "evidence": [dict(item) for item in evidence],
+    }
+    if idempotency_key:
+        event["idempotency_key"] = idempotency_key
+    for key, value in canonical_fields.items():
+        if key != "cursor" and value is not None:
+            event[key] = value
+    return event

--- a/kopano-core/kopano/realtime_event_plane.py
+++ b/kopano-core/kopano/realtime_event_plane.py
@@ -1,15 +1,15 @@
 """Persistent, transport-neutral KPGS realtime event plane.
 
-The event plane is a read/distribution surface. It never owns canonical business
-state and never retries authoritative CRUD mutations. Events are persisted so a
-socket disconnect can be recovered with a server-issued cursor.
+The event plane is an observable distribution surface. It never owns canonical
+business state and never retries CRUD mutations. Durable journal persistence
+supports reconnect/resume while live transports remain disposable.
 """
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 from datetime import datetime, timezone
-import asyncio
 import hashlib
 import json
 from pathlib import Path
@@ -23,7 +23,7 @@ class RealtimeEventError(ValueError):
 
 
 class UnauthorizedScope(RealtimeEventError):
-    """Raised when a principal requests a scope it is not allowed to observe."""
+    """Raised when a principal requests an unauthorized stream scope."""
 
 
 class EventConflict(RealtimeEventError):
@@ -57,55 +57,41 @@ class EventScope:
 
 @dataclass(frozen=True)
 class PersistedEvent:
+    """Canonical renter envelope plus a server-issued replay cursor."""
+
     cursor: int
-    event_id: str
-    event_kind: str
-    tenant_id: str
-    domain_id: str
-    session_id: str
-    task_id: str
-    correlation_id: str
-    renter_id: str
-    lease_id: str
-    issued_at: str
-    payload: Mapping[str, Any]
-    idempotency_key: str | None = None
-    source_sequence: int | None = None
-    checkpoint_ref: str | None = None
-    evidence: tuple[Mapping[str, Any], ...] = ()
-    extras: Mapping[str, Any] | None = None
+    envelope: Mapping[str, Any]
+
+    @property
+    def event_id(self) -> str:
+        return str(self.envelope["event_id"])
+
+    @property
+    def event_kind(self) -> str:
+        return str(self.envelope["event_kind"])
+
+    @property
+    def tenant_id(self) -> str:
+        return str(self.envelope["tenant_id"])
+
+    @property
+    def domain_id(self) -> str:
+        return str(self.envelope["domain_id"])
+
+    @property
+    def session_id(self) -> str:
+        return str(self.envelope["session_id"])
+
+    @property
+    def task_id(self) -> str:
+        return str(self.envelope["task_id"])
 
     def as_dict(self) -> dict[str, Any]:
-        data: dict[str, Any] = {
-            "protocol_version": "1.0",
-            "event_id": self.event_id,
-            "event_kind": self.event_kind,
-            "tenant_id": self.tenant_id,
-            "domain_id": self.domain_id,
-            "session_id": self.session_id,
-            "task_id": self.task_id,
-            "renter_id": self.renter_id,
-            "correlation_id": self.correlation_id,
-            "lease_id": self.lease_id,
-            "issued_at": self.issued_at,
-            "payload": dict(self.payload),
-            "cursor": self.cursor,
-            "sequence": (
-                self.source_sequence
-                if self.source_sequence is not None
-                else self.cursor
-            ),
-        }
-        if self.idempotency_key:
-            data["idempotency_key"] = self.idempotency_key
-        if self.checkpoint_ref:
-            data["checkpoint_ref"] = self.checkpoint_ref
-        if self.evidence:
-            data["evidence"] = [dict(item) for item in self.evidence]
-        if self.extras:
-            for key, value in self.extras.items():
-                if key not in data and key != "cursor":
-                    data[key] = value
+        data = dict(self.envelope)
+        data["cursor"] = self.cursor
+        # The renter schema's optional sequence belongs to the producer. If it
+        # is absent, expose the replay cursor as transport ordering metadata.
+        data.setdefault("sequence", self.cursor)
         return data
 
 
@@ -125,11 +111,7 @@ Authorizer = Callable[[Mapping[str, Any], EventScope], bool]
 def default_scope_authorizer(
     principal: Mapping[str, Any], scope: EventScope
 ) -> bool:
-    """Fail-closed default scope authorization.
-
-    Admin/God principals may observe all domains. Other principals must carry a
-    matching tenant and either an exact domain or an allowed_domains grant.
-    """
+    """Fail closed unless the principal can observe this tenant/domain."""
 
     if not principal or not principal.get("is_active", True):
         return False
@@ -146,7 +128,7 @@ def default_scope_authorizer(
 
 
 class RealtimeEventPlane:
-    """SQLite-backed replay journal with bounded live subscribers."""
+    """SQLite replay journal with bounded, non-authoritative live fan-out."""
 
     NONCRITICAL_EVENT_KINDS = {"task.progress", "presence", "domain.health"}
     REQUIRED_FIELDS = (
@@ -229,8 +211,14 @@ class RealtimeEventPlane:
 
     @staticmethod
     def _fingerprint(envelope: Mapping[str, Any]) -> str:
-        canonical = dict(envelope)
-        canonical.pop("cursor", None)
+        # issued_at is observation time, not idempotency identity. A retried
+        # producer may reconstruct the same governed event later without turning
+        # that harmless timestamp difference into an event conflict.
+        canonical = {
+            key: value
+            for key, value in envelope.items()
+            if key not in {"cursor", "issued_at"}
+        }
         encoded = json.dumps(
             canonical,
             sort_keys=True,
@@ -241,9 +229,7 @@ class RealtimeEventPlane:
 
     @classmethod
     def _validate_envelope(cls, envelope: Mapping[str, Any]) -> None:
-        missing = [
-            field for field in cls.REQUIRED_FIELDS if field not in envelope
-        ]
+        missing = [field for field in cls.REQUIRED_FIELDS if field not in envelope]
         if missing:
             raise RealtimeEventError(
                 f"missing required event fields: {', '.join(missing)}"
@@ -255,12 +241,18 @@ class RealtimeEventPlane:
             raise RealtimeEventError("payload must be an object")
 
     @staticmethod
-    def _stream_params(scope: EventScope) -> tuple[str, str, str]:
+    def _stream(scope: EventScope) -> tuple[str, str, str]:
         scope.validate()
         return scope.tenant_id, scope.domain_id, scope.session_id
 
+    @staticmethod
+    def _decode(row: sqlite3.Row | Mapping[str, Any]) -> PersistedEvent:
+        payload = json.loads(str(row["event_json"]))
+        cursor = int(payload.pop("cursor"))
+        return PersistedEvent(cursor=cursor, envelope=payload)
+
     def publish(self, envelope: Mapping[str, Any]) -> PersistedEvent:
-        """Persist one observation and fan it out without blocking producer work."""
+        """Persist one observation and fan it out without blocking producers."""
 
         self._validate_envelope(envelope)
         scope = EventScope(
@@ -268,29 +260,33 @@ class RealtimeEventPlane:
             str(envelope["domain_id"]),
             str(envelope["session_id"]),
         )
-        stream = self._stream_params(scope)
+        stream = self._stream(scope)
         fingerprint = self._fingerprint(envelope)
-        idempotency_key = envelope.get("idempotency_key")
+        event_id = str(envelope["event_id"])
+        idempotency_key = (
+            str(envelope["idempotency_key"])
+            if envelope.get("idempotency_key")
+            else None
+        )
 
         with self._lock:
             existing = self._connection.execute(
-                "SELECT fingerprint, event_json FROM realtime_events "
-                "WHERE event_id = ?",
-                (str(envelope["event_id"]),),
+                "SELECT fingerprint, event_json FROM realtime_events WHERE event_id = ?",
+                (event_id,),
             ).fetchone()
-            if existing is None and idempotency_key:
+            if existing is None and idempotency_key is not None:
                 existing = self._connection.execute(
                     """SELECT fingerprint, event_json FROM realtime_events
                        WHERE tenant_id = ? AND domain_id = ? AND session_id = ?
                          AND idempotency_key = ?""",
-                    (*stream, str(idempotency_key)),
+                    (*stream, idempotency_key),
                 ).fetchone()
             if existing is not None:
-                if existing["fingerprint"] != fingerprint:
+                if str(existing["fingerprint"]) != fingerprint:
                     raise EventConflict(
                         "event or idempotency key was reused with different content"
                     )
-                return self._event_from_json(existing["event_json"])
+                return self._decode(existing)
 
             next_cursor = int(
                 self._connection.execute(
@@ -300,68 +296,15 @@ class RealtimeEventPlane:
                     stream,
                 ).fetchone()["next_cursor"]
             )
-            issued_at = str(
+            stored = dict(envelope)
+            stored.setdefault("protocol_version", "1.0")
+            stored["issued_at"] = str(
                 envelope.get("issued_at")
                 or datetime.now(timezone.utc).isoformat()
             )
-            event = PersistedEvent(
-                cursor=next_cursor,
-                event_id=str(envelope["event_id"]),
-                event_kind=str(envelope["event_kind"]),
-                tenant_id=scope.tenant_id,
-                domain_id=scope.domain_id,
-                session_id=scope.session_id,
-                task_id=str(envelope["task_id"]),
-                renter_id=str(envelope["renter_id"]),
-                correlation_id=str(envelope["correlation_id"]),
-                lease_id=str(envelope["lease_id"]),
-                issued_at=issued_at,
-                payload=dict(envelope["payload"]),
-                idempotency_key=(
-                    str(idempotency_key) if idempotency_key else None
-                ),
-                source_sequence=(
-                    int(envelope["sequence"])
-                    if envelope.get("sequence") is not None
-                    else None
-                ),
-                checkpoint_ref=(
-                    str(envelope["checkpoint_ref"])
-                    if envelope.get("checkpoint_ref")
-                    else None
-                ),
-                evidence=tuple(
-                    dict(item)
-                    for item in envelope.get("evidence", ())
-                    if isinstance(item, Mapping)
-                ),
-                extras={
-                    key: value
-                    for key, value in envelope.items()
-                    if key
-                    not in {
-                        "protocol_version",
-                        "event_id",
-                        "event_kind",
-                        "tenant_id",
-                        "domain_id",
-                        "session_id",
-                        "task_id",
-                        "renter_id",
-                        "correlation_id",
-                        "lease_id",
-                        "issued_at",
-                        "payload",
-                        "idempotency_key",
-                        "sequence",
-                        "checkpoint_ref",
-                        "evidence",
-                        "cursor",
-                    }
-                },
-            )
+            stored["cursor"] = next_cursor
             event_json = json.dumps(
-                event.as_dict(), sort_keys=True, separators=(",", ":")
+                stored, sort_keys=True, separators=(",", ":"), default=str
             )
             self._connection.execute(
                 """INSERT INTO realtime_events
@@ -370,10 +313,10 @@ class RealtimeEventPlane:
                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     *stream,
-                    event.task_id,
+                    str(envelope["task_id"]),
                     next_cursor,
-                    event.event_id,
-                    event.idempotency_key,
+                    event_id,
+                    idempotency_key,
                     fingerprint,
                     event_json,
                 ),
@@ -389,6 +332,10 @@ class RealtimeEventPlane:
                 (*stream, self.max_events_per_stream, *stream),
             )
             self._connection.commit()
+            event = PersistedEvent(
+                cursor=next_cursor,
+                envelope={key: value for key, value in stored.items() if key != "cursor"},
+            )
             subscribers = tuple(self._subscribers.values())
 
         for subscription in subscribers:
@@ -400,8 +347,8 @@ class RealtimeEventPlane:
                 if event.event_kind in self.NONCRITICAL_EVENT_KINDS:
                     subscription.dropped_noncritical += 1
                 else:
-                    # Never block an authoritative producer. A slow consumer
-                    # reconnects and replays from its last acknowledged cursor.
+                    # The event is durable. Force reconnect/replay instead of
+                    # blocking producer work or pretending delivery succeeded.
                     subscription.overflowed = True
         return event
 
@@ -414,48 +361,6 @@ class RealtimeEventPlane:
             and (scope.task_id is None or scope.task_id == event.task_id)
         )
 
-    @staticmethod
-    def _event_from_json(raw: str) -> PersistedEvent:
-        data = json.loads(raw)
-        known = {
-            "protocol_version",
-            "event_id",
-            "event_kind",
-            "tenant_id",
-            "domain_id",
-            "session_id",
-            "task_id",
-            "renter_id",
-            "correlation_id",
-            "lease_id",
-            "issued_at",
-            "payload",
-            "idempotency_key",
-            "sequence",
-            "checkpoint_ref",
-            "evidence",
-            "cursor",
-        }
-        return PersistedEvent(
-            cursor=int(data["cursor"]),
-            event_id=data["event_id"],
-            event_kind=data["event_kind"],
-            tenant_id=data["tenant_id"],
-            domain_id=data["domain_id"],
-            session_id=data["session_id"],
-            task_id=data["task_id"],
-            renter_id=data["renter_id"],
-            correlation_id=data["correlation_id"],
-            lease_id=data["lease_id"],
-            issued_at=data["issued_at"],
-            payload=data.get("payload", {}),
-            idempotency_key=data.get("idempotency_key"),
-            source_sequence=data.get("sequence"),
-            checkpoint_ref=data.get("checkpoint_ref"),
-            evidence=tuple(data.get("evidence", ())),
-            extras={key: value for key, value in data.items() if key not in known},
-        )
-
     def replay(
         self,
         scope: EventScope,
@@ -463,13 +368,14 @@ class RealtimeEventPlane:
         after_cursor: int = 0,
         limit: int = 200,
     ) -> list[PersistedEvent]:
-        """Replay retained observations after a server-issued cursor."""
+        """Replay retained observations after a server-issued stream cursor."""
 
-        stream = self._stream_params(scope)
+        stream = self._stream(scope)
         if after_cursor < 0:
             raise RealtimeEventError("after_cursor must be >= 0")
         if limit < 1 or limit > 1000:
             raise RealtimeEventError("limit must be between 1 and 1000")
+
         with self._lock:
             bounds = self._connection.execute(
                 """SELECT MIN(cursor) AS oldest, MAX(cursor) AS newest
@@ -484,6 +390,7 @@ class RealtimeEventPlane:
                 and after_cursor < int(oldest) - 1
             ):
                 raise CursorExpired(int(oldest))
+
             if scope.task_id is None:
                 rows = self._connection.execute(
                     """SELECT event_json FROM realtime_events
@@ -500,10 +407,10 @@ class RealtimeEventPlane:
                        ORDER BY cursor ASC LIMIT ?""",
                     (*stream, scope.task_id, after_cursor, limit),
                 ).fetchall()
-        return [self._event_from_json(row["event_json"]) for row in rows]
+        return [self._decode(row) for row in rows]
 
     def latest_cursor(self, scope: EventScope) -> int:
-        stream = self._stream_params(scope)
+        stream = self._stream(scope)
         with self._lock:
             if scope.task_id is None:
                 row = self._connection.execute(
@@ -538,15 +445,15 @@ class RealtimeEventPlane:
         if not subscription_id.strip():
             raise RealtimeEventError("subscription_id is required")
 
-        # Register first. A concurrent publish may then be both in replay and
-        # the live queue, but duplicates are safe; registering after replay
-        # would create a loss window, which is not acceptable.
         subscription = Subscription(
             subscription_id=subscription_id,
             scope=scope,
             queue=asyncio.Queue(maxsize=self.queue_limit),
             last_cursor=after_cursor,
         )
+        # Register first. A racing event may appear both in replay and the live
+        # queue, but a duplicate is recoverable; registering after replay would
+        # create an unrecoverable event-loss window.
         with self._lock:
             self._subscribers[subscription_id] = subscription
         try:
@@ -562,9 +469,7 @@ class RealtimeEventPlane:
 
     def acknowledge(self, subscription: Subscription, cursor: int) -> None:
         if cursor < subscription.last_cursor:
-            raise RealtimeEventError(
-                "acknowledged cursor cannot move backwards"
-            )
+            raise RealtimeEventError("acknowledged cursor cannot move backwards")
         if cursor > self.latest_cursor(subscription.scope):
             raise RealtimeEventError(
                 "acknowledged cursor is ahead of the server stream"
@@ -631,6 +536,6 @@ def make_event(
     if idempotency_key:
         event["idempotency_key"] = idempotency_key
     for key, value in canonical_fields.items():
-        if key != "cursor" and value is not None:
+        if key not in {"cursor", "issued_at"} and value is not None:
             event[key] = value
     return event

--- a/kopano-core/kopano/swfus_realtime_bridge.py
+++ b/kopano-core/kopano/swfus_realtime_bridge.py
@@ -1,0 +1,107 @@
+"""SWFUS -> KPGS realtime distribution adapter.
+
+The bridge is deliberately one-way. SWFUS remains the governed update executor;
+the event plane persists observable distribution evidence and never calls CRUD.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import json
+from typing import Any, Mapping
+
+from .realtime_event_plane import RealtimeEventPlane, make_event
+
+
+@dataclass(frozen=True)
+class SwfusRealtimeContext:
+    tenant_id: str
+    domain_id: str
+    session_id: str
+    task_id: str
+    renter_id: str = "swfus.framework-distributor"
+    lease_id: str = "lease:swfus-framework-distributor"
+
+    def validate(self) -> None:
+        for field_name in ("tenant_id", "domain_id", "session_id", "task_id"):
+            if not str(getattr(self, field_name)).strip():
+                raise ValueError(f"{field_name} is required")
+
+
+class SwfusRealtimeDistributionSink:
+    """Callable sink accepted by ``SwfusHierarchy(distribution_sink=...)``.
+
+    Persistence failure is intentionally raised to SWFUS. The SWFUS runtime
+    already treats a failed distribution sink as HOLD and atomically restores
+    its non-authoritative projection. Slow or disconnected subscribers cannot
+    cause that failure because live fan-out is bounded and non-blocking.
+    """
+
+    def __init__(
+        self,
+        event_plane: RealtimeEventPlane,
+        context: SwfusRealtimeContext,
+    ) -> None:
+        context.validate()
+        self.event_plane = event_plane
+        self.context = context
+
+    @staticmethod
+    def _digest(event: Mapping[str, Any]) -> str:
+        encoded = json.dumps(
+            dict(event),
+            sort_keys=True,
+            separators=(",", ":"),
+            default=str,
+        ).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()
+
+    def __call__(self, distribution_event: dict[str, Any]) -> None:
+        if distribution_event.get("schema") != "kpgs.swfus.distribution.v1":
+            raise ValueError("unsupported SWFUS distribution schema")
+        if distribution_event.get("canonical") is not False:
+            raise ValueError("realtime bridge only accepts non-canonical projections")
+        if distribution_event.get("authority_effect") != "none":
+            raise ValueError("realtime transport cannot widen authority")
+        if distribution_event.get("transport_grants_authority") is not False:
+            raise ValueError("transport authority invariant failed")
+
+        digest = self._digest(distribution_event)
+        evidence = tuple(
+            {"kind": "swfus", "ref": str(ref)}
+            for ref in distribution_event.get("evidence_refs", ())
+        )
+        update_id = str(distribution_event.get("update_id", ""))
+        correlation_id = str(distribution_event.get("correlation_id", ""))
+        if not update_id or not correlation_id:
+            raise ValueError("SWFUS distribution identity is incomplete")
+
+        self.event_plane.publish(
+            make_event(
+                event_id=f"swfus-{digest[:32]}",
+                event_kind="task.progress",
+                tenant_id=self.context.tenant_id,
+                domain_id=self.context.domain_id,
+                session_id=self.context.session_id,
+                task_id=self.context.task_id,
+                correlation_id=correlation_id,
+                renter_id=self.context.renter_id,
+                lease_id=self.context.lease_id,
+                idempotency_key=f"swfus:{update_id}:{digest}",
+                payload={
+                    "state": "working",
+                    "stage": "distribution",
+                    "update_id": update_id,
+                    "node_id": distribution_event.get("node_id"),
+                    "operation": distribution_event.get("operation"),
+                    "state_digest": distribution_event.get("state_digest"),
+                    "canonical": False,
+                    "authority_effect": "none",
+                },
+                evidence=evidence,
+                governing_spec_ref=(
+                    "governance/kpgs-vnext/progressive-updates/README.md"
+                ),
+            )
+        )

--- a/tests/test_kasilink_realtime_adapter.py
+++ b/tests/test_kasilink_realtime_adapter.py
@@ -1,0 +1,115 @@
+import unittest
+
+from kopano import kasilink_realtime
+from kopano.realtime_event_plane import EventScope, RealtimeEventPlane
+
+
+class KasiLinkRealtimeAdapterTests(unittest.TestCase):
+    def setUp(self):
+        self.previous_plane = kasilink_realtime._plane_instance
+        self.plane = RealtimeEventPlane(":memory:")
+        kasilink_realtime._plane_instance = self.plane
+
+    def tearDown(self):
+        kasilink_realtime._plane_instance = self.previous_plane
+        self.plane.close()
+
+    def test_real_match_workflow_emits_live_progress_without_authority(self):
+        live = kasilink_realtime.begin_match(
+            "session-kasilink-001",
+            "task-kasilink-001",
+            "corr-kasilink-001",
+        )
+        metadata = kasilink_realtime.complete_match(
+            live,
+            {"matches": [{"provider_id": "provider-001"}]},
+        )
+
+        scope = EventScope(
+            "kopano",
+            "kasilink",
+            "session-kasilink-001",
+            "task-kasilink-001",
+        )
+        events = [event.as_dict() for event in self.plane.replay(scope)]
+
+        self.assertEqual(
+            [event["event_kind"] for event in events],
+            ["task.accepted", "task.started", "task.completed"],
+        )
+        self.assertEqual(
+            [event["payload"]["state"] for event in events],
+            ["working", "working", "done"],
+        )
+        self.assertEqual(metadata["state"], "done")
+        self.assertEqual(metadata["transport_authority"], "none")
+        self.assertEqual(metadata["resume_cursor"], events[-1]["cursor"])
+        self.assertTrue(
+            all(
+                event["governing_spec_ref"]
+                == "governance/kpgs-vnext/realtime/EVENT_PLANE.md"
+                for event in events
+            )
+        )
+
+    def test_replaying_same_domain_task_does_not_duplicate_events(self):
+        first = kasilink_realtime.begin_match(
+            "session-kasilink-002",
+            "task-kasilink-002",
+            "corr-kasilink-002",
+        )
+        second = kasilink_realtime.begin_match(
+            "session-kasilink-002",
+            "task-kasilink-002",
+            "corr-kasilink-002",
+        )
+        self.assertEqual(first["resume_cursor"], second["resume_cursor"])
+
+        scope = EventScope(
+            "kopano",
+            "kasilink",
+            "session-kasilink-002",
+            "task-kasilink-002",
+        )
+        events = self.plane.replay(scope)
+        self.assertEqual(len(events), 2)
+        self.assertEqual(
+            [event.event_kind for event in events],
+            ["task.accepted", "task.started"],
+        )
+
+    def test_partial_started_failure_preserves_accepted_identity(self):
+        original_publish = kasilink_realtime._publish
+        calls = 0
+
+        def flaky_publish(**kwargs):
+            nonlocal calls
+            calls += 1
+            if calls == 2:
+                raise OSError("simulated journal interruption")
+            return original_publish(**kwargs)
+
+        kasilink_realtime._publish = flaky_publish
+        try:
+            live = kasilink_realtime.begin_match(
+                "session-kasilink-003",
+                "task-kasilink-003",
+                "corr-kasilink-003",
+            )
+        finally:
+            kasilink_realtime._publish = original_publish
+
+        self.assertEqual(live["realtime_state"], "degraded")
+        self.assertEqual(live["task_id"], "task-kasilink-003")
+        scope = EventScope(
+            "kopano",
+            "kasilink",
+            "session-kasilink-003",
+            "task-kasilink-003",
+        )
+        events = self.plane.replay(scope)
+        self.assertEqual([event.event_kind for event in events], ["task.accepted"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_realtime_event_plane.py
+++ b/tests/test_realtime_event_plane.py
@@ -1,0 +1,204 @@
+import importlib.util
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+MODULE_PATH = Path(__file__).parents[1] / "kopano-core" / "kopano" / "realtime_event_plane.py"
+spec = importlib.util.spec_from_file_location("realtime_event_plane_vnext", MODULE_PATH)
+mod = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+sys.modules[spec.name] = mod
+spec.loader.exec_module(mod)
+
+
+class RealtimeEventPlaneTests(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.db = Path(self.tempdir.name) / "events.db"
+        self.plane = mod.RealtimeEventPlane(
+            self.db,
+            max_events_per_stream=4,
+            queue_limit=1,
+        )
+        self.scope = mod.EventScope("kopano", "kasilink", "session-001")
+        self.principal = {
+            "tenant_id": "kopano",
+            "domain_id": "kasilink",
+            "is_active": True,
+        }
+
+    def tearDown(self):
+        self.plane.close()
+        self.tempdir.cleanup()
+
+    def event(self, n, kind="task.progress", idem=None, payload=None):
+        return mod.make_event(
+            event_id=f"event-{n:03d}",
+            event_kind=kind,
+            tenant_id="kopano",
+            domain_id="kasilink",
+            session_id="session-001",
+            task_id="task-001",
+            correlation_id="corr-001",
+            idempotency_key=idem,
+            payload=payload or {"step": n},
+        )
+
+    def test_socket_disconnect_does_not_delete_persisted_events(self):
+        first = self.plane.publish(self.event(1, "task.accepted"))
+        subscription, replay = self.plane.subscribe(
+            self.principal,
+            self.scope,
+            after_cursor=0,
+            subscription_id="sub-1",
+        )
+        self.assertEqual([event.cursor for event in replay], [first.cursor])
+
+        self.plane.unsubscribe(subscription.subscription_id)
+        self.plane.close()
+        self.plane = mod.RealtimeEventPlane(
+            self.db,
+            max_events_per_stream=4,
+            queue_limit=1,
+        )
+        restored = self.plane.replay(self.scope, after_cursor=0)
+        self.assertEqual([event.event_id for event in restored], ["event-001"])
+
+    def test_reconnect_resumes_after_acknowledged_cursor(self):
+        one = self.plane.publish(self.event(1, "task.accepted"))
+        two = self.plane.publish(self.event(2, "task.started"))
+
+        replay = self.plane.polling_fallback(
+            self.principal,
+            self.scope,
+            after_cursor=one.cursor,
+        )
+        self.assertEqual(
+            [event["event_id"] for event in replay["events"]],
+            [two.event_id],
+        )
+        self.assertEqual(replay["resume_cursor"], two.cursor)
+        self.assertTrue(replay["caught_up"])
+
+    def test_duplicate_delivery_is_idempotent_and_collision_is_rejected(self):
+        event = self.event(1, idem="idem-1")
+        first = self.plane.publish(event)
+        again = self.plane.publish(event)
+        self.assertEqual(first.cursor, again.cursor)
+        self.assertEqual(len(self.plane.replay(self.scope)), 1)
+
+        collision = self.event(2, idem="idem-1", payload={"step": 999})
+        with self.assertRaises(mod.EventConflict):
+            self.plane.publish(collision)
+
+    def test_unauthorized_scope_is_rejected_server_side(self):
+        wrong = {
+            "tenant_id": "other",
+            "domain_id": "kasilink",
+            "is_active": True,
+        }
+        with self.assertRaises(mod.UnauthorizedScope):
+            self.plane.polling_fallback(wrong, self.scope)
+        with self.assertRaises(mod.UnauthorizedScope):
+            self.plane.subscribe(
+                wrong,
+                self.scope,
+                subscription_id="forbidden",
+            )
+
+    def test_bounded_queue_never_blocks_producer_and_replay_recovers(self):
+        subscription, _ = self.plane.subscribe(
+            self.principal,
+            self.scope,
+            subscription_id="slow",
+        )
+        self.plane.publish(self.event(1, "task.started"))
+        self.plane.publish(self.event(2, "task.completed"))
+
+        self.assertTrue(subscription.overflowed)
+        self.assertEqual(
+            [event.event_id for event in self.plane.replay(self.scope)],
+            ["event-001", "event-002"],
+        )
+
+    def test_noncritical_overflow_is_counted_without_claiming_delivery(self):
+        subscription, _ = self.plane.subscribe(
+            self.principal,
+            self.scope,
+            subscription_id="slow",
+        )
+        self.plane.publish(self.event(1, "task.progress"))
+        self.plane.publish(self.event(2, "task.progress"))
+
+        self.assertFalse(subscription.overflowed)
+        self.assertEqual(subscription.dropped_noncritical, 1)
+
+    def test_expired_cursor_requires_snapshot_recovery(self):
+        for number in range(1, 7):
+            self.plane.publish(self.event(number))
+
+        with self.assertRaises(mod.CursorExpired) as context:
+            self.plane.replay(self.scope, after_cursor=1)
+        self.assertEqual(context.exception.oldest_cursor, 3)
+
+    def test_ack_cannot_move_backward_or_ahead(self):
+        event = self.plane.publish(self.event(1))
+        subscription, _ = self.plane.subscribe(
+            self.principal,
+            self.scope,
+            subscription_id="sub",
+        )
+        self.plane.acknowledge(subscription, event.cursor)
+        with self.assertRaises(mod.RealtimeEventError):
+            self.plane.acknowledge(subscription, 0)
+        with self.assertRaises(mod.RealtimeEventError):
+            self.plane.acknowledge(subscription, event.cursor + 10)
+
+    def test_task_filtered_polling_uses_relevant_highwater(self):
+        self.plane.publish(self.event(1, "task.started"))
+        other = mod.make_event(
+            event_id="event-other",
+            event_kind="task.started",
+            tenant_id="kopano",
+            domain_id="kasilink",
+            session_id="session-001",
+            task_id="task-002",
+            correlation_id="corr-002",
+            payload={"step": "other"},
+        )
+        self.plane.publish(other)
+
+        task_scope = mod.EventScope(
+            "kopano",
+            "kasilink",
+            "session-001",
+            "task-001",
+        )
+        result = self.plane.polling_fallback(
+            self.principal,
+            task_scope,
+            after_cursor=0,
+        )
+        self.assertEqual(
+            [item["event_id"] for item in result["events"]],
+            ["event-001"],
+        )
+        self.assertEqual(result["latest_cursor"], 1)
+        self.assertTrue(result["caught_up"])
+
+    def test_canonical_failure_fields_survive_transport_framing(self):
+        event = self.event(1, "task.failed")
+        event["failure"] = {
+            "code": "execution_failed",
+            "recoverability": "retry",
+        }
+        persisted = self.plane.publish(event)
+        self.assertEqual(
+            persisted.as_dict()["failure"]["code"],
+            "execution_failed",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_swfus_realtime_bridge.py
+++ b/tests/test_swfus_realtime_bridge.py
@@ -1,0 +1,104 @@
+import importlib.util
+from pathlib import Path
+import sys
+import tempfile
+import types
+import unittest
+
+KOPANO_DIR = Path(__file__).parents[1] / "kopano-core" / "kopano"
+
+package = types.ModuleType("kopano")
+package.__path__ = [str(KOPANO_DIR)]
+sys.modules.setdefault("kopano", package)
+
+
+def load(name: str, filename: str):
+    spec = importlib.util.spec_from_file_location(name, KOPANO_DIR / filename)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+realtime = load("kopano.realtime_event_plane", "realtime_event_plane.py")
+bridge_mod = load("kopano.swfus_realtime_bridge", "swfus_realtime_bridge.py")
+
+
+class SwfusRealtimeBridgeTests(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.plane = realtime.RealtimeEventPlane(
+            Path(self.tempdir.name) / "events.db"
+        )
+        self.context = bridge_mod.SwfusRealtimeContext(
+            tenant_id="kopano",
+            domain_id="fivesarena",
+            session_id="session-live-001",
+            task_id="task-update-001",
+        )
+        self.sink = bridge_mod.SwfusRealtimeDistributionSink(
+            self.plane,
+            self.context,
+        )
+        self.scope = realtime.EventScope(
+            "kopano",
+            "fivesarena",
+            "session-live-001",
+            "task-update-001",
+        )
+
+    def tearDown(self):
+        self.plane.close()
+        self.tempdir.cleanup()
+
+    def distribution(self, **overrides):
+        payload = {
+            "schema": "kpgs.swfus.distribution.v1",
+            "update_id": "update-001",
+            "node_id": "arena-state-001",
+            "operation": "UPDATE",
+            "state_digest": "abc123",
+            "evidence_refs": ["receipt://poc/001"],
+            "correlation_id": "corr-001",
+            "authority_effect": "none",
+            "canonical": False,
+            "transport_grants_authority": False,
+        }
+        payload.update(overrides)
+        return payload
+
+    def test_valid_swfus_distribution_becomes_replayable_progress(self):
+        self.sink(self.distribution())
+        events = self.plane.replay(self.scope)
+        self.assertEqual(len(events), 1)
+        event = events[0].as_dict()
+        self.assertEqual(event["event_kind"], "task.progress")
+        self.assertEqual(event["payload"]["stage"], "distribution")
+        self.assertFalse(event["payload"]["canonical"])
+        self.assertEqual(event["payload"]["authority_effect"], "none")
+        self.assertEqual(event["evidence"][0]["ref"], "receipt://poc/001")
+
+    def test_replayed_distribution_does_not_duplicate_observation(self):
+        distribution = self.distribution()
+        self.sink(distribution)
+        self.sink(distribution)
+        self.assertEqual(len(self.plane.replay(self.scope)), 1)
+
+    def test_transport_cannot_accept_authority_widening(self):
+        with self.assertRaises(ValueError):
+            self.sink(self.distribution(authority_effect="grant"))
+        with self.assertRaises(ValueError):
+            self.sink(self.distribution(canonical=True))
+        with self.assertRaises(ValueError):
+            self.sink(self.distribution(transport_grants_authority=True))
+        self.assertEqual(self.plane.replay(self.scope), [])
+
+    def test_invalid_distribution_schema_is_fail_closed(self):
+        with self.assertRaises(ValueError):
+            self.sink(self.distribution(schema="other.schema"))
+        self.assertEqual(self.plane.replay(self.scope), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- implements the canonical persistent realtime event plane with SQLite replay journal, server-issued cursors, idempotent duplicate handling, scoped authorization and bounded subscriber queues
- adapts the existing KasiLink `/api/kasilink/match` workflow rather than creating a replacement product flow
- adds WebSocket-first delivery at the scoped KasiLink adapter with first-message auth, re-auth, acknowledgements, heartbeat and reconnect/backpressure semantics
- adds governed polling fallback for constrained networks
- bridges the existing `Adaptive PU -> Progressive Update -> CRUD -> SWFUS` distribution boundary into replayable realtime observations without granting transport authority or calling back into CRUD
- documents legacy broadcast sockets as compatibility-only rather than canonical proof

## Authority / truth boundary

- sockets and polling are delivery surfaces, never the canonical database
- subscriber disconnect/backpressure cannot block authoritative producer work
- SWFUS distribution-journal failure remains fail-closed through the existing SWFUS rollback contract
- duplicate/reconnect delivery cannot rerun CRUD
- no provider/model/cloud execution is implied

## Validation

Added focused tests for persistence across disconnect/restart, cursor resume, idempotency collisions, scope rejection, bounded backpressure, degraded polling, task-filtered high-water marks, preserved failure fields, and SWFUS transport authority invariants.

Closes #40