### PR TITLE
feat(skills): complete canonical lease-bound skill package runtime

### DIFF
--- a/.github/workflows/kpgs-vnext-phase0-gate.yml
+++ b/.github/workflows/kpgs-vnext-phase0-gate.yml
@@ -6,10 +6,15 @@ on:
       - "governance/kpgs-vnext/**"
       - "kopano-core/kopano/swfus_engine.py"
       - "kopano-core/kopano/kessa_mmao_api.py"
+      - "kopano-core/kopano/skill_runtime.py"
+      - "scripts/ci/validate_skill_registry.py"
+      - "scripts/ci/manage_skill_package.py"
       - "tests/test_swfus_progressive_updates.py"
       - "tests/test_capability_lease_runtime.py"
       - "tests/test_sovereign_estate_registry.py"
       - "tests/test_evidence_bundles.py"
+      - "tests/test_canonical_skill_runtime.py"
+      - "tests/test_skill_package_workflow.py"
       - "CONTRIBUTING.md"
       - "THIRD_PARTY_NOTICES.md"
       - "LICENSE"
@@ -19,10 +24,15 @@ on:
       - "governance/kpgs-vnext/**"
       - "kopano-core/kopano/swfus_engine.py"
       - "kopano-core/kopano/kessa_mmao_api.py"
+      - "kopano-core/kopano/skill_runtime.py"
+      - "scripts/ci/validate_skill_registry.py"
+      - "scripts/ci/manage_skill_package.py"
       - "tests/test_swfus_progressive_updates.py"
       - "tests/test_capability_lease_runtime.py"
       - "tests/test_sovereign_estate_registry.py"
       - "tests/test_evidence_bundles.py"
+      - "tests/test_canonical_skill_runtime.py"
+      - "tests/test_skill_package_workflow.py"
       - "CONTRIBUTING.md"
       - "THIRD_PARTY_NOTICES.md"
       - "LICENSE"
@@ -40,7 +50,7 @@ jobs:
   truth-contracts:
     name: Validate KPGS truth and governance contracts
     runs-on: ubuntu-latest
-    timeout-minutes: 7
+    timeout-minutes: 8
 
     steps:
       - name: Checkout
@@ -84,6 +94,15 @@ jobs:
       - name: Prove evidence bundle runtime conformance
         run: python -m unittest discover -s tests -p 'test_evidence_bundles.py' -v
 
+      - name: Validate canonical skill registry
+        run: python scripts/ci/validate_skill_registry.py
+
+      - name: Prove canonical skill execution membrane
+        run: python -m unittest discover -s tests -p 'test_canonical_skill_runtime.py' -v
+
+      - name: Prove canonical skill package developer workflow
+        run: python -m unittest discover -s tests -p 'test_skill_package_workflow.py' -v
+
       - name: Compile validators and governed runtimes
         run: >-
           python -m py_compile
@@ -99,3 +118,6 @@ jobs:
           governance/kpgs-vnext/evidence/evidence.py
           kopano-core/kopano/swfus_engine.py
           kopano-core/kopano/kessa_mmao_api.py
+          kopano-core/kopano/skill_runtime.py
+          scripts/ci/validate_skill_registry.py
+          scripts/ci/manage_skill_package.py

--- a/governance/kpgs-vnext/skills/SKILL_PACKAGE.md
+++ b/governance/kpgs-vnext/skills/SKILL_PACKAGE.md
@@ -17,7 +17,7 @@ skills/<category>/<skill-name>/
   REFERENCES.md            # optional links and provenance notes
   ARTICLE.md               # optional long explanation
   scripts/                 # optional helpers
-  assets/                  # optional reusable assets
+  assets/                   # optional reusable assets
   examples/                # optional fixtures
   tests/                   # optional conformance/eval fixtures
 ```
@@ -46,9 +46,14 @@ python scripts/ci/validate_skill_registry.py --discover governance
 python scripts/ci/validate_skill_registry.py --discover "" --platform stateless-renter
 ```
 
-The validator rejects duplicate identities, missing package files, manifest/registry identity drift, missing provenance/license state, missing capability declarations and missing validation contracts. CI runs the same conformance logic through `tests/test_skill_registry.py`.
+The validator rejects duplicate identities, repository-path escapes, missing package files, manifest/registry identity drift, invalid manifest state/provenance/license/source relationships, missing local schema references, missing capability declarations and invalid validation contracts. CI runs the same conformance logic through `tests/test_skill_registry.py`.
 
-A registered package is production-selectable only when its manifest state is `validated` or `approved`. The caller must still separately obtain a capability lease equal to or narrower than the package requirements. `draft`, `blocked` and `deprecated` packages remain non-production-loadable even when discoverable.
+A registered package is production-selectable only when **both** conditions are true:
+
+1. its manifest state is `validated` or `approved`; and
+2. its provenance `license_status` is `verified-compatible`.
+
+The caller must still separately obtain a capability lease equal to or narrower than the package requirements. `draft`, `blocked` and `deprecated` packages remain non-production-loadable even when discoverable. A `validated` or `approved` package with `pending`, `unknown` or `incompatible` licensing also remains non-production-loadable.
 
 Publication adapters may be indexed so external package surfaces can be found and validated, but their `authority_class` must remain `publication-adapter`; registry presence must never be interpreted as a second canonical runtime.
 
@@ -68,7 +73,7 @@ python scripts/ci/manage_skill_package.py create \
   --tag governance
 ```
 
-The command deliberately leaves the package in `draft`. **Scaffolded + registered + conformance-valid is not approved for production execution.** Promotion to `validated`/`approved` remains a separate evidence/governance decision.
+The command deliberately leaves the package in `draft` with unresolved licensing. **Scaffolded + registered + conformance-valid is not approved for production execution.** Promotion to `validated`/`approved` and promotion of licensing to `verified-compatible` remain separate evidence/governance decisions.
 
 Re-run canonical package validation independently with:
 
@@ -110,7 +115,7 @@ The schema is `skill-manifest.schema.json`.
 ```text
 discover
   -> resolve policy
-  -> verify package/provenance
+  -> verify package/provenance/license
   -> lease capabilities
   -> load bounded handler
   -> execute
@@ -124,19 +129,21 @@ The reference execution membrane is `kopano-core/kopano/skill_runtime.py`.
 It enforces the following order:
 
 1. Resolve an exact registered `name@version`.
-2. Refuse production execution unless the package state is `validated` or `approved`.
-3. Verify the selected runtime platform and package/provenance boundary.
+2. Refuse production execution unless the package state is `validated` or `approved` **and** its license status is `verified-compatible`.
+3. Verify registry selection policy, selected runtime platform, package path containment and provenance sources.
 4. Resolve every non-optional declared capability through the injected Sovereign Hub capability authorizer.
 5. Refuse to call the handler when any required capability/resource scope is denied.
 6. Execute only a handler explicitly registered for the exact skill identity.
 7. Run the deterministic output validator when one is registered.
-8. Emit `kpgs.skill-execution-receipt.v1` containing skill version, manifest digest, input/output digests, lease IDs, capability decisions, validation result and correlation ID.
+8. Emit `kpgs.skill-execution-receipt.v1` containing skill version, manifest digest, license status, input/output digests, lease IDs, capability decisions, validation result, correlation ID and execution-context release state.
 
 The runtime does not issue its own lease and does not make registry discovery an authorization mechanism. The injected authorizer is the membrane to the canonical capability-lease authority defined under `governance/kpgs-vnext/security/`.
 
+`execution_context.released=true` means only that the skill runtime has released its execution-local context after the bounded call. It does **not** claim that the upstream capability lease was revoked; upstream lease lifetime and revocation remain owned by the capability-lease authority.
+
 ### Execution receipt boundary
 
-A successful execution receipt proves the bounded handler ran under the recorded lease decisions and validation path. It does **not** make the skill a new authority source and does not promote its package state.
+A successful execution receipt proves the bounded handler ran under the recorded lease decisions and validation path. It does **not** make the skill a new authority source and does not promote its package state or license state.
 
 ```text
 SKILL DISCOVERY != AUTHORITY
@@ -151,7 +158,7 @@ EXECUTION RECEIPT != CANONICAL BUSINESS TRUTH
 2. The active capability lease MUST be equal to or narrower than the skill's declared capability requirements.
 3. A renter MUST reject a skill whose runtime/protocol compatibility is not satisfied.
 4. Imported or fork-derived skill material MUST carry provenance and license metadata.
-5. `pending`, `unknown` or incompatible license status blocks canonical vendoring/import.
+5. `pending`, `unknown` or `incompatible` license status blocks production loading and canonical vendoring/import.
 6. Skills MUST NOT contain raw secrets, private client data or machine-specific absolute paths as required runtime assumptions.
 7. Skill promotion requires declared validation evidence.
 8. Breaking behavior changes require a major-version compatibility decision or migration note.
@@ -164,14 +171,14 @@ EXECUTION RECEIPT != CANONICAL BUSINESS TRUTH
 - `deprecated`
 - `blocked`
 
-Only `validated` or `approved` skills may be selected for governed production execution, subject to domain policy.
+Only `validated` or `approved` skills with `verified-compatible` licensing may be selected for governed production execution, subject to domain policy and a valid capability lease.
 
 ## Validation dimensions
 
 A skill MAY use several verification methods, but each package MUST declare at least one:
 
 - schema/contract validation
-- deterministic test fixture
+- deterministic unit test fixture
 - integration test
 - end-to-end workflow test
 - security review

--- a/governance/kpgs-vnext/skills/SKILL_PACKAGE.md
+++ b/governance/kpgs-vnext/skills/SKILL_PACKAGE.md
@@ -52,6 +52,32 @@ A registered package is production-selectable only when its manifest state is `v
 
 Publication adapters may be indexed so external package surfaces can be found and validated, but their `authority_class` must remain `publication-adapter`; registry presence must never be interpreted as a second canonical runtime.
 
+## One-command package workflow
+
+Create a versioned draft package, register it in canonical discovery and run the registry/package conformance gate in one workflow:
+
+```bash
+python scripts/ci/manage_skill_package.py create \
+  --name example-governed-skill \
+  --version 0.1.0 \
+  --category governance \
+  --summary "Explain and execute one bounded governed example." \
+  --capability example.execute \
+  --resource-scope active-task \
+  --tag example \
+  --tag governance
+```
+
+The command deliberately leaves the package in `draft`. **Scaffolded + registered + conformance-valid is not approved for production execution.** Promotion to `validated`/`approved` remains a separate evidence/governance decision.
+
+Re-run canonical package validation independently with:
+
+```bash
+python scripts/ci/manage_skill_package.py validate
+```
+
+If registration/conformance fails during `create`, the new registry entry is removed so a partial workflow cannot poison canonical discovery. The generated package remains on disk for inspection and repair.
+
 ## Required `SKILL.md` frontmatter
 
 ```yaml
@@ -86,11 +112,37 @@ discover
   -> resolve policy
   -> verify package/provenance
   -> lease capabilities
-  -> load
+  -> load bounded handler
   -> execute
   -> validate output
   -> emit evidence
-  -> release capabilities
+  -> release execution context
+```
+
+The reference execution membrane is `kopano-core/kopano/skill_runtime.py`.
+
+It enforces the following order:
+
+1. Resolve an exact registered `name@version`.
+2. Refuse production execution unless the package state is `validated` or `approved`.
+3. Verify the selected runtime platform and package/provenance boundary.
+4. Resolve every non-optional declared capability through the injected Sovereign Hub capability authorizer.
+5. Refuse to call the handler when any required capability/resource scope is denied.
+6. Execute only a handler explicitly registered for the exact skill identity.
+7. Run the deterministic output validator when one is registered.
+8. Emit `kpgs.skill-execution-receipt.v1` containing skill version, manifest digest, input/output digests, lease IDs, capability decisions, validation result and correlation ID.
+
+The runtime does not issue its own lease and does not make registry discovery an authorization mechanism. The injected authorizer is the membrane to the canonical capability-lease authority defined under `governance/kpgs-vnext/security/`.
+
+### Execution receipt boundary
+
+A successful execution receipt proves the bounded handler ran under the recorded lease decisions and validation path. It does **not** make the skill a new authority source and does not promote its package state.
+
+```text
+SKILL DISCOVERY != AUTHORITY
+REGISTERED != PRODUCTION-LOADABLE
+LEASED CAPABILITY != AMBIENT POWER
+EXECUTION RECEIPT != CANONICAL BUSINESS TRUTH
 ```
 
 ## Governance rules

--- a/governance/kpgs-vnext/skills/skill-execution-receipt.schema.json
+++ b/governance/kpgs-vnext/skills/skill-execution-receipt.schema.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kpgs.local/schemas/skill-execution-receipt.schema.json",
+  "title": "KPGS Skill Execution Receipt",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "execution_id",
+    "skill",
+    "correlation_id",
+    "input_digest",
+    "output_digest",
+    "capability_lease_ids",
+    "capability_decisions",
+    "validation",
+    "outcome",
+    "failure",
+    "authority_effect",
+    "created_at"
+  ],
+  "properties": {
+    "schema": { "const": "kpgs.skill-execution-receipt.v1" },
+    "execution_id": { "type": "string", "minLength": 8 },
+    "skill": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "version", "package_path", "authority_class", "manifest_digest"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "version": { "type": "string", "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$" },
+        "package_path": { "type": "string", "minLength": 1 },
+        "authority_class": { "enum": ["canonical-core", "publication-adapter"] },
+        "manifest_digest": { "type": "string", "pattern": "^[a-f0-9]{64}$" }
+      }
+    },
+    "correlation_id": { "type": "string", "minLength": 1 },
+    "input_digest": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+    "output_digest": {
+      "oneOf": [
+        { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+        { "type": "null" }
+      ]
+    },
+    "capability_lease_ids": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "capability_decisions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["capability", "resource_scope"],
+        "properties": {
+          "lease_id": { "type": "string" },
+          "capability": { "type": "string", "minLength": 1 },
+          "resource_scope": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "validation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["passed", "reason", "kind"],
+      "properties": {
+        "passed": { "type": "boolean" },
+        "reason": { "type": "string", "minLength": 1 },
+        "kind": { "enum": ["deterministic", "execution"] }
+      }
+    },
+    "outcome": { "enum": ["completed", "rejected", "failed"] },
+    "failure": { "type": ["string", "null"] },
+    "authority_effect": { "const": "none" },
+    "created_at": { "type": "string", "format": "date-time" }
+  }
+}

--- a/kopano-core/kopano/skill_runtime.py
+++ b/kopano-core/kopano/skill_runtime.py
@@ -17,6 +17,7 @@ import secrets
 from typing import Any, Callable, Mapping, Protocol
 
 PRODUCTION_STATES = {"validated", "approved"}
+PRODUCTION_LICENSE_STATUS = "verified-compatible"
 
 
 class SkillRuntimeError(Exception):
@@ -75,7 +76,13 @@ class SkillExecutionResult:
 
 
 def _canonical_json(value: Any) -> str:
-    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False, default=str)
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        default=str,
+    )
 
 
 def _digest(value: Any) -> str:
@@ -83,7 +90,12 @@ def _digest(value: Any) -> str:
 
 
 def _iso_now() -> str:
-    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    return (
+        datetime.now(timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
 
 
 def _decision_dict(decision: Any) -> dict[str, Any]:
@@ -113,8 +125,9 @@ class CanonicalSkillRuntime:
     """Discover, authorize, execute, validate and receipt one registered skill.
 
     The runtime never interprets registry presence as permission. A package must
-    already be in a production-loadable state and every non-optional capability
-    must be authorized by the injected lease authority before the handler runs.
+    already be in a production-loadable state with verified-compatible licensing,
+    and every non-optional capability must be authorized by the injected lease
+    authority before the handler runs.
     """
 
     def __init__(
@@ -171,6 +184,18 @@ class CanonicalSkillRuntime:
 
     def select(self, name: str, version: str, *, platform: str) -> SkillSelection:
         registry = self._read_json(self.registry_path)
+        policy = registry.get("selection_policy")
+        if not isinstance(policy, dict):
+            raise SkillNotLoadable("registry selection_policy is missing")
+        if set(policy.get("production_states", [])) != PRODUCTION_STATES:
+            raise SkillNotLoadable("registry production-state policy drift detected")
+        if policy.get("require_capability_lease") is not True:
+            raise SkillNotLoadable("registry no longer requires capability leases")
+        if policy.get("require_provenance") is not True:
+            raise SkillNotLoadable("registry no longer requires provenance")
+        if policy.get("require_license_status") is not True:
+            raise SkillNotLoadable("registry no longer requires license status")
+
         entries = [
             entry
             for entry in registry.get("skills", [])
@@ -186,7 +211,7 @@ class CanonicalSkillRuntime:
         if not isinstance(package_path, str) or not package_path:
             raise SkillNotLoadable("registry package_path is invalid")
         package_dir = (self.repo_root / package_path).resolve()
-        if self.repo_root not in package_dir.parents:
+        if package_dir != self.repo_root and self.repo_root not in package_dir.parents:
             raise SkillNotLoadable("package path escapes repository root")
 
         manifest = self._read_json(package_dir / "skill.json")
@@ -199,9 +224,18 @@ class CanonicalSkillRuntime:
         platforms = manifest.get("runtime", {}).get("platforms", [])
         if platform not in platforms:
             raise SkillNotLoadable(f"runtime platform is not declared: {platform}")
-        provenance = manifest.get("provenance", {})
-        if not provenance.get("origin") or not provenance.get("license_status"):
-            raise SkillNotLoadable("provenance/license status is incomplete")
+
+        provenance = manifest.get("provenance")
+        if not isinstance(provenance, dict) or not provenance.get("origin"):
+            raise SkillNotLoadable("provenance is incomplete")
+        license_status = provenance.get("license_status")
+        if license_status != PRODUCTION_LICENSE_STATUS:
+            raise SkillNotLoadable(
+                f"{name}@{version} license status is not production-compatible: {license_status}"
+            )
+        sources = provenance.get("sources")
+        if not isinstance(sources, list) or not sources:
+            raise SkillNotLoadable("provenance sources are incomplete")
         if not (package_dir / "SKILL.md").is_file():
             raise SkillNotLoadable("SKILL.md is missing")
 
@@ -260,7 +294,7 @@ class CanonicalSkillRuntime:
                 )
             except Exception as exc:
                 raise SkillAuthorizationDenied(
-                    f"capability denied before execution: {capability}@{resource_scope}: {exc}"
+                    f"capability denied before execution: {capability}@{resource_scope}: {type(exc).__name__}"
                 ) from exc
             capability_decisions.append(_decision_dict(decision))
 
@@ -275,16 +309,23 @@ class CanonicalSkillRuntime:
                 input_digest=input_digest,
                 output_digest=None,
                 capability_decisions=capability_decisions,
-                validation={"passed": False, "reason": "handler raised", "kind": "execution"},
+                validation={
+                    "passed": False,
+                    "reason": "bounded handler raised",
+                    "kind": "execution",
+                },
                 outcome="failed",
-                failure=str(exc),
+                failure=f"HANDLER_FAILED:{type(exc).__name__}",
             )
             self._emit(receipt)
             raise
 
         validator = self._validators.get(identity)
         if validator is None:
-            passed, reason = True, "handler completed; no additional runtime output validator registered"
+            passed, reason = (
+                True,
+                "handler completed; no additional runtime output validator registered",
+            )
         else:
             passed, reason = validator(output)
         if not passed:
@@ -295,7 +336,11 @@ class CanonicalSkillRuntime:
                 input_digest=input_digest,
                 output_digest=_digest(output),
                 capability_decisions=capability_decisions,
-                validation={"passed": False, "reason": reason, "kind": "deterministic"},
+                validation={
+                    "passed": False,
+                    "reason": reason,
+                    "kind": "deterministic",
+                },
                 outcome="rejected",
                 failure="output validation failed",
             )
@@ -346,6 +391,7 @@ class CanonicalSkillRuntime:
                 "package_path": selection.package_path,
                 "authority_class": selection.authority_class,
                 "manifest_digest": _digest(manifest),
+                "license_status": manifest.get("provenance", {}).get("license_status"),
             },
             "correlation_id": correlation_id,
             "input_digest": input_digest,
@@ -356,6 +402,10 @@ class CanonicalSkillRuntime:
             "outcome": outcome,
             "failure": failure,
             "authority_effect": "none",
+            "execution_context": {
+                "released": True,
+                "upstream_lease_revoked": False,
+            },
             "created_at": _iso_now(),
         }
 

--- a/kopano-core/kopano/skill_runtime.py
+++ b/kopano-core/kopano/skill_runtime.py
@@ -1,0 +1,376 @@
+"""Canonical KPGS skill-package execution membrane.
+
+Skills describe bounded procedures; they never grant themselves authority. This
+runtime deliberately depends on an injected capability authorizer so the
+Sovereign Hub remains the landlord of leases while Stateless Renters stay
+replaceable execution tenants.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, is_dataclass
+from datetime import datetime, timezone
+import hashlib
+import json
+from pathlib import Path
+import secrets
+from typing import Any, Callable, Mapping, Protocol
+
+PRODUCTION_STATES = {"validated", "approved"}
+
+
+class SkillRuntimeError(Exception):
+    """Base class for fail-closed skill runtime errors."""
+
+
+class SkillNotFound(SkillRuntimeError):
+    pass
+
+
+class SkillNotLoadable(SkillRuntimeError):
+    pass
+
+
+class SkillAuthorizationDenied(SkillRuntimeError):
+    pass
+
+
+class SkillValidationFailed(SkillRuntimeError):
+    pass
+
+
+class CapabilityAuthorizer(Protocol):
+    def __call__(
+        self,
+        token: str,
+        *,
+        tenant_id: str,
+        domain_id: str,
+        task_id: str,
+        capability: str,
+        resource_scope: str,
+        operation_nonce: str,
+        correlation_id: str,
+    ) -> Any: ...
+
+
+SkillHandler = Callable[[Any], Any]
+OutputValidator = Callable[[Any], tuple[bool, str]]
+EvidenceSink = Callable[[Mapping[str, Any]], None]
+
+
+@dataclass(frozen=True)
+class SkillSelection:
+    name: str
+    version: str
+    package_path: str
+    authority_class: str
+    manifest: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class SkillExecutionResult:
+    output: Any
+    receipt: Mapping[str, Any]
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False, default=str)
+
+
+def _digest(value: Any) -> str:
+    return hashlib.sha256(_canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _decision_dict(decision: Any) -> dict[str, Any]:
+    if is_dataclass(decision):
+        return asdict(decision)
+    if isinstance(decision, Mapping):
+        return dict(decision)
+    return {
+        key: getattr(decision, key)
+        for key in (
+            "lease_id",
+            "subject_id",
+            "subject_kind",
+            "tenant_id",
+            "domain_id",
+            "task_id",
+            "capability",
+            "resource_scope",
+            "correlation_id",
+            "key_id",
+        )
+        if hasattr(decision, key)
+    }
+
+
+class CanonicalSkillRuntime:
+    """Discover, authorize, execute, validate and receipt one registered skill.
+
+    The runtime never interprets registry presence as permission. A package must
+    already be in a production-loadable state and every non-optional capability
+    must be authorized by the injected lease authority before the handler runs.
+    """
+
+    def __init__(
+        self,
+        *,
+        repo_root: Path,
+        capability_authorizer: CapabilityAuthorizer,
+        registry_path: Path | None = None,
+        evidence_sink: EvidenceSink | None = None,
+    ) -> None:
+        self.repo_root = Path(repo_root).resolve()
+        self.registry_path = (
+            Path(registry_path).resolve()
+            if registry_path
+            else self.repo_root / "governance/kpgs-vnext/skills/registry.json"
+        )
+        self.capability_authorizer = capability_authorizer
+        self.evidence_sink = evidence_sink
+        self._handlers: dict[tuple[str, str], SkillHandler] = {}
+        self._validators: dict[tuple[str, str], OutputValidator] = {}
+
+    def register_handler(
+        self,
+        name: str,
+        version: str,
+        handler: SkillHandler,
+        *,
+        output_validator: OutputValidator | None = None,
+    ) -> None:
+        identity = (name, version)
+        self._handlers[identity] = handler
+        if output_validator is not None:
+            self._validators[identity] = output_validator
+
+    def discover(self, query: str = "") -> list[dict[str, Any]]:
+        registry = self._read_json(self.registry_path)
+        needle = query.casefold().strip()
+        found: list[dict[str, Any]] = []
+        for entry in registry.get("skills", []):
+            if not isinstance(entry, dict):
+                continue
+            discovery = entry.get("discovery", {})
+            haystack = " ".join(
+                [
+                    str(entry.get("name", "")),
+                    str(entry.get("category", "")),
+                    str(discovery.get("summary", "")),
+                    *[str(tag) for tag in discovery.get("tags", [])],
+                ]
+            ).casefold()
+            if not needle or needle in haystack:
+                found.append(dict(entry))
+        return found
+
+    def select(self, name: str, version: str, *, platform: str) -> SkillSelection:
+        registry = self._read_json(self.registry_path)
+        entries = [
+            entry
+            for entry in registry.get("skills", [])
+            if isinstance(entry, dict)
+            and entry.get("name") == name
+            and entry.get("version") == version
+        ]
+        if len(entries) != 1:
+            raise SkillNotFound(f"registered skill not found: {name}@{version}")
+
+        entry = entries[0]
+        package_path = entry.get("package_path")
+        if not isinstance(package_path, str) or not package_path:
+            raise SkillNotLoadable("registry package_path is invalid")
+        package_dir = (self.repo_root / package_path).resolve()
+        if self.repo_root not in package_dir.parents:
+            raise SkillNotLoadable("package path escapes repository root")
+
+        manifest = self._read_json(package_dir / "skill.json")
+        if manifest.get("name") != name or manifest.get("version") != version:
+            raise SkillNotLoadable("registry/manifest identity mismatch")
+        if manifest.get("state") not in PRODUCTION_STATES:
+            raise SkillNotLoadable(
+                f"{name}@{version} is not production-loadable: {manifest.get('state')}"
+            )
+        platforms = manifest.get("runtime", {}).get("platforms", [])
+        if platform not in platforms:
+            raise SkillNotLoadable(f"runtime platform is not declared: {platform}")
+        provenance = manifest.get("provenance", {})
+        if not provenance.get("origin") or not provenance.get("license_status"):
+            raise SkillNotLoadable("provenance/license status is incomplete")
+        if not (package_dir / "SKILL.md").is_file():
+            raise SkillNotLoadable("SKILL.md is missing")
+
+        return SkillSelection(
+            name=name,
+            version=version,
+            package_path=package_path,
+            authority_class=str(entry.get("authority_class", "")),
+            manifest=manifest,
+        )
+
+    def execute(
+        self,
+        *,
+        name: str,
+        version: str,
+        platform: str,
+        lease_token: str,
+        tenant_id: str,
+        domain_id: str,
+        task_id: str,
+        correlation_id: str,
+        input_value: Any,
+    ) -> SkillExecutionResult:
+        selection = self.select(name, version, platform=platform)
+        identity = (name, version)
+        handler = self._handlers.get(identity)
+        if handler is None:
+            raise SkillNotLoadable(f"no bounded handler registered for {name}@{version}")
+
+        execution_id = "skill_exec_" + secrets.token_urlsafe(12)
+        capability_decisions: list[dict[str, Any]] = []
+        requirements = selection.manifest.get("required_capabilities", [])
+        if not isinstance(requirements, list) or not requirements:
+            raise SkillAuthorizationDenied("skill declares no capability requirements")
+
+        for index, requirement in enumerate(requirements):
+            if not isinstance(requirement, dict):
+                raise SkillAuthorizationDenied("invalid capability requirement")
+            if requirement.get("optional") is True:
+                continue
+            capability = requirement.get("name")
+            resource_scope = requirement.get("resource_scope")
+            if not isinstance(capability, str) or not isinstance(resource_scope, str):
+                raise SkillAuthorizationDenied("invalid required capability contract")
+            try:
+                decision = self.capability_authorizer(
+                    lease_token,
+                    tenant_id=tenant_id,
+                    domain_id=domain_id,
+                    task_id=task_id,
+                    capability=capability,
+                    resource_scope=resource_scope,
+                    operation_nonce=f"{execution_id}:{index}",
+                    correlation_id=correlation_id,
+                )
+            except Exception as exc:
+                raise SkillAuthorizationDenied(
+                    f"capability denied before execution: {capability}@{resource_scope}: {exc}"
+                ) from exc
+            capability_decisions.append(_decision_dict(decision))
+
+        input_digest = _digest(input_value)
+        try:
+            output = handler(input_value)
+        except Exception as exc:
+            receipt = self._receipt(
+                selection=selection,
+                execution_id=execution_id,
+                correlation_id=correlation_id,
+                input_digest=input_digest,
+                output_digest=None,
+                capability_decisions=capability_decisions,
+                validation={"passed": False, "reason": "handler raised", "kind": "execution"},
+                outcome="failed",
+                failure=str(exc),
+            )
+            self._emit(receipt)
+            raise
+
+        validator = self._validators.get(identity)
+        if validator is None:
+            passed, reason = True, "handler completed; no additional runtime output validator registered"
+        else:
+            passed, reason = validator(output)
+        if not passed:
+            receipt = self._receipt(
+                selection=selection,
+                execution_id=execution_id,
+                correlation_id=correlation_id,
+                input_digest=input_digest,
+                output_digest=_digest(output),
+                capability_decisions=capability_decisions,
+                validation={"passed": False, "reason": reason, "kind": "deterministic"},
+                outcome="rejected",
+                failure="output validation failed",
+            )
+            self._emit(receipt)
+            raise SkillValidationFailed(reason)
+
+        receipt = self._receipt(
+            selection=selection,
+            execution_id=execution_id,
+            correlation_id=correlation_id,
+            input_digest=input_digest,
+            output_digest=_digest(output),
+            capability_decisions=capability_decisions,
+            validation={"passed": True, "reason": reason, "kind": "deterministic"},
+            outcome="completed",
+            failure=None,
+        )
+        self._emit(receipt)
+        return SkillExecutionResult(output=output, receipt=receipt)
+
+    def _receipt(
+        self,
+        *,
+        selection: SkillSelection,
+        execution_id: str,
+        correlation_id: str,
+        input_digest: str,
+        output_digest: str | None,
+        capability_decisions: list[dict[str, Any]],
+        validation: Mapping[str, Any],
+        outcome: str,
+        failure: str | None,
+    ) -> dict[str, Any]:
+        manifest = dict(selection.manifest)
+        lease_ids = sorted(
+            {
+                str(decision.get("lease_id"))
+                for decision in capability_decisions
+                if decision.get("lease_id")
+            }
+        )
+        return {
+            "schema": "kpgs.skill-execution-receipt.v1",
+            "execution_id": execution_id,
+            "skill": {
+                "name": selection.name,
+                "version": selection.version,
+                "package_path": selection.package_path,
+                "authority_class": selection.authority_class,
+                "manifest_digest": _digest(manifest),
+            },
+            "correlation_id": correlation_id,
+            "input_digest": input_digest,
+            "output_digest": output_digest,
+            "capability_lease_ids": lease_ids,
+            "capability_decisions": capability_decisions,
+            "validation": dict(validation),
+            "outcome": outcome,
+            "failure": failure,
+            "authority_effect": "none",
+            "created_at": _iso_now(),
+        }
+
+    def _emit(self, receipt: Mapping[str, Any]) -> None:
+        if self.evidence_sink is not None:
+            self.evidence_sink(receipt)
+
+    @staticmethod
+    def _read_json(path: Path) -> dict[str, Any]:
+        try:
+            value = json.loads(path.read_text(encoding="utf-8"))
+        except FileNotFoundError as exc:
+            raise SkillNotLoadable(f"missing skill runtime file: {path}") from exc
+        except json.JSONDecodeError as exc:
+            raise SkillNotLoadable(f"invalid JSON: {path}") from exc
+        if not isinstance(value, dict):
+            raise SkillNotLoadable(f"expected JSON object: {path}")
+        return value

--- a/scripts/ci/manage_skill_package.py
+++ b/scripts/ci/manage_skill_package.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""Scaffold, register and validate canonical KPGS skill packages.
+
+This tool writes repository artifacts only. It does not approve a skill, issue a
+capability lease or execute the skill. Registration remains discovery metadata.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+from pathlib import Path
+import re
+import sys
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_REGISTRY = REPO_ROOT / "governance/kpgs-vnext/skills/registry.json"
+DEFAULT_ROOT = REPO_ROOT / "governance/kpgs-vnext/skills/core"
+NAME_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+SEMVER_PATTERN = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
+
+
+class SkillPackageWorkflowError(ValueError):
+    pass
+
+
+def _load_registry_validator(repo_root: Path):
+    path = repo_root / "scripts/ci/validate_skill_registry.py"
+    spec = importlib.util.spec_from_file_location("kpgs_validate_skill_registry", path)
+    if spec is None or spec.loader is None:
+        raise SkillPackageWorkflowError("could not load canonical registry validator")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise SkillPackageWorkflowError(f"missing JSON file: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise SkillPackageWorkflowError(f"invalid JSON: {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise SkillPackageWorkflowError(f"expected JSON object: {path}")
+    return value
+
+
+def _write_json(path: Path, value: MappingLike) -> None:
+    path.write_text(json.dumps(value, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+MappingLike = dict[str, Any]
+
+
+def scaffold(
+    *,
+    repo_root: Path,
+    package_root: Path,
+    name: str,
+    version: str,
+    category: str,
+    summary: str,
+    capability: str,
+    resource_scope: str,
+) -> Path:
+    if not NAME_PATTERN.fullmatch(name):
+        raise SkillPackageWorkflowError("name must be lowercase kebab-case")
+    if not SEMVER_PATTERN.fullmatch(version):
+        raise SkillPackageWorkflowError("version must be semantic x.y.z")
+    for field_name, value in {
+        "category": category,
+        "summary": summary,
+        "capability": capability,
+        "resource_scope": resource_scope,
+    }.items():
+        if not value.strip():
+            raise SkillPackageWorkflowError(f"{field_name} is required")
+
+    package_dir = (package_root / name).resolve()
+    root = repo_root.resolve()
+    if root != package_dir and root not in package_dir.parents:
+        raise SkillPackageWorkflowError("package path must stay inside repository root")
+    if package_dir.exists():
+        raise SkillPackageWorkflowError(f"package already exists: {package_dir}")
+    package_dir.mkdir(parents=True)
+
+    skill_md = f"""---
+name: {name}
+description: {summary}
+---
+
+# {name}
+
+## What this skill does
+
+{summary}
+
+## What it can access
+
+This skill requires `{capability}` scoped to `{resource_scope}`. The skill itself does not grant that access; the active task must supply a valid capability lease.
+
+## Procedure
+
+1. Confirm the active human task and governing specification.
+2. Confirm the required capability lease and resource scope.
+3. Execute only the bounded task described by the active handler.
+4. Validate the output using the declared validation method.
+5. Emit an execution receipt and return a plain-language result.
+
+## Failure and recovery
+
+If authority, evidence or validation is missing, stop before consequential execution and explain the next safe action. Never convert discovery, registration or confidence into permission.
+"""
+    (package_dir / "SKILL.md").write_text(skill_md, encoding="utf-8")
+
+    manifest: MappingLike = {
+        "name": name,
+        "version": version,
+        "description": summary,
+        "category": category,
+        "state": "draft",
+        "runtime": {
+            "renter_protocol": "1.0",
+            "platforms": ["human", "agent", "stateless-renter", "server"],
+            "languages": ["markdown", "json"],
+        },
+        "inputs": {"schema_ref": None, "description": "Task-scoped input supplied by the caller."},
+        "outputs": {"schema_ref": None, "description": "Validated task-scoped output plus an execution receipt."},
+        "required_capabilities": [
+            {"name": capability, "resource_scope": resource_scope, "optional": False}
+        ],
+        "dependencies": [
+            {"kind": "runtime", "name": "kpgs-stateless-renter-protocol", "version_constraint": "1.0"}
+        ],
+        "provenance": {
+            "origin": "kpgs-original",
+            "license_status": "unknown",
+            "license_spdx": None,
+            "sources": [
+                {
+                    "ref": "human-authored-scaffold",
+                    "relationship": "origin",
+                    "commit": None,
+                }
+            ],
+        },
+        "validation": {
+            "hard_gates": [
+                "No execution without the declared capability lease",
+                "No fabricated validation evidence",
+            ],
+            "methods": ["schema"],
+            "evidence_refs": [],
+        },
+        "failures": [
+            {
+                "code": "CAPABILITY_DENIED",
+                "recoverability": "user-action",
+                "user_message": "This action is not permitted for the active task. Request the required scoped permission and try again.",
+            },
+            {
+                "code": "VALIDATION_FAILED",
+                "recoverability": "retry",
+                "user_message": "The output did not pass its declared checks, so it was not accepted. Correct the input or implementation and retry.",
+            },
+        ],
+    }
+    _write_json(package_dir / "skill.json", manifest)
+    return package_dir
+
+
+def register(
+    *,
+    repo_root: Path,
+    registry_path: Path,
+    package_dir: Path,
+    authority_class: str,
+    summary: str,
+    tags: list[str],
+) -> None:
+    if authority_class not in {"canonical-core", "publication-adapter"}:
+        raise SkillPackageWorkflowError("unsupported authority_class")
+    manifest = _read_json(package_dir / "skill.json")
+    try:
+        relative_path = package_dir.resolve().relative_to(repo_root.resolve()).as_posix()
+    except ValueError as exc:
+        raise SkillPackageWorkflowError("package must be inside repository root") from exc
+
+    registry = _read_json(registry_path)
+    entries = registry.get("skills")
+    if not isinstance(entries, list):
+        raise SkillPackageWorkflowError("registry skills must be an array")
+    identity = (manifest.get("name"), manifest.get("version"))
+    if any((entry.get("name"), entry.get("version")) == identity for entry in entries if isinstance(entry, dict)):
+        raise SkillPackageWorkflowError(f"registry already contains {identity[0]}@{identity[1]}")
+    entries.append(
+        {
+            "name": manifest["name"],
+            "version": manifest["version"],
+            "category": manifest["category"],
+            "package_path": relative_path,
+            "authority_class": authority_class,
+            "discovery": {"summary": summary, "tags": sorted(set(tags))},
+        }
+    )
+    _write_json(registry_path, registry)
+
+
+def validate(*, repo_root: Path, registry_path: Path) -> None:
+    validator = _load_registry_validator(repo_root)
+    validator.validate_registry(registry_path, repo_root)
+
+
+def create_workflow(args: argparse.Namespace) -> Path:
+    repo_root = args.repo_root.resolve()
+    registry_path = args.registry.resolve()
+    package_root = args.package_root.resolve()
+    package_dir = scaffold(
+        repo_root=repo_root,
+        package_root=package_root,
+        name=args.name,
+        version=args.version,
+        category=args.category,
+        summary=args.summary,
+        capability=args.capability,
+        resource_scope=args.resource_scope,
+    )
+    try:
+        register(
+            repo_root=repo_root,
+            registry_path=registry_path,
+            package_dir=package_dir,
+            authority_class=args.authority_class,
+            summary=args.summary,
+            tags=args.tag,
+        )
+        validate(repo_root=repo_root, registry_path=registry_path)
+    except Exception:
+        # The package remains on disk for inspection, but registry mutation is
+        # restored so a failed create cannot poison canonical discovery.
+        registry = _read_json(registry_path)
+        registry["skills"] = [
+            entry
+            for entry in registry.get("skills", [])
+            if not (
+                isinstance(entry, dict)
+                and entry.get("name") == args.name
+                and entry.get("version") == args.version
+            )
+        ]
+        _write_json(registry_path, registry)
+        raise
+    return package_dir
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=REPO_ROOT)
+    parser.add_argument("--registry", type=Path, default=DEFAULT_REGISTRY)
+    parser.add_argument("--package-root", type=Path, default=DEFAULT_ROOT)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    create = sub.add_parser("create", help="Scaffold, register and conformance-validate a new draft skill.")
+    create.add_argument("--name", required=True)
+    create.add_argument("--version", default="0.1.0")
+    create.add_argument("--category", required=True)
+    create.add_argument("--summary", required=True)
+    create.add_argument("--capability", required=True)
+    create.add_argument("--resource-scope", default="active-task")
+    create.add_argument("--authority-class", default="canonical-core")
+    create.add_argument("--tag", action="append", required=True)
+
+    validate_cmd = sub.add_parser("validate", help="Validate the canonical registry and registered packages.")
+
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "create":
+            package_dir = create_workflow(args)
+            print(f"KPGS skill package CREATED+DRAFT+REGISTERED+CONFORMANCE-PASS: {package_dir}")
+        elif args.command == "validate":
+            validate(repo_root=args.repo_root.resolve(), registry_path=args.registry.resolve())
+            print("KPGS skill package registry PASS")
+        else:
+            raise SkillPackageWorkflowError("unsupported command")
+    except Exception as exc:
+        print(f"KPGS skill package workflow FAIL: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/manage_skill_package.py
+++ b/scripts/ci/manage_skill_package.py
@@ -48,11 +48,14 @@ def _read_json(path: Path) -> dict[str, Any]:
     return value
 
 
-def _write_json(path: Path, value: MappingLike) -> None:
-    path.write_text(json.dumps(value, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
-
-
 MappingLike = dict[str, Any]
+
+
+def _write_json(path: Path, value: MappingLike) -> None:
+    path.write_text(
+        json.dumps(value, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
 
 
 def scaffold(
@@ -127,13 +130,27 @@ If authority, evidence or validation is missing, stop before consequential execu
             "platforms": ["human", "agent", "stateless-renter", "server"],
             "languages": ["markdown", "json"],
         },
-        "inputs": {"schema_ref": None, "description": "Task-scoped input supplied by the caller."},
-        "outputs": {"schema_ref": None, "description": "Validated task-scoped output plus an execution receipt."},
+        "inputs": {
+            "schema_ref": None,
+            "description": "Task-scoped input supplied by the caller.",
+        },
+        "outputs": {
+            "schema_ref": None,
+            "description": "Validated task-scoped output plus an execution receipt.",
+        },
         "required_capabilities": [
-            {"name": capability, "resource_scope": resource_scope, "optional": False}
+            {
+                "name": capability,
+                "resource_scope": resource_scope,
+                "optional": False,
+            }
         ],
         "dependencies": [
-            {"kind": "runtime", "name": "kpgs-stateless-renter-protocol", "version_constraint": "1.0"}
+            {
+                "kind": "runtime",
+                "name": "kpgs-stateless-renter-protocol",
+                "version_constraint": "1.0",
+            }
         ],
         "provenance": {
             "origin": "kpgs-original",
@@ -142,7 +159,10 @@ If authority, evidence or validation is missing, stop before consequential execu
             "sources": [
                 {
                     "ref": "human-authored-scaffold",
-                    "relationship": "origin",
+                    # `origin` is intentionally not a source relationship in the
+                    # canonical manifest schema. The package's origin is already
+                    # declared above; this source entry records the scaffold event.
+                    "relationship": "reference",
                     "commit": None,
                 }
             ],
@@ -194,8 +214,14 @@ def register(
     if not isinstance(entries, list):
         raise SkillPackageWorkflowError("registry skills must be an array")
     identity = (manifest.get("name"), manifest.get("version"))
-    if any((entry.get("name"), entry.get("version")) == identity for entry in entries if isinstance(entry, dict)):
-        raise SkillPackageWorkflowError(f"registry already contains {identity[0]}@{identity[1]}")
+    if any(
+        (entry.get("name"), entry.get("version")) == identity
+        for entry in entries
+        if isinstance(entry, dict)
+    ):
+        raise SkillPackageWorkflowError(
+            f"registry already contains {identity[0]}@{identity[1]}"
+        )
     entries.append(
         {
             "name": manifest["name"],
@@ -263,7 +289,10 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--package-root", type=Path, default=DEFAULT_ROOT)
     sub = parser.add_subparsers(dest="command", required=True)
 
-    create = sub.add_parser("create", help="Scaffold, register and conformance-validate a new draft skill.")
+    create = sub.add_parser(
+        "create",
+        help="Scaffold, register and conformance-validate a new draft skill.",
+    )
     create.add_argument("--name", required=True)
     create.add_argument("--version", default="0.1.0")
     create.add_argument("--category", required=True)
@@ -273,15 +302,24 @@ def main(argv: list[str] | None = None) -> int:
     create.add_argument("--authority-class", default="canonical-core")
     create.add_argument("--tag", action="append", required=True)
 
-    validate_cmd = sub.add_parser("validate", help="Validate the canonical registry and registered packages.")
+    sub.add_parser(
+        "validate",
+        help="Validate the canonical registry and registered packages.",
+    )
 
     args = parser.parse_args(argv)
     try:
         if args.command == "create":
             package_dir = create_workflow(args)
-            print(f"KPGS skill package CREATED+DRAFT+REGISTERED+CONFORMANCE-PASS: {package_dir}")
+            print(
+                "KPGS skill package CREATED+DRAFT+REGISTERED+CONFORMANCE-PASS: "
+                f"{package_dir}"
+            )
         elif args.command == "validate":
-            validate(repo_root=args.repo_root.resolve(), registry_path=args.registry.resolve())
+            validate(
+                repo_root=args.repo_root.resolve(),
+                registry_path=args.registry.resolve(),
+            )
             print("KPGS skill package registry PASS")
         else:
             raise SkillPackageWorkflowError("unsupported command")

--- a/scripts/ci/validate_skill_registry.py
+++ b/scripts/ci/validate_skill_registry.py
@@ -3,7 +3,8 @@
 
 The registry is discovery metadata, not an authority escalation surface. A registered
 skill remains non-loadable for production unless its manifest state is validated or
-approved and the caller separately holds the declared capability lease.
+approved, its license state is verified-compatible, and the caller separately holds
+the declared capability lease.
 """
 
 from __future__ import annotations
@@ -33,21 +34,44 @@ REQUIRED_MANIFEST_KEYS = {
 }
 PRODUCTION_STATES = {"validated", "approved"}
 AUTHORITY_CLASSES = {"canonical-core", "publication-adapter"}
+MANIFEST_STATES = {"draft", "validated", "approved", "deprecated", "blocked"}
+PROVENANCE_ORIGINS = {"kpgs-original", "adapted", "imported", "fork-derived-reference"}
+LICENSE_STATUSES = {"verified-compatible", "pending", "incompatible", "unknown"}
+SOURCE_RELATIONSHIPS = {"inspiration", "adaptation", "import", "upstream", "reference"}
+VALIDATION_METHODS = {
+    "schema",
+    "unit",
+    "integration",
+    "e2e",
+    "security",
+    "accessibility",
+    "human-review",
+    "model-eval",
+}
 
 
 class RegistryValidationError(ValueError):
     """Raised when registry or package conformance fails."""
 
 
-def _read_json(path: Path) -> dict[str, Any]:
+def _display_path(path: Path, repo_root: Path = REPO_ROOT) -> str:
+    try:
+        return path.resolve().relative_to(repo_root.resolve()).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def _read_json(path: Path, repo_root: Path = REPO_ROOT) -> dict[str, Any]:
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
     except FileNotFoundError as exc:
-        raise RegistryValidationError(f"missing file: {path.relative_to(REPO_ROOT)}") from exc
+        raise RegistryValidationError(f"missing file: {_display_path(path, repo_root)}") from exc
     except json.JSONDecodeError as exc:
-        raise RegistryValidationError(f"invalid JSON: {path.relative_to(REPO_ROOT)}: {exc}") from exc
+        raise RegistryValidationError(
+            f"invalid JSON: {_display_path(path, repo_root)}: {exc}"
+        ) from exc
     if not isinstance(data, dict):
-        raise RegistryValidationError(f"expected JSON object: {path.relative_to(REPO_ROOT)}")
+        raise RegistryValidationError(f"expected JSON object: {_display_path(path, repo_root)}")
     return data
 
 
@@ -64,18 +88,61 @@ def _frontmatter_name(skill_md: Path) -> str | None:
     return None
 
 
-def validate_registry(registry_path: Path = DEFAULT_REGISTRY, repo_root: Path = REPO_ROOT) -> list[dict[str, Any]]:
-    registry = _read_json(registry_path)
+def _validate_schema_ref(
+    *,
+    name: str,
+    version: str,
+    contract_name: str,
+    contract: Any,
+    package_dir: Path,
+    repo_root: Path,
+) -> None:
+    if not isinstance(contract, dict) or "schema_ref" not in contract:
+        raise RegistryValidationError(
+            f"{name}@{version}: {contract_name}.schema_ref is required"
+        )
+    schema_ref = contract.get("schema_ref")
+    if schema_ref is None:
+        return
+    if not isinstance(schema_ref, str) or not schema_ref.strip():
+        raise RegistryValidationError(
+            f"{name}@{version}: {contract_name}.schema_ref must be null or a non-empty string"
+        )
+    # Canonical package schema refs are repository-local artifacts. Reject path
+    # escapes so a manifest cannot make validation depend on an arbitrary host file.
+    schema_path = (package_dir / schema_ref).resolve()
+    root = repo_root.resolve()
+    if schema_path != root and root not in schema_path.parents:
+        raise RegistryValidationError(
+            f"{name}@{version}: {contract_name}.schema_ref escapes repository root"
+        )
+    if not schema_path.is_file():
+        raise RegistryValidationError(
+            f"{name}@{version}: missing {contract_name} schema {_display_path(schema_path, root)}"
+        )
+    _read_json(schema_path, root)
+
+
+def validate_registry(
+    registry_path: Path = DEFAULT_REGISTRY,
+    repo_root: Path = REPO_ROOT,
+) -> list[dict[str, Any]]:
+    repo_root = repo_root.resolve()
+    registry = _read_json(registry_path, repo_root)
     if registry.get("registry_version") != "1.0.0":
         raise RegistryValidationError("registry_version must be 1.0.0")
     if registry.get("authority") != "governance/kpgs-vnext/skills":
-        raise RegistryValidationError("canonical registry authority must remain governance/kpgs-vnext/skills")
+        raise RegistryValidationError(
+            "canonical registry authority must remain governance/kpgs-vnext/skills"
+        )
 
     policy = registry.get("selection_policy")
     if not isinstance(policy, dict):
         raise RegistryValidationError("selection_policy must be an object")
     if set(policy.get("production_states", [])) != PRODUCTION_STATES:
-        raise RegistryValidationError("production_states must be exactly validated + approved")
+        raise RegistryValidationError(
+            "production_states must be exactly validated + approved"
+        )
     if policy.get("require_capability_lease") is not True:
         raise RegistryValidationError("canonical registry must require a capability lease")
     if policy.get("require_provenance") is not True:
@@ -100,58 +167,173 @@ def validate_registry(registry_path: Path = DEFAULT_REGISTRY, repo_root: Path = 
         authority_class = entry.get("authority_class")
         discovery = entry.get("discovery")
 
-        if not all(isinstance(value, str) and value for value in (name, version, category, package_path)):
-            raise RegistryValidationError("registry entries require non-empty name/version/category/package_path")
+        if not all(
+            isinstance(value, str) and value
+            for value in (name, version, category, package_path)
+        ):
+            raise RegistryValidationError(
+                "registry entries require non-empty name/version/category/package_path"
+            )
         if authority_class not in AUTHORITY_CLASSES:
-            raise RegistryValidationError(f"{name}@{version}: unsupported authority_class {authority_class!r}")
-        if not isinstance(discovery, dict) or not isinstance(discovery.get("summary"), str):
-            raise RegistryValidationError(f"{name}@{version}: discovery.summary is required")
+            raise RegistryValidationError(
+                f"{name}@{version}: unsupported authority_class {authority_class!r}"
+            )
+        if not isinstance(discovery, dict) or not isinstance(
+            discovery.get("summary"), str
+        ):
+            raise RegistryValidationError(
+                f"{name}@{version}: discovery.summary is required"
+            )
         tags = discovery.get("tags")
-        if not isinstance(tags, list) or not tags or not all(isinstance(tag, str) and tag for tag in tags):
-            raise RegistryValidationError(f"{name}@{version}: discovery.tags must be a non-empty string array")
+        if (
+            not isinstance(tags, list)
+            or not tags
+            or not all(isinstance(tag, str) and tag for tag in tags)
+        ):
+            raise RegistryValidationError(
+                f"{name}@{version}: discovery.tags must be a non-empty string array"
+            )
 
         identity = (name, version)
         if identity in seen:
             raise RegistryValidationError(f"duplicate registry identity: {name}@{version}")
         seen.add(identity)
 
-        package_dir = repo_root / package_path
+        package_dir = (repo_root / package_path).resolve()
+        if package_dir != repo_root and repo_root not in package_dir.parents:
+            raise RegistryValidationError(
+                f"{name}@{version}: package_path escapes repository root"
+            )
         manifest_path = package_dir / "skill.json"
         skill_md_path = package_dir / "SKILL.md"
-        manifest = _read_json(manifest_path)
+        manifest = _read_json(manifest_path, repo_root)
         if not skill_md_path.is_file():
             raise RegistryValidationError(f"{name}@{version}: missing SKILL.md")
 
         missing_keys = REQUIRED_MANIFEST_KEYS - manifest.keys()
         if missing_keys:
-            raise RegistryValidationError(f"{name}@{version}: manifest missing {sorted(missing_keys)}")
-        if manifest["name"] != name or manifest["version"] != version or manifest["category"] != category:
-            raise RegistryValidationError(f"{name}@{version}: registry identity does not match skill.json")
+            raise RegistryValidationError(
+                f"{name}@{version}: manifest missing {sorted(missing_keys)}"
+            )
+        if (
+            manifest["name"] != name
+            or manifest["version"] != version
+            or manifest["category"] != category
+        ):
+            raise RegistryValidationError(
+                f"{name}@{version}: registry identity does not match skill.json"
+            )
         if _frontmatter_name(skill_md_path) != name:
-            raise RegistryValidationError(f"{name}@{version}: SKILL.md frontmatter name does not match registry")
+            raise RegistryValidationError(
+                f"{name}@{version}: SKILL.md frontmatter name does not match registry"
+            )
+
+        manifest_state = manifest.get("state")
+        if manifest_state not in MANIFEST_STATES:
+            raise RegistryValidationError(
+                f"{name}@{version}: unsupported manifest state {manifest_state!r}"
+            )
+
+        runtime = manifest.get("runtime")
+        if not isinstance(runtime, dict):
+            raise RegistryValidationError(f"{name}@{version}: runtime must be an object")
+        platforms = runtime.get("platforms")
+        if not isinstance(platforms, list) or not platforms:
+            raise RegistryValidationError(
+                f"{name}@{version}: runtime.platforms must not be empty"
+            )
+
+        _validate_schema_ref(
+            name=name,
+            version=version,
+            contract_name="inputs",
+            contract=manifest.get("inputs"),
+            package_dir=package_dir,
+            repo_root=repo_root,
+        )
+        _validate_schema_ref(
+            name=name,
+            version=version,
+            contract_name="outputs",
+            contract=manifest.get("outputs"),
+            package_dir=package_dir,
+            repo_root=repo_root,
+        )
 
         provenance = manifest.get("provenance")
-        if not isinstance(provenance, dict) or not provenance.get("origin"):
-            raise RegistryValidationError(f"{name}@{version}: provenance.origin is required")
-        if "license_status" not in provenance or not provenance.get("license_status"):
-            raise RegistryValidationError(f"{name}@{version}: provenance.license_status is required")
-        if not isinstance(provenance.get("sources"), list) or not provenance["sources"]:
-            raise RegistryValidationError(f"{name}@{version}: provenance.sources must not be empty")
+        if not isinstance(provenance, dict):
+            raise RegistryValidationError(
+                f"{name}@{version}: provenance must be an object"
+            )
+        origin = provenance.get("origin")
+        if origin not in PROVENANCE_ORIGINS:
+            raise RegistryValidationError(
+                f"{name}@{version}: unsupported provenance.origin {origin!r}"
+            )
+        license_status = provenance.get("license_status")
+        if license_status not in LICENSE_STATUSES:
+            raise RegistryValidationError(
+                f"{name}@{version}: unsupported provenance.license_status {license_status!r}"
+            )
+        sources = provenance.get("sources")
+        if not isinstance(sources, list) or not sources:
+            raise RegistryValidationError(
+                f"{name}@{version}: provenance.sources must not be empty"
+            )
+        for source in sources:
+            if not isinstance(source, dict) or not isinstance(source.get("ref"), str) or not source.get("ref"):
+                raise RegistryValidationError(
+                    f"{name}@{version}: each provenance source requires a non-empty ref"
+                )
+            if source.get("relationship") not in SOURCE_RELATIONSHIPS:
+                raise RegistryValidationError(
+                    f"{name}@{version}: unsupported provenance source relationship {source.get('relationship')!r}"
+                )
 
         capabilities = manifest.get("required_capabilities")
         if not isinstance(capabilities, list) or not capabilities:
-            raise RegistryValidationError(f"{name}@{version}: required_capabilities must not be empty")
+            raise RegistryValidationError(
+                f"{name}@{version}: required_capabilities must not be empty"
+            )
+        for capability in capabilities:
+            if (
+                not isinstance(capability, dict)
+                or not isinstance(capability.get("name"), str)
+                or not capability.get("name")
+                or not isinstance(capability.get("resource_scope"), str)
+                or not capability.get("resource_scope")
+            ):
+                raise RegistryValidationError(
+                    f"{name}@{version}: invalid required capability contract"
+                )
+            if "optional" in capability and not isinstance(capability["optional"], bool):
+                raise RegistryValidationError(
+                    f"{name}@{version}: capability optional must be boolean"
+                )
 
         validation = manifest.get("validation")
-        if not isinstance(validation, dict) or not validation.get("methods"):
-            raise RegistryValidationError(f"{name}@{version}: validation.methods must not be empty")
+        methods = validation.get("methods") if isinstance(validation, dict) else None
+        if not isinstance(methods, list) or not methods:
+            raise RegistryValidationError(
+                f"{name}@{version}: validation.methods must not be empty"
+            )
+        unknown_methods = set(methods) - VALIDATION_METHODS
+        if unknown_methods:
+            raise RegistryValidationError(
+                f"{name}@{version}: unsupported validation method(s) {sorted(unknown_methods)}"
+            )
 
-        manifest_state = manifest.get("state")
-        production_loadable = manifest_state in PRODUCTION_STATES
+        # State alone is never enough for production selection. This mirrors the
+        # contract rule that pending/unknown/incompatible licensing remains HOLD.
+        production_loadable = (
+            manifest_state in PRODUCTION_STATES
+            and license_status == "verified-compatible"
+        )
         validated.append(
             {
                 **entry,
                 "state": manifest_state,
+                "license_status": license_status,
                 "production_loadable": production_loadable,
                 "required_capabilities": capabilities,
             }
@@ -177,7 +359,10 @@ def discover(
         if production_only and not entry["production_loadable"]:
             continue
 
-        manifest = _read_json(repo_root / entry["package_path"] / "skill.json")
+        manifest = _read_json(
+            repo_root.resolve() / entry["package_path"] / "skill.json",
+            repo_root.resolve(),
+        )
         platforms = manifest.get("runtime", {}).get("platforms", [])
         if platform and platform not in platforms:
             continue
@@ -199,16 +384,33 @@ def discover(
 
 def _print_entries(entries: Iterable[dict[str, Any]]) -> None:
     for entry in entries:
-        status = "production-loadable" if entry["production_loadable"] else f"not-loadable:{entry['state']}"
-        print(f"{entry['name']}@{entry['version']}\t{entry['authority_class']}\t{status}\t{entry['package_path']}")
+        status = (
+            "production-loadable"
+            if entry["production_loadable"]
+            else f"not-loadable:{entry['state']}:{entry['license_status']}"
+        )
+        print(
+            f"{entry['name']}@{entry['version']}\t{entry['authority_class']}\t{status}\t{entry['package_path']}"
+        )
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--registry", type=Path, default=DEFAULT_REGISTRY)
-    parser.add_argument("--discover", default=None, metavar="QUERY", help="Search the validated registry.")
-    parser.add_argument("--platform", help="Filter discovery by declared runtime platform.")
-    parser.add_argument("--production-only", action="store_true", help="Return only validated/approved packages.")
+    parser.add_argument(
+        "--discover",
+        default=None,
+        metavar="QUERY",
+        help="Search the validated registry.",
+    )
+    parser.add_argument(
+        "--platform", help="Filter discovery by declared runtime platform."
+    )
+    parser.add_argument(
+        "--production-only",
+        action="store_true",
+        help="Return only validated/approved packages with verified-compatible licensing.",
+    )
     args = parser.parse_args(argv)
 
     try:

--- a/tests/test_canonical_skill_runtime.py
+++ b/tests/test_canonical_skill_runtime.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import importlib.util
+import json
+from pathlib import Path
+import sys
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+CORE = ROOT / "kopano-core"
+if str(CORE) not in sys.path:
+    sys.path.insert(0, str(CORE))
+
+from kopano.skill_runtime import (  # noqa: E402
+    CanonicalSkillRuntime,
+    SkillAuthorizationDenied,
+    SkillNotLoadable,
+)
+
+
+def load_capability_module():
+    path = ROOT / "governance/kpgs-vnext/security/capability_lease.py"
+    spec = importlib.util.spec_from_file_location("kpgs_capability_lease_for_skill_test", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def write_fixture(repo: Path, *, state: str = "validated") -> None:
+    package = repo / "skills/demo/demo-skill"
+    package.mkdir(parents=True)
+    (package / "SKILL.md").write_text(
+        "---\nname: demo-skill\ndescription: Demonstrate governed skill execution.\n---\n\n# Demo\n",
+        encoding="utf-8",
+    )
+    (package / "skill.json").write_text(
+        json.dumps(
+            {
+                "name": "demo-skill",
+                "version": "1.2.3",
+                "description": "Demonstrate governed skill execution.",
+                "category": "demo",
+                "state": state,
+                "runtime": {
+                    "renter_protocol": "1.0",
+                    "platforms": ["stateless-renter"],
+                    "languages": ["json"],
+                },
+                "inputs": {"schema_ref": None, "description": "integer"},
+                "outputs": {"schema_ref": None, "description": "integer"},
+                "required_capabilities": [
+                    {"name": "demo.execute", "resource_scope": "active-task", "optional": False}
+                ],
+                "dependencies": [],
+                "provenance": {
+                    "origin": "kpgs-original",
+                    "license_status": "compatible",
+                    "license_spdx": "MIT",
+                    "sources": [{"ref": "test-fixture", "relationship": "origin", "commit": None}],
+                },
+                "validation": {
+                    "hard_gates": ["output must be an even integer"],
+                    "methods": ["deterministic-test"],
+                    "evidence_refs": ["tests/test_canonical_skill_runtime.py"],
+                },
+                "failures": [
+                    {
+                        "code": "VALIDATION_FAILED",
+                        "recoverability": "retry",
+                        "user_message": "The output failed its declared check.",
+                    }
+                ],
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    registry = repo / "governance/kpgs-vnext/skills/registry.json"
+    registry.parent.mkdir(parents=True)
+    registry.write_text(
+        json.dumps(
+            {
+                "registry_version": "1.0.0",
+                "authority": "governance/kpgs-vnext/skills",
+                "selection_policy": {
+                    "production_states": ["validated", "approved"],
+                    "require_capability_lease": True,
+                    "require_provenance": True,
+                    "require_license_status": True,
+                },
+                "skills": [
+                    {
+                        "name": "demo-skill",
+                        "version": "1.2.3",
+                        "category": "demo",
+                        "package_path": "skills/demo/demo-skill",
+                        "authority_class": "canonical-core",
+                        "discovery": {"summary": "Demo skill", "tags": ["demo"]},
+                    }
+                ],
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def authority_and_token(capability: str = "demo.execute"):
+    lease = load_capability_module()
+    authority = lease.CapabilityLeaseAuthority(
+        lease.KeyRing({"k1": b"a" * 32}, "k1"),
+        clock=lambda: datetime(2026, 8, 19, 0, 0, tzinfo=timezone.utc),
+    )
+    token = authority.issue(
+        subject_id="renter:test",
+        subject_kind="renter",
+        tenant_id="tenant:test",
+        domain_id="domain:test",
+        task_id="task:test",
+        capabilities=[
+            {"name": capability, "resource_scope": "active-task", "constraints": ["test-only"]}
+        ],
+        policy_decision_ref="policy:test",
+        governing_spec_ref="spec:test",
+        correlation_id="corr:test",
+        evidence_ref="evidence:test",
+    )
+    return authority, token
+
+
+def test_skill_executes_only_after_capability_authorization_and_emits_bound_receipt(tmp_path: Path) -> None:
+    write_fixture(tmp_path)
+    authority, token = authority_and_token()
+    evidence: list[dict] = []
+    calls = 0
+
+    runtime = CanonicalSkillRuntime(
+        repo_root=tmp_path,
+        capability_authorizer=authority.authorize,
+        evidence_sink=lambda receipt: evidence.append(dict(receipt)),
+    )
+
+    def handler(value: int) -> int:
+        nonlocal calls
+        calls += 1
+        return value * 2
+
+    runtime.register_handler(
+        "demo-skill",
+        "1.2.3",
+        handler,
+        output_validator=lambda output: (isinstance(output, int) and output % 2 == 0, "output is even integer"),
+    )
+    result = runtime.execute(
+        name="demo-skill",
+        version="1.2.3",
+        platform="stateless-renter",
+        lease_token=token,
+        tenant_id="tenant:test",
+        domain_id="domain:test",
+        task_id="task:test",
+        correlation_id="corr:test",
+        input_value=21,
+    )
+
+    assert result.output == 42
+    assert calls == 1
+    assert result.receipt["schema"] == "kpgs.skill-execution-receipt.v1"
+    assert result.receipt["skill"]["name"] == "demo-skill"
+    assert result.receipt["skill"]["version"] == "1.2.3"
+    assert result.receipt["input_digest"]
+    assert result.receipt["output_digest"]
+    assert result.receipt["capability_lease_ids"]
+    assert result.receipt["capability_decisions"][0]["capability"] == "demo.execute"
+    assert result.receipt["validation"]["passed"] is True
+    assert result.receipt["outcome"] == "completed"
+    assert result.receipt["authority_effect"] == "none"
+    assert evidence == [result.receipt]
+
+
+def test_undeclared_capability_blocks_before_handler(tmp_path: Path) -> None:
+    write_fixture(tmp_path)
+    authority, token = authority_and_token("different.execute")
+    calls = 0
+    runtime = CanonicalSkillRuntime(repo_root=tmp_path, capability_authorizer=authority.authorize)
+
+    def handler(value):
+        nonlocal calls
+        calls += 1
+        return value
+
+    runtime.register_handler("demo-skill", "1.2.3", handler)
+    with pytest.raises(SkillAuthorizationDenied, match="capability denied before execution"):
+        runtime.execute(
+            name="demo-skill",
+            version="1.2.3",
+            platform="stateless-renter",
+            lease_token=token,
+            tenant_id="tenant:test",
+            domain_id="domain:test",
+            task_id="task:test",
+            correlation_id="corr:test",
+            input_value={"unsafe": False},
+        )
+    assert calls == 0
+
+
+def test_draft_registered_skill_is_discoverable_but_not_loadable(tmp_path: Path) -> None:
+    write_fixture(tmp_path, state="draft")
+    authority, token = authority_and_token()
+    runtime = CanonicalSkillRuntime(repo_root=tmp_path, capability_authorizer=authority.authorize)
+    runtime.register_handler("demo-skill", "1.2.3", lambda value: value)
+
+    assert runtime.discover("demo")[0]["name"] == "demo-skill"
+    with pytest.raises(SkillNotLoadable, match="not production-loadable: draft"):
+        runtime.execute(
+            name="demo-skill",
+            version="1.2.3",
+            platform="stateless-renter",
+            lease_token=token,
+            tenant_id="tenant:test",
+            domain_id="domain:test",
+            task_id="task:test",
+            correlation_id="corr:test",
+            input_value=1,
+        )

--- a/tests/test_canonical_skill_runtime.py
+++ b/tests/test_canonical_skill_runtime.py
@@ -22,7 +22,9 @@ from kopano.skill_runtime import (  # noqa: E402
 
 def load_capability_module():
     path = ROOT / "governance/kpgs-vnext/security/capability_lease.py"
-    spec = importlib.util.spec_from_file_location("kpgs_capability_lease_for_skill_test", path)
+    spec = importlib.util.spec_from_file_location(
+        "kpgs_capability_lease_for_skill_test", path
+    )
     assert spec and spec.loader
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
@@ -30,7 +32,12 @@ def load_capability_module():
     return module
 
 
-def write_fixture(repo: Path, *, state: str = "validated") -> None:
+def write_fixture(
+    repo: Path,
+    *,
+    state: str = "validated",
+    license_status: str = "verified-compatible",
+) -> None:
     package = repo / "skills/demo/demo-skill"
     package.mkdir(parents=True)
     (package / "SKILL.md").write_text(
@@ -53,18 +60,28 @@ def write_fixture(repo: Path, *, state: str = "validated") -> None:
                 "inputs": {"schema_ref": None, "description": "integer"},
                 "outputs": {"schema_ref": None, "description": "integer"},
                 "required_capabilities": [
-                    {"name": "demo.execute", "resource_scope": "active-task", "optional": False}
+                    {
+                        "name": "demo.execute",
+                        "resource_scope": "active-task",
+                        "optional": False,
+                    }
                 ],
                 "dependencies": [],
                 "provenance": {
                     "origin": "kpgs-original",
-                    "license_status": "compatible",
-                    "license_spdx": "MIT",
-                    "sources": [{"ref": "test-fixture", "relationship": "origin", "commit": None}],
+                    "license_status": license_status,
+                    "license_spdx": "MIT" if license_status == "verified-compatible" else None,
+                    "sources": [
+                        {
+                            "ref": "test-fixture",
+                            "relationship": "reference",
+                            "commit": None,
+                        }
+                    ],
                 },
                 "validation": {
                     "hard_gates": ["output must be an even integer"],
-                    "methods": ["deterministic-test"],
+                    "methods": ["unit"],
                     "evidence_refs": ["tests/test_canonical_skill_runtime.py"],
                 },
                 "failures": [
@@ -124,7 +141,11 @@ def authority_and_token(capability: str = "demo.execute"):
         domain_id="domain:test",
         task_id="task:test",
         capabilities=[
-            {"name": capability, "resource_scope": "active-task", "constraints": ["test-only"]}
+            {
+                "name": capability,
+                "resource_scope": "active-task",
+                "constraints": ["test-only"],
+            }
         ],
         policy_decision_ref="policy:test",
         governing_spec_ref="spec:test",
@@ -135,7 +156,9 @@ def authority_and_token(capability: str = "demo.execute"):
 
 
 class CanonicalSkillRuntimeTests(unittest.TestCase):
-    def test_skill_executes_only_after_capability_authorization_and_emits_bound_receipt(self) -> None:
+    def test_skill_executes_only_after_capability_authorization_and_emits_bound_receipt(
+        self,
+    ) -> None:
         with tempfile.TemporaryDirectory() as directory:
             repo = Path(directory)
             write_fixture(repo)
@@ -177,16 +200,28 @@ class CanonicalSkillRuntimeTests(unittest.TestCase):
 
             self.assertEqual(result.output, 42)
             self.assertEqual(calls, 1)
-            self.assertEqual(result.receipt["schema"], "kpgs.skill-execution-receipt.v1")
+            self.assertEqual(
+                result.receipt["schema"], "kpgs.skill-execution-receipt.v1"
+            )
             self.assertEqual(result.receipt["skill"]["name"], "demo-skill")
             self.assertEqual(result.receipt["skill"]["version"], "1.2.3")
+            self.assertEqual(
+                result.receipt["skill"]["license_status"], "verified-compatible"
+            )
             self.assertTrue(result.receipt["input_digest"])
             self.assertTrue(result.receipt["output_digest"])
             self.assertTrue(result.receipt["capability_lease_ids"])
-            self.assertEqual(result.receipt["capability_decisions"][0]["capability"], "demo.execute")
+            self.assertEqual(
+                result.receipt["capability_decisions"][0]["capability"],
+                "demo.execute",
+            )
             self.assertIs(result.receipt["validation"]["passed"], True)
             self.assertEqual(result.receipt["outcome"], "completed")
             self.assertEqual(result.receipt["authority_effect"], "none")
+            self.assertIs(result.receipt["execution_context"]["released"], True)
+            self.assertIs(
+                result.receipt["execution_context"]["upstream_lease_revoked"], False
+            )
             self.assertEqual(evidence, [result.receipt])
 
     def test_undeclared_capability_blocks_before_handler(self) -> None:
@@ -195,7 +230,9 @@ class CanonicalSkillRuntimeTests(unittest.TestCase):
             write_fixture(repo)
             authority, token = authority_and_token("different.execute")
             calls = 0
-            runtime = CanonicalSkillRuntime(repo_root=repo, capability_authorizer=authority.authorize)
+            runtime = CanonicalSkillRuntime(
+                repo_root=repo, capability_authorizer=authority.authorize
+            )
 
             def handler(value):
                 nonlocal calls
@@ -203,7 +240,9 @@ class CanonicalSkillRuntimeTests(unittest.TestCase):
                 return value
 
             runtime.register_handler("demo-skill", "1.2.3", handler)
-            with self.assertRaisesRegex(SkillAuthorizationDenied, "capability denied before execution"):
+            with self.assertRaisesRegex(
+                SkillAuthorizationDenied, "capability denied before execution"
+            ):
                 runtime.execute(
                     name="demo-skill",
                     version="1.2.3",
@@ -222,11 +261,15 @@ class CanonicalSkillRuntimeTests(unittest.TestCase):
             repo = Path(directory)
             write_fixture(repo, state="draft")
             authority, token = authority_and_token()
-            runtime = CanonicalSkillRuntime(repo_root=repo, capability_authorizer=authority.authorize)
+            runtime = CanonicalSkillRuntime(
+                repo_root=repo, capability_authorizer=authority.authorize
+            )
             runtime.register_handler("demo-skill", "1.2.3", lambda value: value)
 
             self.assertEqual(runtime.discover("demo")[0]["name"], "demo-skill")
-            with self.assertRaisesRegex(SkillNotLoadable, "not production-loadable: draft"):
+            with self.assertRaisesRegex(
+                SkillNotLoadable, "not production-loadable: draft"
+            ):
                 runtime.execute(
                     name="demo-skill",
                     version="1.2.3",
@@ -238,6 +281,40 @@ class CanonicalSkillRuntimeTests(unittest.TestCase):
                     correlation_id="corr:test",
                     input_value=1,
                 )
+
+    def test_validated_skill_with_unresolved_license_is_not_loadable(self) -> None:
+        for license_status in ("unknown", "pending", "incompatible"):
+            with self.subTest(license_status=license_status):
+                with tempfile.TemporaryDirectory() as directory:
+                    repo = Path(directory)
+                    write_fixture(
+                        repo,
+                        state="validated",
+                        license_status=license_status,
+                    )
+                    authority, token = authority_and_token()
+                    runtime = CanonicalSkillRuntime(
+                        repo_root=repo,
+                        capability_authorizer=authority.authorize,
+                    )
+                    runtime.register_handler(
+                        "demo-skill", "1.2.3", lambda value: value
+                    )
+                    with self.assertRaisesRegex(
+                        SkillNotLoadable,
+                        "license status is not production-compatible",
+                    ):
+                        runtime.execute(
+                            name="demo-skill",
+                            version="1.2.3",
+                            platform="stateless-renter",
+                            lease_token=token,
+                            tenant_id="tenant:test",
+                            domain_id="domain:test",
+                            task_id="task:test",
+                            correlation_id="corr:test",
+                            input_value=1,
+                        )
 
 
 if __name__ == "__main__":

--- a/tests/test_canonical_skill_runtime.py
+++ b/tests/test_canonical_skill_runtime.py
@@ -5,8 +5,8 @@ import importlib.util
 import json
 from pathlib import Path
 import sys
-
-import pytest
+import tempfile
+import unittest
 
 ROOT = Path(__file__).resolve().parents[1]
 CORE = ROOT / "kopano-core"
@@ -134,99 +134,111 @@ def authority_and_token(capability: str = "demo.execute"):
     return authority, token
 
 
-def test_skill_executes_only_after_capability_authorization_and_emits_bound_receipt(tmp_path: Path) -> None:
-    write_fixture(tmp_path)
-    authority, token = authority_and_token()
-    evidence: list[dict] = []
-    calls = 0
+class CanonicalSkillRuntimeTests(unittest.TestCase):
+    def test_skill_executes_only_after_capability_authorization_and_emits_bound_receipt(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = Path(directory)
+            write_fixture(repo)
+            authority, token = authority_and_token()
+            evidence: list[dict] = []
+            calls = 0
 
-    runtime = CanonicalSkillRuntime(
-        repo_root=tmp_path,
-        capability_authorizer=authority.authorize,
-        evidence_sink=lambda receipt: evidence.append(dict(receipt)),
-    )
+            runtime = CanonicalSkillRuntime(
+                repo_root=repo,
+                capability_authorizer=authority.authorize,
+                evidence_sink=lambda receipt: evidence.append(dict(receipt)),
+            )
 
-    def handler(value: int) -> int:
-        nonlocal calls
-        calls += 1
-        return value * 2
+            def handler(value: int) -> int:
+                nonlocal calls
+                calls += 1
+                return value * 2
 
-    runtime.register_handler(
-        "demo-skill",
-        "1.2.3",
-        handler,
-        output_validator=lambda output: (isinstance(output, int) and output % 2 == 0, "output is even integer"),
-    )
-    result = runtime.execute(
-        name="demo-skill",
-        version="1.2.3",
-        platform="stateless-renter",
-        lease_token=token,
-        tenant_id="tenant:test",
-        domain_id="domain:test",
-        task_id="task:test",
-        correlation_id="corr:test",
-        input_value=21,
-    )
+            runtime.register_handler(
+                "demo-skill",
+                "1.2.3",
+                handler,
+                output_validator=lambda output: (
+                    isinstance(output, int) and output % 2 == 0,
+                    "output is even integer",
+                ),
+            )
+            result = runtime.execute(
+                name="demo-skill",
+                version="1.2.3",
+                platform="stateless-renter",
+                lease_token=token,
+                tenant_id="tenant:test",
+                domain_id="domain:test",
+                task_id="task:test",
+                correlation_id="corr:test",
+                input_value=21,
+            )
 
-    assert result.output == 42
-    assert calls == 1
-    assert result.receipt["schema"] == "kpgs.skill-execution-receipt.v1"
-    assert result.receipt["skill"]["name"] == "demo-skill"
-    assert result.receipt["skill"]["version"] == "1.2.3"
-    assert result.receipt["input_digest"]
-    assert result.receipt["output_digest"]
-    assert result.receipt["capability_lease_ids"]
-    assert result.receipt["capability_decisions"][0]["capability"] == "demo.execute"
-    assert result.receipt["validation"]["passed"] is True
-    assert result.receipt["outcome"] == "completed"
-    assert result.receipt["authority_effect"] == "none"
-    assert evidence == [result.receipt]
+            self.assertEqual(result.output, 42)
+            self.assertEqual(calls, 1)
+            self.assertEqual(result.receipt["schema"], "kpgs.skill-execution-receipt.v1")
+            self.assertEqual(result.receipt["skill"]["name"], "demo-skill")
+            self.assertEqual(result.receipt["skill"]["version"], "1.2.3")
+            self.assertTrue(result.receipt["input_digest"])
+            self.assertTrue(result.receipt["output_digest"])
+            self.assertTrue(result.receipt["capability_lease_ids"])
+            self.assertEqual(result.receipt["capability_decisions"][0]["capability"], "demo.execute")
+            self.assertIs(result.receipt["validation"]["passed"], True)
+            self.assertEqual(result.receipt["outcome"], "completed")
+            self.assertEqual(result.receipt["authority_effect"], "none")
+            self.assertEqual(evidence, [result.receipt])
+
+    def test_undeclared_capability_blocks_before_handler(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = Path(directory)
+            write_fixture(repo)
+            authority, token = authority_and_token("different.execute")
+            calls = 0
+            runtime = CanonicalSkillRuntime(repo_root=repo, capability_authorizer=authority.authorize)
+
+            def handler(value):
+                nonlocal calls
+                calls += 1
+                return value
+
+            runtime.register_handler("demo-skill", "1.2.3", handler)
+            with self.assertRaisesRegex(SkillAuthorizationDenied, "capability denied before execution"):
+                runtime.execute(
+                    name="demo-skill",
+                    version="1.2.3",
+                    platform="stateless-renter",
+                    lease_token=token,
+                    tenant_id="tenant:test",
+                    domain_id="domain:test",
+                    task_id="task:test",
+                    correlation_id="corr:test",
+                    input_value={"unsafe": False},
+                )
+            self.assertEqual(calls, 0)
+
+    def test_draft_registered_skill_is_discoverable_but_not_loadable(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = Path(directory)
+            write_fixture(repo, state="draft")
+            authority, token = authority_and_token()
+            runtime = CanonicalSkillRuntime(repo_root=repo, capability_authorizer=authority.authorize)
+            runtime.register_handler("demo-skill", "1.2.3", lambda value: value)
+
+            self.assertEqual(runtime.discover("demo")[0]["name"], "demo-skill")
+            with self.assertRaisesRegex(SkillNotLoadable, "not production-loadable: draft"):
+                runtime.execute(
+                    name="demo-skill",
+                    version="1.2.3",
+                    platform="stateless-renter",
+                    lease_token=token,
+                    tenant_id="tenant:test",
+                    domain_id="domain:test",
+                    task_id="task:test",
+                    correlation_id="corr:test",
+                    input_value=1,
+                )
 
 
-def test_undeclared_capability_blocks_before_handler(tmp_path: Path) -> None:
-    write_fixture(tmp_path)
-    authority, token = authority_and_token("different.execute")
-    calls = 0
-    runtime = CanonicalSkillRuntime(repo_root=tmp_path, capability_authorizer=authority.authorize)
-
-    def handler(value):
-        nonlocal calls
-        calls += 1
-        return value
-
-    runtime.register_handler("demo-skill", "1.2.3", handler)
-    with pytest.raises(SkillAuthorizationDenied, match="capability denied before execution"):
-        runtime.execute(
-            name="demo-skill",
-            version="1.2.3",
-            platform="stateless-renter",
-            lease_token=token,
-            tenant_id="tenant:test",
-            domain_id="domain:test",
-            task_id="task:test",
-            correlation_id="corr:test",
-            input_value={"unsafe": False},
-        )
-    assert calls == 0
-
-
-def test_draft_registered_skill_is_discoverable_but_not_loadable(tmp_path: Path) -> None:
-    write_fixture(tmp_path, state="draft")
-    authority, token = authority_and_token()
-    runtime = CanonicalSkillRuntime(repo_root=tmp_path, capability_authorizer=authority.authorize)
-    runtime.register_handler("demo-skill", "1.2.3", lambda value: value)
-
-    assert runtime.discover("demo")[0]["name"] == "demo-skill"
-    with pytest.raises(SkillNotLoadable, match="not production-loadable: draft"):
-        runtime.execute(
-            name="demo-skill",
-            version="1.2.3",
-            platform="stateless-renter",
-            lease_token=token,
-            tenant_id="tenant:test",
-            domain_id="domain:test",
-            task_id="task:test",
-            correlation_id="corr:test",
-            input_value=1,
-        )
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_skill_package_workflow.py
+++ b/tests/test_skill_package_workflow.py
@@ -5,6 +5,8 @@ import json
 from pathlib import Path
 import shutil
 import sys
+import tempfile
+import unittest
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -45,79 +47,89 @@ def seed_repo(repo: Path) -> None:
     )
 
 
-def test_create_workflow_scaffolds_versions_registers_and_validates(tmp_path: Path) -> None:
-    module = load_module()
-    seed_repo(tmp_path)
-    package_root = tmp_path / "governance/kpgs-vnext/skills/core"
-    registry = tmp_path / "governance/kpgs-vnext/skills/registry.json"
+class SkillPackageWorkflowTests(unittest.TestCase):
+    def test_create_workflow_scaffolds_versions_registers_and_validates(self) -> None:
+        module = load_module()
+        with tempfile.TemporaryDirectory() as directory:
+            repo = Path(directory)
+            seed_repo(repo)
+            package_root = repo / "governance/kpgs-vnext/skills/core"
+            registry = repo / "governance/kpgs-vnext/skills/registry.json"
 
-    args = module.argparse.Namespace(
-        repo_root=tmp_path,
-        registry=registry,
-        package_root=package_root,
-        name="example-governed-skill",
-        version="1.4.0",
-        category="governance",
-        summary="Explain and execute one bounded governed example.",
-        capability="example.execute",
-        resource_scope="active-task",
-        authority_class="canonical-core",
-        tag=["example", "governance"],
-        command="create",
-    )
-    package = module.create_workflow(args)
+            args = module.argparse.Namespace(
+                repo_root=repo,
+                registry=registry,
+                package_root=package_root,
+                name="example-governed-skill",
+                version="1.4.0",
+                category="governance",
+                summary="Explain and execute one bounded governed example.",
+                capability="example.execute",
+                resource_scope="active-task",
+                authority_class="canonical-core",
+                tag=["example", "governance"],
+                command="create",
+            )
+            package = module.create_workflow(args)
 
-    manifest = json.loads((package / "skill.json").read_text(encoding="utf-8"))
-    registry_value = json.loads(registry.read_text(encoding="utf-8"))
-    assert manifest["name"] == "example-governed-skill"
-    assert manifest["version"] == "1.4.0"
-    assert manifest["state"] == "draft"
-    assert manifest["required_capabilities"] == [
-        {"name": "example.execute", "resource_scope": "active-task", "optional": False}
-    ]
-    assert "what it can access" in (package / "SKILL.md").read_text(encoding="utf-8").lower()
-    assert registry_value["skills"][0]["name"] == "example-governed-skill"
-    assert registry_value["skills"][0]["version"] == "1.4.0"
-    assert registry_value["skills"][0]["package_path"] == "governance/kpgs-vnext/skills/core/example-governed-skill"
+            manifest = json.loads((package / "skill.json").read_text(encoding="utf-8"))
+            registry_value = json.loads(registry.read_text(encoding="utf-8"))
+            self.assertEqual(manifest["name"], "example-governed-skill")
+            self.assertEqual(manifest["version"], "1.4.0")
+            self.assertEqual(manifest["state"], "draft")
+            self.assertEqual(
+                manifest["required_capabilities"],
+                [{"name": "example.execute", "resource_scope": "active-task", "optional": False}],
+            )
+            self.assertIn(
+                "what it can access",
+                (package / "SKILL.md").read_text(encoding="utf-8").lower(),
+            )
+            self.assertEqual(registry_value["skills"][0]["name"], "example-governed-skill")
+            self.assertEqual(registry_value["skills"][0]["version"], "1.4.0")
+            self.assertEqual(
+                registry_value["skills"][0]["package_path"],
+                "governance/kpgs-vnext/skills/core/example-governed-skill",
+            )
 
-    # Re-run the canonical validator against the newly generated package.
-    module.validate(repo_root=tmp_path, registry_path=registry)
+            module.validate(repo_root=repo, registry_path=registry)
+
+    def test_failed_registration_does_not_duplicate_identity(self) -> None:
+        module = load_module()
+        with tempfile.TemporaryDirectory() as directory:
+            repo = Path(directory)
+            seed_repo(repo)
+            package_root = repo / "governance/kpgs-vnext/skills/core"
+            registry = repo / "governance/kpgs-vnext/skills/registry.json"
+            package = module.scaffold(
+                repo_root=repo,
+                package_root=package_root,
+                name="single-identity",
+                version="0.1.0",
+                category="demo",
+                summary="One identity only.",
+                capability="demo.execute",
+                resource_scope="active-task",
+            )
+            module.register(
+                repo_root=repo,
+                registry_path=registry,
+                package_dir=package,
+                authority_class="canonical-core",
+                summary="One identity only.",
+                tags=["demo"],
+            )
+
+            with self.assertRaisesRegex(module.SkillPackageWorkflowError, "already contains"):
+                module.register(
+                    repo_root=repo,
+                    registry_path=registry,
+                    package_dir=package,
+                    authority_class="canonical-core",
+                    summary="One identity only.",
+                    tags=["demo"],
+                )
 
 
-def test_failed_registration_does_not_duplicate_identity(tmp_path: Path) -> None:
-    module = load_module()
-    seed_repo(tmp_path)
-    package_root = tmp_path / "governance/kpgs-vnext/skills/core"
-    registry = tmp_path / "governance/kpgs-vnext/skills/registry.json"
-    package = module.scaffold(
-        repo_root=tmp_path,
-        package_root=package_root,
-        name="single-identity",
-        version="0.1.0",
-        category="demo",
-        summary="One identity only.",
-        capability="demo.execute",
-        resource_scope="active-task",
-    )
-    module.register(
-        repo_root=tmp_path,
-        registry_path=registry,
-        package_dir=package,
-        authority_class="canonical-core",
-        summary="One identity only.",
-        tags=["demo"],
-    )
-
-    try:
-        module.register(
-            repo_root=tmp_path,
-            registry_path=registry,
-            package_dir=package,
-            authority_class="canonical-core",
-            summary="One identity only.",
-            tags=["demo"],
-        )
-    except module.SkillPackageWorkflowError as exc:
-        assert "already contains" in str(exc)
-    else:
-        raise AssertionError("duplicate skill identity was not rejected")
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_skill_package_workflow.py
+++ b/tests/test_skill_package_workflow.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import shutil
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_module():
+    path = ROOT / "scripts/ci/manage_skill_package.py"
+    spec = importlib.util.spec_from_file_location("kpgs_manage_skill_package_test", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def seed_repo(repo: Path) -> None:
+    scripts = repo / "scripts/ci"
+    scripts.mkdir(parents=True)
+    shutil.copy2(ROOT / "scripts/ci/validate_skill_registry.py", scripts / "validate_skill_registry.py")
+    registry = repo / "governance/kpgs-vnext/skills/registry.json"
+    registry.parent.mkdir(parents=True)
+    registry.write_text(
+        json.dumps(
+            {
+                "registry_version": "1.0.0",
+                "authority": "governance/kpgs-vnext/skills",
+                "selection_policy": {
+                    "production_states": ["validated", "approved"],
+                    "require_capability_lease": True,
+                    "require_provenance": True,
+                    "require_license_status": True,
+                },
+                "skills": [],
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_create_workflow_scaffolds_versions_registers_and_validates(tmp_path: Path) -> None:
+    module = load_module()
+    seed_repo(tmp_path)
+    package_root = tmp_path / "governance/kpgs-vnext/skills/core"
+    registry = tmp_path / "governance/kpgs-vnext/skills/registry.json"
+
+    args = module.argparse.Namespace(
+        repo_root=tmp_path,
+        registry=registry,
+        package_root=package_root,
+        name="example-governed-skill",
+        version="1.4.0",
+        category="governance",
+        summary="Explain and execute one bounded governed example.",
+        capability="example.execute",
+        resource_scope="active-task",
+        authority_class="canonical-core",
+        tag=["example", "governance"],
+        command="create",
+    )
+    package = module.create_workflow(args)
+
+    manifest = json.loads((package / "skill.json").read_text(encoding="utf-8"))
+    registry_value = json.loads(registry.read_text(encoding="utf-8"))
+    assert manifest["name"] == "example-governed-skill"
+    assert manifest["version"] == "1.4.0"
+    assert manifest["state"] == "draft"
+    assert manifest["required_capabilities"] == [
+        {"name": "example.execute", "resource_scope": "active-task", "optional": False}
+    ]
+    assert "what it can access" in (package / "SKILL.md").read_text(encoding="utf-8").lower()
+    assert registry_value["skills"][0]["name"] == "example-governed-skill"
+    assert registry_value["skills"][0]["version"] == "1.4.0"
+    assert registry_value["skills"][0]["package_path"] == "governance/kpgs-vnext/skills/core/example-governed-skill"
+
+    # Re-run the canonical validator against the newly generated package.
+    module.validate(repo_root=tmp_path, registry_path=registry)
+
+
+def test_failed_registration_does_not_duplicate_identity(tmp_path: Path) -> None:
+    module = load_module()
+    seed_repo(tmp_path)
+    package_root = tmp_path / "governance/kpgs-vnext/skills/core"
+    registry = tmp_path / "governance/kpgs-vnext/skills/registry.json"
+    package = module.scaffold(
+        repo_root=tmp_path,
+        package_root=package_root,
+        name="single-identity",
+        version="0.1.0",
+        category="demo",
+        summary="One identity only.",
+        capability="demo.execute",
+        resource_scope="active-task",
+    )
+    module.register(
+        repo_root=tmp_path,
+        registry_path=registry,
+        package_dir=package,
+        authority_class="canonical-core",
+        summary="One identity only.",
+        tags=["demo"],
+    )
+
+    try:
+        module.register(
+            repo_root=tmp_path,
+            registry_path=registry,
+            package_dir=package,
+            authority_class="canonical-core",
+            summary="One identity only.",
+            tags=["demo"],
+        )
+    except module.SkillPackageWorkflowError as exc:
+        assert "already contains" in str(exc)
+    else:
+        raise AssertionError("duplicate skill identity was not rejected")


### PR DESCRIPTION
Closes #37.

## Canonical skill runtime

Completes the canonical package/runtime membrane without turning discovery into authority.

- one-command draft scaffold → register → conformance validate workflow;
- canonical registry path containment, identity, manifest state, platform, schema-ref, capability, provenance/license/source-relationship and validation-method checks;
- production selection requires **both** `validated|approved` state **and** `verified-compatible` licensing;
- unresolved/incompatible licensing remains non-production-loadable even if package state later changes;
- injected Sovereign Hub capability authorizer gates every non-optional capability before the handler runs;
- execution receipts bind exact skill version + manifest digest + license status + input/output digests + capability lease decisions + correlation + validation outcome;
- execution-context release is recorded without pretending the upstream lease was revoked;
- scaffolder now emits schema-valid provenance relationship metadata and deliberately leaves new packages `draft` with unresolved licensing;
- registered draft packages remain discoverable but cannot execute in the production runtime.

## Governance boundary

The current repository licensing decision remains `AWAITING_HUMAN_DECISION`. This PR does **not** promote any existing package to `validated`, `approved` or `verified-compatible`; it only makes those production gates machine-enforceable.

## Exact-head promotion receipt

Head: `7dd8fd6587e57a68c4386a072df98d6f24e09c18`

- KPGS vNext Contract Gate run `32200105538` ✅
- CodeQL Advanced run `32200105599` ✅
- Kopano CI Pipeline run `32200105526` ✅

The KPGS gate includes canonical registry validation, canonical skill execution membrane tests, package developer-workflow tests, capability-lease conformance, progressive-update/SWFUS contracts and runtime compilation. The broader CI additionally passed Python matrix, GUI build/lint, CLI package checks and the Agent/KPEFS PoC lane.

Any head movement after this receipt requires re-proof before promotion.