### PR TITLE
Cars4Mars: seed canonical physical-build contract and P-001 wheel sandbox

### DIFF
--- a/governance/kpgs-vnext/domain-contracts/cars4mars/README.md
+++ b/governance/kpgs-vnext/domain-contracts/cars4mars/README.md
@@ -1,0 +1,259 @@
+# Cars4Mars Canonical Build Contract
+
+Status: **ACTIVE — physical-build transition / evidence-gated**  
+Canonical timestamp: **2026-08-18 19:17 SAST**  
+Project baseline: **DFR-01 — 02 August 2026**
+
+This contract binds the Cars4Mars physical-build work to the same KPGS vNext laws already enforced in `Introduction-to-MCP`.
+
+It does **not** replace DFR-01. It prevents the new fabrication work from drifting away from DFR-01 while allowing bounded prototype parameters to evolve through evidence.
+
+## 1. Authority order
+
+```text
+ARC 2026 Rulebook Rev 2.0
+        ↓
+DFR-01 locked engineering baseline
+        ↓
+Cars4Mars canonical build contract (this folder)
+        ↓
+Cars4Mars engineering repository
+        ↓
+prototype / CAD / fabrication / test receipts
+        ↓
+public Cars4Mars surfaces
+```
+
+A render, generated image, simulation, software test, laboratory-access photograph, or fabrication plan cannot silently promote a physical claim.
+
+## 2. Truth boundary at this timestamp
+
+### Locked / designed
+
+- exactly six wheels;
+- six-wheel skid-steer with passive rocker-bogie;
+- 250 mm wheel diameter baseline;
+- 700 × 650 × 500 mm target rover envelope;
+- 28 kg BOM target and 30 kg engineering load case;
+- six Rhino IG52 24 V / 60 rpm / 100 W gearmotors;
+- three Cytron MDDS30 drivers;
+- Teensy 4.1 owns deterministic drive and safety authority;
+- Jetson Orin Nano Super owns perception, not motor safety;
+- Intel RealSense D455 + RPLIDAR A2M12 sensing baseline;
+- 24 V 20 Ah LiFePO4, BMS, 60 A master fuse, contactor and E-stop;
+- local Wi-Fi for command/video;
+- RFM95W LoRa is heartbeat/fail-stop support only;
+- payload tray baseline 350 × 300 × 180 mm for up to 1 kg mission object.
+
+### Software / virtual evidence already present
+
+The canonical Cars4Mars engineering repository already records host-side and native embedded-core software tests. Those receipts remain **software evidence only**. They do not promote the physical rover to assembled/tested/validated.
+
+### New physical-build context — 18 August 2026
+
+The current session adds a new **facility-access observation**, not a rover-validation claim:
+
+- location reported and visually shown: HPI d-school fabrication / 3D lab;
+- LightBurn 2 is available in the lab workflow;
+- the team is beginning small-part prototyping;
+- no wheel, axle, hub, rocker-bogie assembly, complete chassis, or integrated rover is yet promoted by this contract as fabricated or tested.
+
+## 3. Canonical build law
+
+Cars4Mars now follows the existing KPGS vNext progressive-update chain:
+
+```text
+Adaptive Progressive Updates (APU)
+        ↓
+Progressive Update
+        ↓
+#NB
+        ↓
+bounded CRUD
+        ↓
+SWFUS
+```
+
+The canonical stage order remains:
+
+```text
+1. Telemetry
+2. Classification
+3. Routing
+4. Protocol Selection
+5. Invariant Audit
+6. POC / FOC Check
+7. State Update
+8. Distribution
+```
+
+For Cars4Mars:
+
+- **Telemetry** = timestamp, person/session, lab/tool, part ID, revision ID.
+- **Classification** = design-only / generated / simulated / software-tested / fabricated / physically-tested / validated.
+- **Routing** = mechanical / electrical / firmware / perception / payload / evidence lane.
+- **Protocol Selection** = the specific Cars4Mars P-step and acceptance contract.
+- **Invariant Audit** = DFR-01 constants and challenge limits cannot be silently widened.
+- **POC / FOC Check** = evidence must support the state being requested.
+- **State Update** = only the bounded part/revision projection changes.
+- **Distribution** = repo/site/team surfaces synchronize only after the admitted update.
+
+**SWFUS synchronizes a governed projection; it is never authority.**
+
+## 4. Black Mask / BlackMass application
+
+The repository's existing doctrine is preserved exactly:
+
+- **Black Mask v0.5** = pre-flight inspect and proof discipline;
+- **BlackMass v1.5/v2.0** = sandbox/external orchestration only after the inspect gate;
+- no fake ACK;
+- no production graduation claim without receipts;
+- proof before narrative;
+- realism before aesthetics.
+
+For physical design work, the BlackMass sandbox is the place to try dimensions, interfaces, inserts, materials, and geometry **without changing DFR-01 truth**.
+
+Promotion from sandbox requires a Black Mask review row and a dated artifact.
+
+## 5. PKA split — x may move, y stays fixed
+
+### y — constants / locked constraints
+
+- six-wheel architecture;
+- passive rocker-bogie mobility concept;
+- 250 mm wheel diameter baseline unless a governed DFR change is explicitly approved;
+- 40 kg challenge maximum starting mass;
+- DFR-01 control/safety authority;
+- challenge envelope limit;
+- evidence-state truth boundary.
+
+### x — changeable prototype parameters
+
+Until physically measured and promoted, the following remain changeable:
+
+- wheel width;
+- spoke count and spoke geometry;
+- hub bolt count / pitch-circle diameter;
+- axle-shaft diameter and exact hub fit;
+- bearing selection and housing geometry;
+- tread-pocket count, dimensions, retention geometry and insert material;
+- prototype filament/material;
+- tolerances and clearances;
+- rocker/bogie link thickness and fastener size.
+
+Generated visuals may suggest values for `x`; they may not silently convert them into `y`.
+
+## 6. P-step build sequence
+
+The current build starts small. Do not fabricate the whole rover from a generated board.
+
+```text
+P-001 wheel interface
+  -> P-002 hub
+  -> P-003 axle shaft
+  -> P-004 bearing housing
+  -> P-005 mounting bracket
+  -> P-006 bogie/rocker link
+  -> P-007 dry assembly
+  -> P-008 rolling/load prototype
+```
+
+Each P-step is independently reviewable, printable/fabricatable and falsifiable.
+
+## 7. P-001 — wheel is now the active part
+
+The first physical-design target is **one wheel**, not the six-wheel assembly.
+
+Canonical intent:
+
+- open-spoke wheel structure;
+- a deliberate central mounting face for a separate wheel hub;
+- central bore sized by the later hub/axle interface, not guessed from artwork;
+- removable screw/bolt interface between wheel and hub;
+- outer tread pockets capable of receiving replaceable traction inserts;
+- the axle shaft passes through/is retained by the hub interface; it does not rely on the bare wheel shell as its precision bearing surface.
+
+### Tread-pocket experiment
+
+The brown tread elements shown in the generated concept are treated as **replaceable traction inserts**, not a final material decision.
+
+Initial candidate set for small prototypes:
+
+- wheel-body fit prototype: PLA or PETG;
+- flexible traction insert: TPU or another rubber-like material;
+- stronger later body candidate: nylon or reinforced filament, subject to printer/material availability and test evidence.
+
+Purpose of the insert experiment:
+
+- increase contact compliance on stones/rough terrain;
+- reduce hard-plastic slip;
+- reduce the chance of the wheel wedging on small rocks by testing tread spacing and compliant contact;
+- allow insert geometry/material to change without reprinting the entire wheel.
+
+**None of these materials is promoted as final rover hardware by this document.**
+
+## 8. Minimum design-team packet before P-001 printing
+
+The design team should receive one bounded packet containing:
+
+1. one rough hand sketch;
+2. front view;
+3. side view;
+4. top or section view where needed;
+5. 250 mm locked outer-diameter reference;
+6. proposed wheel width;
+7. proposed center bore;
+8. proposed hub mounting face diameter;
+9. proposed bolt pattern;
+10. proposed tread-pocket dimensions;
+11. prototype material + printer/process;
+12. revision ID and timestamp.
+
+Unknown dimensions must be marked **TBD**, not inferred from a render.
+
+## 9. Evidence promotion ladder
+
+```text
+GENERATED
+  -> DIMENSIONED
+  -> CAD-RELEASED
+  -> SLICED / TOOLPATH-REVIEWED
+  -> FABRICATED
+  -> FIT-TESTED
+  -> ROLL-TESTED
+  -> LOAD-TESTED
+  -> ACCEPTED | REVISE
+```
+
+This ladder is part-specific and does not replace the system-level DFR ladder:
+
+`DESIGNED → FUNDED → ORDERED → RECEIVED → ASSEMBLED → TESTED → VALIDATED`.
+
+## 10. Current generated artifacts
+
+The 18 August concept images are admitted as **generated design references only**:
+
+- Cars4Mars Axle Module Concept Board;
+- Cars4Mars Axle Module Assembly Guide;
+- Cars4Mars Part 1 — Wheel Concept Poster.
+
+They are useful for communication and geometry discussion. They are not CAD, slicer output, LightBurn toolpaths, fabrication evidence, or measured hardware.
+
+## 11. Drift blockers
+
+Reject or hold any update that:
+
+- changes six wheels to four;
+- treats generated measurements as physical measurements;
+- marks the rover built because lab access exists;
+- treats LightBurn availability as proof that a part was cut;
+- treats software simulation as physical mobility evidence;
+- lets AI/cloud/perception widen motor authority;
+- changes a locked DFR-01 constant without an explicit governed design-change record;
+- synchronizes a state to public surfaces before the evidence receipt exists.
+
+## 12. Immediate next gate
+
+**P-001A — Dimension the wheel/hub interface before printing.**
+
+The next admitted update should contain the user's rough sketch plus the three key views and actual proposed dimensions. From that packet the design team can create a dimensioned CAD revision and a first small test coupon / hub-interface prototype before committing material to a full 250 mm wheel.

--- a/governance/kpgs-vnext/domain-contracts/cars4mars/build-state.json
+++ b/governance/kpgs-vnext/domain-contracts/cars4mars/build-state.json
@@ -1,0 +1,151 @@
+{
+  "schema": "kpgs.cars4mars.build-state.v1",
+  "timestamp": "2026-08-18T19:17:00+02:00",
+  "baseline": {
+    "id": "DFR-01",
+    "date": "2026-08-02",
+    "status": "locked_design_baseline",
+    "physical_validation_complete": false
+  },
+  "canonical_sources": [
+    "ARC 2026 Rulebook Rev 2.0",
+    "Cars4Mars DFR-01 Verified Final Design Report",
+    "RobynAwesome/cars4mars-project"
+  ],
+  "runtime_contract": {
+    "chain": ["APU", "Progressive Update", "#NB", "bounded CRUD", "SWFUS"],
+    "stage_order": [
+      "telemetry",
+      "classification",
+      "routing",
+      "protocol_selection",
+      "invariant_audit",
+      "poc_foc_check",
+      "state_update",
+      "distribution"
+    ],
+    "authority_effect": "none",
+    "swfus_is_authority": false
+  },
+  "black_mask": {
+    "preflight_version": "v0.5",
+    "sandbox_after_preflight": true,
+    "fake_ack_allowed": false,
+    "proof_before_narrative": true
+  },
+  "locked_y": {
+    "wheel_count": 6,
+    "wheel_diameter_mm": 250,
+    "mobility": "six-wheel skid-steer + passive rocker-bogie",
+    "target_envelope_mm": [700, 650, 500],
+    "bom_target_kg": 28,
+    "engineering_load_case_kg": 30,
+    "competition_max_mass_kg": 40,
+    "payload_tray_mm": [350, 300, 180],
+    "payload_object_max_kg": 1,
+    "control_authority": "Teensy 4.1",
+    "perception_compute": "Jetson Orin Nano Super"
+  },
+  "changeable_x": [
+    "wheel_width",
+    "spoke_count",
+    "spoke_geometry",
+    "hub_bolt_count",
+    "hub_pitch_circle_diameter",
+    "axle_shaft_diameter",
+    "bearing_selection",
+    "bearing_housing_geometry",
+    "tread_pocket_count",
+    "tread_pocket_dimensions",
+    "tread_insert_material",
+    "prototype_body_material",
+    "tolerances",
+    "clearances",
+    "rocker_bogie_link_thickness",
+    "fastener_size"
+  ],
+  "facility_context": {
+    "location": "HPI d-school fabrication / 3D lab",
+    "source_state": "user_reported_and_visually_shown_in_session",
+    "lightburn_2_available": true,
+    "fabricated_part_claim": false
+  },
+  "active_p_step": {
+    "id": "P-001",
+    "name": "wheel_interface",
+    "status": "generated_concept_requires_dimensioning",
+    "next_gate": "P-001A_dimension_wheel_hub_interface",
+    "required_inputs": [
+      "rough_hand_sketch",
+      "front_view",
+      "side_view",
+      "top_or_section_view",
+      "proposed_wheel_width_mm",
+      "proposed_center_bore_mm",
+      "proposed_hub_mounting_face_mm",
+      "proposed_bolt_pattern",
+      "proposed_tread_pocket_dimensions_mm",
+      "prototype_material",
+      "printer_or_process"
+    ]
+  },
+  "wheel_concept": {
+    "outer_diameter_mm": 250,
+    "open_spoke_structure": "concept_admitted",
+    "separate_hub_mounting_face": "concept_admitted",
+    "removable_fastener_interface": "concept_admitted",
+    "replaceable_tread_insert_pockets": "concept_admitted",
+    "axle_directly_bears_in_bare_wheel_shell": false,
+    "prototype_material_candidates": {
+      "wheel_body": ["PLA", "PETG"],
+      "traction_insert": ["TPU", "rubber-like material"],
+      "later_strength_candidate": ["nylon", "reinforced filament"]
+    },
+    "final_material_locked": false
+  },
+  "part_sequence": [
+    "P-001 wheel interface",
+    "P-002 hub",
+    "P-003 axle shaft",
+    "P-004 bearing housing",
+    "P-005 mounting bracket",
+    "P-006 bogie/rocker link",
+    "P-007 dry assembly",
+    "P-008 rolling/load prototype"
+  ],
+  "part_evidence_ladder": [
+    "GENERATED",
+    "DIMENSIONED",
+    "CAD_RELEASED",
+    "SLICED_OR_TOOLPATH_REVIEWED",
+    "FABRICATED",
+    "FIT_TESTED",
+    "ROLL_TESTED",
+    "LOAD_TESTED",
+    "ACCEPTED_OR_REVISE"
+  ],
+  "generated_artifacts": [
+    {
+      "name": "Cars4Mars Axle Module Concept Board",
+      "state": "generated_design_reference"
+    },
+    {
+      "name": "Cars4Mars Axle Module Assembly Guide",
+      "state": "generated_design_reference"
+    },
+    {
+      "name": "Cars4Mars Part 1 - Wheel Concept Poster",
+      "state": "generated_design_reference"
+    }
+  ],
+  "drift_blockers": [
+    "wheel_count_change_without_governed_baseline_change",
+    "generated_measurement_presented_as_physical_measurement",
+    "lab_access_presented_as_fabrication",
+    "LightBurn_availability_presented_as_cut_part_evidence",
+    "software_simulation_presented_as_physical_mobility_evidence",
+    "AI_or_cloud_motor_authority",
+    "DFR_locked_constant_changed_without_design_change_record",
+    "public_distribution_before_evidence_receipt"
+  ]
+}

--- a/governance/kpgs-vnext/domain-contracts/cars4mars/sandbox/P-001-wheel-progressive-update.json
+++ b/governance/kpgs-vnext/domain-contracts/cars4mars/sandbox/P-001-wheel-progressive-update.json
@@ -1,0 +1,100 @@
+{
+  "schema": "kpgs.cars4mars.progressive-update.receipt.v1",
+  "update_id": "C4M-P001-20260818-1917-SAST",
+  "timestamp": "2026-08-18T19:17:00+02:00",
+  "part_id": "P-001",
+  "revision": "concept-r0",
+  "lane": "mechanical/wheel",
+  "black_mask_preflight": {
+    "version": "v0.5",
+    "status": "PASS_FOR_SANDBOX_ONLY",
+    "production_graduation": false,
+    "fake_ack": false
+  },
+  "apu": {
+    "state": "YELLOW",
+    "reason": "concept is coherent but critical interface dimensions are still TBD"
+  },
+  "nb_boundary_present": true,
+  "crud": {
+    "operation": "CREATE",
+    "target": "non_authoritative/prototypes/P-001/concept-r0",
+    "authority_effect": "none",
+    "poc_validated": false,
+    "mutation_decision": "HOLD"
+  },
+  "stages": [
+    {
+      "stage": 1,
+      "name": "telemetry",
+      "status": "PASS",
+      "evidence": ["timestamp", "part_id", "revision", "session-generated concept artifacts"]
+    },
+    {
+      "stage": 2,
+      "name": "classification",
+      "status": "PASS",
+      "classification": "generated_design_reference"
+    },
+    {
+      "stage": 3,
+      "name": "routing",
+      "status": "PASS",
+      "route": "Cars4Mars/mechanical/wheel/P-001"
+    },
+    {
+      "stage": 4,
+      "name": "protocol_selection",
+      "status": "PASS",
+      "protocol": "Cars4Mars P-step / P-001 wheel interface"
+    },
+    {
+      "stage": 5,
+      "name": "invariant_audit",
+      "status": "PASS_WITH_TBD",
+      "preserved": [
+        "six-wheel DFR-01 architecture",
+        "250 mm wheel diameter baseline",
+        "separate deterministic safety authority",
+        "generated imagery is not physical evidence"
+      ]
+    },
+    {
+      "stage": 6,
+      "name": "poc_foc_check",
+      "status": "HOLD",
+      "reason": "no dimensioned CAD, slicer/toolpath receipt, fabricated part or fit test exists"
+    },
+    {
+      "stage": 7,
+      "name": "state_update",
+      "status": "NOT_REACHED"
+    },
+    {
+      "stage": 8,
+      "name": "distribution",
+      "status": "NOT_REACHED",
+      "swfus_event_emitted": false
+    }
+  ],
+  "hypothesis": "A 250 mm open-spoke wheel with a separate removable hub interface and replaceable compliant tread inserts can reduce prototype mass and allow traction geometry/material experiments without reprinting the whole wheel.",
+  "falsification_questions": [
+    "Does the hub interface deform or loosen under representative radial and drive loads?",
+    "Do the tread insert pockets trap stones instead of shedding them?",
+    "Does the flexible insert improve traction relative to the rigid body on representative rough terrain?",
+    "Can a damaged insert be replaced without damaging the wheel shell?",
+    "Is the wheel printable/fabricatable with the actual lab process and tolerances?"
+  ],
+  "required_to_turn_green": [
+    "rough sketch captured",
+    "front/side/top-or-section views captured",
+    "wheel width proposed",
+    "center bore proposed from hub/shaft interface",
+    "bolt pattern proposed",
+    "tread pocket dimensions proposed",
+    "prototype material and printer/process named",
+    "dimensioned CAD revision released",
+    "small interface coupon or first wheel revision fabricated and measured"
+  ],
+  "next_gate": "P-001A_dimension_wheel_hub_interface"
+}


### PR DESCRIPTION
## Purpose
Lock the beginning of the Cars4Mars physical-build transition into the existing KPGS vNext governance so virtual/generated/software-tested evidence cannot drift into unsupported physical claims.

## Canonical sources
- ARC 2026 Rulebook Rev 2.0
- DFR-01 locked baseline (02 Aug 2026)
- existing `cars4mars-project` evidence ledger and CI receipts
- 18 Aug 2026 HPI d-school lab session context

## Adds
- `domain-contracts/cars4mars/README.md`
- machine-readable `build-state.json`
- Black Mask / BlackMass sandbox receipt for `P-001` wheel

## Key laws preserved
- APU → Progressive Update → #NB → bounded CRUD → SWFUS
- telemetry → classification → routing → protocol selection → invariant audit → POC/FOC → state update → distribution
- SWFUS is synchronization, not authority
- Black Mask v0.5 before BlackMass sandbox promotion
- no fake ACK
- generated visuals and simulations are not physical test evidence

## P-step
Current active gate is `P-001A`: dimension the wheel/hub interface before printing. The 250 mm wheel diameter remains locked; width, bolt pattern, bore, hub fit, tread-pocket geometry and prototype materials remain bounded experimental variables until measured and promoted.

No production or physical-validation claim is made by this PR.