### PR TITLE
feat(dotnet): ship canonical domain adapter preview packages

### DIFF
--- a/.github/workflows/kpgs-dotnet-domain-adapter-proof.yml
+++ b/.github/workflows/kpgs-dotnet-domain-adapter-proof.yml
@@ -4,13 +4,13 @@ on:
   pull_request:
     branches: [master]
     paths:
-      - 'dotnet/Kopano.Kpgs.**'
+      - 'dotnet/Kopano.Kpgs.*/**'
       - 'governance/kpgs-vnext/dotnet/**'
       - '.github/workflows/kpgs-dotnet-domain-adapter-proof.yml'
   push:
     branches: [master]
     paths:
-      - 'dotnet/Kopano.Kpgs.**'
+      - 'dotnet/Kopano.Kpgs.*/**'
       - 'governance/kpgs-vnext/dotnet/**'
       - '.github/workflows/kpgs-dotnet-domain-adapter-proof.yml'
   workflow_dispatch:

--- a/.github/workflows/kpgs-dotnet-domain-adapter-proof.yml
+++ b/.github/workflows/kpgs-dotnet-domain-adapter-proof.yml
@@ -1,0 +1,62 @@
+name: KPGS .NET Domain Adapter Proof
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - 'dotnet/Kopano.Kpgs.**'
+      - 'governance/kpgs-vnext/dotnet/**'
+      - '.github/workflows/kpgs-dotnet-domain-adapter-proof.yml'
+  push:
+    branches: [master]
+    paths:
+      - 'dotnet/Kopano.Kpgs.**'
+      - 'governance/kpgs-vnext/dotnet/**'
+      - '.github/workflows/kpgs-dotnet-domain-adapter-proof.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: kpgs-dotnet-adapter-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  proof:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Restore canonical adapter graph
+        run: dotnet restore dotnet/Kopano.Kpgs.Adapter.Tests/Kopano.Kpgs.Adapter.Tests.csproj
+
+      - name: Build reusable packages and proof harness
+        run: dotnet build dotnet/Kopano.Kpgs.Adapter.Tests/Kopano.Kpgs.Adapter.Tests.csproj --configuration Release --no-restore -warnaserror
+
+      - name: Build reference ASP.NET adapter
+        run: dotnet build dotnet/Kopano.Kpgs.ReferenceAdapter/Kopano.Kpgs.ReferenceAdapter.csproj --configuration Release -warnaserror
+
+      - name: Prove lifecycle, lease denial, idempotency, realtime fallback and rollback
+        run: dotnet run --project dotnet/Kopano.Kpgs.Adapter.Tests/Kopano.Kpgs.Adapter.Tests.csproj --configuration Release --no-build
+
+      - name: Pack canonical preview packages
+        run: |
+          mkdir -p artifacts/nuget
+          dotnet pack dotnet/Kopano.Kpgs.Contracts/Kopano.Kpgs.Contracts.csproj --configuration Release --no-build --output artifacts/nuget
+          dotnet pack dotnet/Kopano.Kpgs.Evidence/Kopano.Kpgs.Evidence.csproj --configuration Release --no-build --output artifacts/nuget
+          dotnet pack dotnet/Kopano.Kpgs.Realtime/Kopano.Kpgs.Realtime.csproj --configuration Release --no-build --output artifacts/nuget
+          dotnet pack dotnet/Kopano.Kpgs.Adapter/Kopano.Kpgs.Adapter.csproj --configuration Release --no-build --output artifacts/nuget
+
+      - name: Upload preview package evidence
+        uses: actions/upload-artifact@v6
+        with:
+          name: kpgs-dotnet-adapter-preview-${{ github.sha }}
+          path: artifacts/nuget/*.nupkg
+          if-no-files-found: error
+          retention-days: 14

--- a/dotnet/Kopano.Kpgs.Adapter.Tests/Kopano.Kpgs.Adapter.Tests.csproj
+++ b/dotnet/Kopano.Kpgs.Adapter.Tests/Kopano.Kpgs.Adapter.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Kopano.Kpgs.Adapter/Kopano.Kpgs.Adapter.csproj" />
+    <ProjectReference Include="../Kopano.Kpgs.Contracts/Kopano.Kpgs.Contracts.csproj" />
+    <ProjectReference Include="../Kopano.Kpgs.Evidence/Kopano.Kpgs.Evidence.csproj" />
+    <ProjectReference Include="../Kopano.Kpgs.Realtime/Kopano.Kpgs.Realtime.csproj" />
+  </ItemGroup>
+</Project>

--- a/dotnet/Kopano.Kpgs.Adapter.Tests/Program.cs
+++ b/dotnet/Kopano.Kpgs.Adapter.Tests/Program.cs
@@ -1,0 +1,140 @@
+using Kopano.Kpgs.Adapter;
+using Kopano.Kpgs.Contracts;
+using Kopano.Kpgs.Evidence;
+using Kopano.Kpgs.Realtime;
+
+static void Assert(bool condition, string message)
+{
+    if (!condition) throw new InvalidOperationException(message);
+}
+
+var manifest = new DomainManifest("example.kopanolabs.com", "proof-adapter", "0.1.0-preview.1", "1.0", "kpgs://spec/domain-proof");
+var options = new KpgsAdapterOptions(manifest, TimeSpan.FromMilliseconds(100), 1, 2);
+var evidence = new InMemoryEvidenceSink();
+var hub = new ProofHub();
+var adapter = new KpgsDomainAdapter(options, hub, evidence);
+await adapter.RegisterAsync();
+Assert(hub.Registered, "domain registration did not execute");
+Assert((await adapter.HealthAsync()).Ready, "adapter is not ready");
+Assert(adapter.Version("1.9").Compatible, "same protocol major should be compatible");
+Assert(!adapter.Version("2.0").Compatible, "different protocol major must be incompatible");
+
+var identity = new DomainIdentity("human:1", "human", "tenant:1", new Dictionary<string, string>());
+var context = new HubContext(manifest.EstateProperty, "tenant:1", "domain:1", "task:1", "corr:1", identity, manifest.GoverningSpecRef);
+var request = new GovernedTaskRequest("task:1", "corr:1", manifest.GoverningSpecRef, new { goal = "proof" }, "idem:create:1");
+var created = await adapter.CreateTaskAsync(context, request);
+var replay = await adapter.CreateTaskAsync(context, request);
+Assert(created == replay, "idempotent task replay changed the result");
+Assert(hub.CreateCalls == 1, "idempotent task replay executed twice");
+Assert(evidence.Items.Count == 1 && evidence.Items[0].AuthorityEffect == "none", "execution evidence missing or promoted authority");
+
+hub.Allow = false;
+try
+{
+    await adapter.ExecuteCommandAsync(context, new GovernedCommand("cmd:deny", "approve", null, "idem:deny:1", "corr:deny"));
+    throw new InvalidOperationException("denied capability executed");
+}
+catch (CapabilityDeniedException)
+{
+    Assert(hub.CommandCalls == 0, "denied command reached the privileged hub operation");
+}
+hub.Allow = true;
+
+var fallbackLog = new List<RealtimeTransportKind>();
+var realtime = new KpgsRealtimeClient(
+    new ProofSnapshotSource(),
+    [
+        new ProofTransport(RealtimeTransportKind.Polling, true, fallbackLog),
+        new ProofTransport(RealtimeTransportKind.ServerSentEvents, true, fallbackLog),
+        new ProofTransport(RealtimeTransportKind.WebSocket, false, fallbackLog),
+    ]);
+var connection = await realtime.ConnectAsync("task:1");
+Assert(connection.Transport == RealtimeTransportKind.ServerSentEvents, "realtime fallback did not prefer WS then SSE");
+Assert(fallbackLog.SequenceEqual([RealtimeTransportKind.WebSocket, RealtimeTransportKind.ServerSentEvents]), "fallback order drifted");
+Assert(connection.Snapshot.Version == 4, "reconnect did not restore snapshot first");
+var sequences = new List<long>();
+await foreach (var evt in connection.Events) sequences.Add(evt.Sequence);
+Assert(sequences.SequenceEqual([5L, 6L]), "duplicate/old realtime events were not filtered");
+
+var removal = new KpgsDomainAdapter(options, new UnreadyHub(), new InMemoryEvidenceSink());
+try
+{
+    await removal.RegisterAsync();
+    throw new InvalidOperationException("rejected registration was promoted");
+}
+catch (InvalidOperationException)
+{
+    // Adapter removal/rollback leaves the domain app independent; failure is explicit.
+}
+
+Console.WriteLine("KPGS .NET DOMAIN ADAPTER PROOF PASS");
+
+sealed class ProofHub : IKpgsHubClient
+{
+    public bool Registered { get; private set; }
+    public bool Allow { get; set; } = true;
+    public int CreateCalls { get; private set; }
+    public int CommandCalls { get; private set; }
+
+    public Task<bool> RegisterAsync(DomainManifest manifest, CancellationToken cancellationToken)
+    {
+        Registered = true;
+        return Task.FromResult(true);
+    }
+
+    public Task<bool> IsReadyAsync(CancellationToken cancellationToken) => Task.FromResult(true);
+    public Task<CapabilityDecision> RequestCapabilityAsync(HubContext context, CapabilityRequest request, CancellationToken cancellationToken) =>
+        Task.FromResult(new CapabilityDecision(Allow, "policy://proof", Allow ? "lease:proof" : null, Allow ? DateTimeOffset.UtcNow.AddMinutes(1) : null, Allow ? "allowed" : "not permitted for this task"));
+
+    public Task<GovernedTaskSnapshot> CreateTaskAsync(HubContext context, GovernedTaskRequest request, string leaseToken, CancellationToken cancellationToken)
+    {
+        CreateCalls++;
+        return Task.FromResult(new GovernedTaskSnapshot(request.TaskId, "created", 1, ["continue"], "created", request.CorrelationId));
+    }
+
+    public Task<GovernedTaskSnapshot> ExecuteCommandAsync(HubContext context, GovernedCommand command, string leaseToken, CancellationToken cancellationToken)
+    {
+        CommandCalls++;
+        return Task.FromResult(new GovernedTaskSnapshot(context.TaskId, command.Name, 2, [], command.Name, command.CorrelationId));
+    }
+
+    public Task<GovernedTaskSnapshot?> GetSessionAsync(HubContext context, CancellationToken cancellationToken) => Task.FromResult<GovernedTaskSnapshot?>(null);
+    public Task<EvidenceSummary> GetEvidenceAsync(HubContext context, CancellationToken cancellationToken) => Task.FromResult(new EvidenceSummary(context.TaskId, context.CorrelationId, [], "proof"));
+}
+
+sealed class UnreadyHub : IKpgsHubClient
+{
+    public Task<bool> RegisterAsync(DomainManifest manifest, CancellationToken cancellationToken) => Task.FromResult(false);
+    public Task<bool> IsReadyAsync(CancellationToken cancellationToken) => Task.FromResult(false);
+    public Task<CapabilityDecision> RequestCapabilityAsync(HubContext context, CapabilityRequest request, CancellationToken cancellationToken) => throw new InvalidOperationException();
+    public Task<GovernedTaskSnapshot> CreateTaskAsync(HubContext context, GovernedTaskRequest request, string leaseToken, CancellationToken cancellationToken) => throw new InvalidOperationException();
+    public Task<GovernedTaskSnapshot> ExecuteCommandAsync(HubContext context, GovernedCommand command, string leaseToken, CancellationToken cancellationToken) => throw new InvalidOperationException();
+    public Task<GovernedTaskSnapshot?> GetSessionAsync(HubContext context, CancellationToken cancellationToken) => throw new InvalidOperationException();
+    public Task<EvidenceSummary> GetEvidenceAsync(HubContext context, CancellationToken cancellationToken) => throw new InvalidOperationException();
+}
+
+sealed class ProofSnapshotSource : IKpgsSnapshotSource
+{
+    public Task<RealtimeSnapshot> GetSnapshotAsync(string taskId, CancellationToken cancellationToken) =>
+        Task.FromResult(new RealtimeSnapshot(taskId, 4, []));
+}
+
+sealed class ProofTransport(RealtimeTransportKind kind, bool available, List<RealtimeTransportKind> log) : IKpgsRealtimeTransport
+{
+    public RealtimeTransportKind Kind => kind;
+
+    public Task<bool> ConnectAsync(string taskId, CancellationToken cancellationToken)
+    {
+        log.Add(kind);
+        return Task.FromResult(available);
+    }
+
+    public async IAsyncEnumerable<RealtimeEvent> ReadAsync(string taskId, long afterSequence, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        foreach (var sequence in new long[] { 4, 5, 5, 6 })
+        {
+            await Task.Yield();
+            yield return new RealtimeEvent(sequence, taskId, "proof", new { sequence }, "corr:realtime", DateTimeOffset.UtcNow);
+        }
+    }
+}

--- a/dotnet/Kopano.Kpgs.Adapter/Adapter.cs
+++ b/dotnet/Kopano.Kpgs.Adapter/Adapter.cs
@@ -1,0 +1,154 @@
+using System.Collections.Concurrent;
+using Kopano.Kpgs.Contracts;
+using Kopano.Kpgs.Evidence;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace Kopano.Kpgs.Adapter;
+
+public sealed record KpgsAdapterOptions(
+    DomainManifest Manifest,
+    TimeSpan RequestTimeout,
+    int SafeRetryCount,
+    int CircuitFailureThreshold);
+
+public interface IKpgsSecretProvider
+{
+    ValueTask<string?> ResolveReferenceAsync(string reference, CancellationToken cancellationToken = default);
+}
+
+public interface IKpgsHubClient
+{
+    Task<bool> RegisterAsync(DomainManifest manifest, CancellationToken cancellationToken);
+    Task<bool> IsReadyAsync(CancellationToken cancellationToken);
+    Task<CapabilityDecision> RequestCapabilityAsync(HubContext context, CapabilityRequest request, CancellationToken cancellationToken);
+    Task<GovernedTaskSnapshot> CreateTaskAsync(HubContext context, GovernedTaskRequest request, string leaseToken, CancellationToken cancellationToken);
+    Task<GovernedTaskSnapshot> ExecuteCommandAsync(HubContext context, GovernedCommand command, string leaseToken, CancellationToken cancellationToken);
+    Task<GovernedTaskSnapshot?> GetSessionAsync(HubContext context, CancellationToken cancellationToken);
+    Task<EvidenceSummary> GetEvidenceAsync(HubContext context, CancellationToken cancellationToken);
+}
+
+public sealed class CapabilityDeniedException(string message) : InvalidOperationException(message);
+
+public sealed class KpgsResiliencePolicy(KpgsAdapterOptions options)
+{
+    private int _failures;
+    private DateTimeOffset? _openedAt;
+
+    public async Task<T> ExecuteSafeAsync<T>(Func<CancellationToken, Task<T>> action, CancellationToken cancellationToken)
+    {
+        if (_openedAt is not null && DateTimeOffset.UtcNow - _openedAt < options.RequestTimeout)
+            throw new InvalidOperationException("KPGS adapter circuit is open.");
+
+        Exception? last = null;
+        for (var attempt = 0; attempt <= options.SafeRetryCount; attempt++)
+        {
+            using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeout.CancelAfter(options.RequestTimeout);
+            try
+            {
+                var result = await action(timeout.Token);
+                _failures = 0;
+                _openedAt = null;
+                return result;
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException || !cancellationToken.IsCancellationRequested)
+            {
+                last = ex;
+                _failures++;
+                if (_failures >= options.CircuitFailureThreshold) _openedAt = DateTimeOffset.UtcNow;
+                if (attempt == options.SafeRetryCount) break;
+            }
+        }
+        throw last ?? new InvalidOperationException("KPGS safe operation failed.");
+    }
+}
+
+public sealed class KpgsDomainAdapter(
+    KpgsAdapterOptions options,
+    IKpgsHubClient hub,
+    IKpgsEvidenceSink evidence)
+{
+    private readonly ConcurrentDictionary<string, GovernedTaskSnapshot> _idempotentResults = new(StringComparer.Ordinal);
+    private readonly KpgsResiliencePolicy _resilience = new(options);
+
+    public DomainManifest Manifest => options.Manifest;
+
+    public async Task<AdapterHealth> HealthAsync(CancellationToken cancellationToken = default)
+    {
+        var ready = await _resilience.ExecuteSafeAsync(hub.IsReadyAsync, cancellationToken);
+        return new AdapterHealth(true, ready, ready ? "ready" : "unavailable", KpgsProtocol.Current, DateTimeOffset.UtcNow);
+    }
+
+    public AdapterVersionInfo Version(string requestedProtocol = KpgsProtocol.Current) =>
+        new(options.Manifest.AdapterId, options.Manifest.AdapterVersion, KpgsProtocol.Current, KpgsProtocol.IsCompatible(requestedProtocol));
+
+    public async Task RegisterAsync(CancellationToken cancellationToken = default)
+    {
+        if (!KpgsProtocol.IsCompatible(options.Manifest.ProtocolVersion))
+            throw new InvalidOperationException("Domain manifest protocol is incompatible with this adapter.");
+        var registered = await _resilience.ExecuteSafeAsync(ct => hub.RegisterAsync(options.Manifest, ct), cancellationToken);
+        if (!registered) throw new InvalidOperationException("Sovereign Hub rejected domain registration.");
+    }
+
+    public async Task<GovernedTaskSnapshot> CreateTaskAsync(HubContext context, GovernedTaskRequest request, CancellationToken cancellationToken = default)
+    {
+        if (_idempotentResults.TryGetValue(request.IdempotencyKey, out var replay)) return replay;
+        var lease = await RequireLeaseAsync(context, new CapabilityRequest("task.create", $"task:{request.TaskId}", request.IdempotencyKey), cancellationToken);
+        // Non-idempotent business execution is never transparently retried here. The
+        // caller-supplied key and Hub remain the durable replay authority.
+        var result = await hub.CreateTaskAsync(context, request, lease, cancellationToken);
+        _idempotentResults.TryAdd(request.IdempotencyKey, result);
+        await evidence.EmitAsync(EvidenceFactory.Create(context, "task-created", $"kpgs://task/{request.TaskId}", result), cancellationToken);
+        return result;
+    }
+
+    public async Task<GovernedTaskSnapshot> ExecuteCommandAsync(HubContext context, GovernedCommand command, CancellationToken cancellationToken = default)
+    {
+        if (_idempotentResults.TryGetValue(command.IdempotencyKey, out var replay)) return replay;
+        var lease = await RequireLeaseAsync(context, new CapabilityRequest($"task.command.{command.Name}", $"task:{context.TaskId}", command.IdempotencyKey), cancellationToken);
+        var result = await hub.ExecuteCommandAsync(context, command, lease, cancellationToken);
+        _idempotentResults.TryAdd(command.IdempotencyKey, result);
+        await evidence.EmitAsync(EvidenceFactory.Create(context, "task-command", $"kpgs://command/{command.CommandId}", result), cancellationToken);
+        return result;
+    }
+
+    public Task<GovernedTaskSnapshot?> GetSessionAsync(HubContext context, CancellationToken cancellationToken = default) =>
+        _resilience.ExecuteSafeAsync(ct => hub.GetSessionAsync(context, ct), cancellationToken);
+
+    public Task<EvidenceSummary> GetEvidenceAsync(HubContext context, CancellationToken cancellationToken = default) =>
+        _resilience.ExecuteSafeAsync(ct => hub.GetEvidenceAsync(context, ct), cancellationToken);
+
+    private async Task<string> RequireLeaseAsync(HubContext context, CapabilityRequest request, CancellationToken cancellationToken)
+    {
+        var decision = await _resilience.ExecuteSafeAsync(ct => hub.RequestCapabilityAsync(context, request, ct), cancellationToken);
+        if (!decision.Allowed || string.IsNullOrWhiteSpace(decision.LeaseToken))
+            throw new CapabilityDeniedException(decision.UserSafeReason);
+        return decision.LeaseToken;
+    }
+}
+
+public static class KpgsAdapterEndpointExtensions
+{
+    public static IEndpointRouteBuilder MapKpgsAdapter(this IEndpointRouteBuilder endpoints, KpgsDomainAdapter adapter, Func<HttpContext, HubContext> contextFactory)
+    {
+        endpoints.MapGet("/kpgs/health", async (CancellationToken ct) => Results.Ok(await adapter.HealthAsync(ct)));
+        endpoints.MapGet("/kpgs/version", (string? protocol) => Results.Ok(adapter.Version(protocol ?? KpgsProtocol.Current)));
+        endpoints.MapGet("/kpgs/session/{id}", async (HttpContext http, CancellationToken ct) =>
+            Results.Ok(await adapter.GetSessionAsync(contextFactory(http), ct)));
+        endpoints.MapGet("/kpgs/tasks/{id}/evidence", async (HttpContext http, CancellationToken ct) =>
+            Results.Ok(await adapter.GetEvidenceAsync(contextFactory(http), ct)));
+        endpoints.MapPost("/kpgs/tasks", async (HttpContext http, GovernedTaskRequest request, CancellationToken ct) =>
+        {
+            try { return Results.Ok(await adapter.CreateTaskAsync(contextFactory(http), request, ct)); }
+            catch (CapabilityDeniedException ex) { return Results.Json(new { error = ex.Message }, statusCode: StatusCodes.Status403Forbidden); }
+        });
+        endpoints.MapPost("/kpgs/tasks/{id}/commands", async (HttpContext http, GovernedCommand command, CancellationToken ct) =>
+        {
+            try { return Results.Ok(await adapter.ExecuteCommandAsync(contextFactory(http), command, ct)); }
+            catch (CapabilityDeniedException ex) { return Results.Json(new { error = ex.Message }, statusCode: StatusCodes.Status403Forbidden); }
+        });
+        return endpoints;
+    }
+}

--- a/dotnet/Kopano.Kpgs.Adapter/Kopano.Kpgs.Adapter.csproj
+++ b/dotnet/Kopano.Kpgs.Adapter/Kopano.Kpgs.Adapter.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <PackageId>Kopano.Kpgs.Adapter</PackageId>
+    <Version>0.1.0-preview.1</Version>
+  </PropertyGroup>
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <ProjectReference Include="../Kopano.Kpgs.Contracts/Kopano.Kpgs.Contracts.csproj" />
+    <ProjectReference Include="../Kopano.Kpgs.Evidence/Kopano.Kpgs.Evidence.csproj" />
+    <ProjectReference Include="../Kopano.Kpgs.Realtime/Kopano.Kpgs.Realtime.csproj" />
+  </ItemGroup>
+</Project>

--- a/dotnet/Kopano.Kpgs.Contracts/Contracts.cs
+++ b/dotnet/Kopano.Kpgs.Contracts/Contracts.cs
@@ -1,0 +1,100 @@
+namespace Kopano.Kpgs.Contracts;
+
+public static class KpgsProtocol
+{
+    public const string Current = "1.0";
+
+    public static bool IsCompatible(string requested, string supported = Current)
+    {
+        static int Major(string value) => int.TryParse(value.Split('.', 2)[0], out var major) ? major : -1;
+        return Major(requested) >= 0 && Major(requested) == Major(supported);
+    }
+}
+
+public sealed record DomainManifest(
+    string EstateProperty,
+    string AdapterId,
+    string AdapterVersion,
+    string ProtocolVersion,
+    string GoverningSpecRef);
+
+public sealed record DomainIdentity(
+    string SubjectId,
+    string SubjectKind,
+    string TenantId,
+    IReadOnlyDictionary<string, string> Claims);
+
+public sealed record HubContext(
+    string EstateProperty,
+    string TenantId,
+    string DomainId,
+    string TaskId,
+    string CorrelationId,
+    DomainIdentity Identity,
+    string GoverningSpecRef);
+
+public sealed record CapabilityRequest(
+    string Capability,
+    string ResourceScope,
+    string IdempotencyKey);
+
+public sealed record CapabilityDecision(
+    bool Allowed,
+    string DecisionRef,
+    string? LeaseToken,
+    DateTimeOffset? ExpiresAt,
+    string UserSafeReason);
+
+public sealed record GovernedTaskRequest(
+    string TaskId,
+    string CorrelationId,
+    string GoverningSpecRef,
+    object Input,
+    string IdempotencyKey);
+
+public sealed record GovernedTaskSnapshot(
+    string TaskId,
+    string Status,
+    long Version,
+    IReadOnlyList<string> NextActions,
+    string UserSafeExplanation,
+    string CorrelationId);
+
+public sealed record GovernedCommand(
+    string CommandId,
+    string Name,
+    object? Payload,
+    string IdempotencyKey,
+    string CorrelationId);
+
+public sealed record EvidenceSummary(
+    string TaskId,
+    string CorrelationId,
+    IReadOnlyList<string> EvidenceRefs,
+    string VerificationStatus);
+
+public sealed record AdapterHealth(
+    bool Live,
+    bool Ready,
+    string HubStatus,
+    string ProtocolVersion,
+    DateTimeOffset CheckedAt);
+
+public sealed record AdapterVersionInfo(
+    string AdapterId,
+    string AdapterVersion,
+    string ProtocolVersion,
+    bool Compatible);
+
+public sealed record RealtimeEvent(
+    long Sequence,
+    string TaskId,
+    string EventType,
+    object Payload,
+    string CorrelationId,
+    DateTimeOffset OccurredAt);
+
+public sealed record RealtimeSnapshot(
+    string TaskId,
+    long Version,
+    IReadOnlyList<RealtimeEvent> Events);

--- a/dotnet/Kopano.Kpgs.Contracts/Kopano.Kpgs.Contracts.csproj
+++ b/dotnet/Kopano.Kpgs.Contracts/Kopano.Kpgs.Contracts.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <PackageId>Kopano.Kpgs.Contracts</PackageId>
+    <Version>0.1.0-preview.1</Version>
+    <Description>Language-neutral KPGS domain-adapter contracts for existing PWAs and services.</Description>
+  </PropertyGroup>
+</Project>

--- a/dotnet/Kopano.Kpgs.Evidence/Evidence.cs
+++ b/dotnet/Kopano.Kpgs.Evidence/Evidence.cs
@@ -1,0 +1,55 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Kopano.Kpgs.Contracts;
+
+namespace Kopano.Kpgs.Evidence;
+
+public sealed record AdapterEvidence(
+    string Schema,
+    string EstateProperty,
+    string TaskId,
+    string CorrelationId,
+    string Kind,
+    string EvidenceRef,
+    string PayloadDigest,
+    DateTimeOffset CreatedAt,
+    string AuthorityEffect = "none");
+
+public interface IKpgsEvidenceSink
+{
+    ValueTask EmitAsync(AdapterEvidence evidence, CancellationToken cancellationToken = default);
+}
+
+public sealed class InMemoryEvidenceSink : IKpgsEvidenceSink
+{
+    private readonly List<AdapterEvidence> _items = [];
+    public IReadOnlyList<AdapterEvidence> Items => _items;
+
+    public ValueTask EmitAsync(AdapterEvidence evidence, CancellationToken cancellationToken = default)
+    {
+        _items.Add(evidence);
+        return ValueTask.CompletedTask;
+    }
+}
+
+public static class EvidenceFactory
+{
+    public static AdapterEvidence Create(HubContext context, string kind, string evidenceRef, object payload)
+    {
+        if (string.IsNullOrWhiteSpace(evidenceRef) || !evidenceRef.Contains("://", StringComparison.Ordinal))
+            throw new ArgumentException("Evidence references must be governed URIs.", nameof(evidenceRef));
+
+        var json = JsonSerializer.Serialize(payload);
+        var digest = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(json))).ToLowerInvariant();
+        return new AdapterEvidence(
+            "kpgs.dotnet-adapter-evidence.v1",
+            context.EstateProperty,
+            context.TaskId,
+            context.CorrelationId,
+            kind,
+            evidenceRef,
+            digest,
+            DateTimeOffset.UtcNow);
+    }
+}

--- a/dotnet/Kopano.Kpgs.Evidence/Kopano.Kpgs.Evidence.csproj
+++ b/dotnet/Kopano.Kpgs.Evidence/Kopano.Kpgs.Evidence.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <PackageId>Kopano.Kpgs.Evidence</PackageId>
+    <Version>0.1.0-preview.1</Version>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Kopano.Kpgs.Contracts/Kopano.Kpgs.Contracts.csproj" />
+  </ItemGroup>
+</Project>

--- a/dotnet/Kopano.Kpgs.Realtime/Kopano.Kpgs.Realtime.csproj
+++ b/dotnet/Kopano.Kpgs.Realtime/Kopano.Kpgs.Realtime.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <PackageId>Kopano.Kpgs.Realtime</PackageId>
+    <Version>0.1.0-preview.1</Version>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Kopano.Kpgs.Contracts/Kopano.Kpgs.Contracts.csproj" />
+  </ItemGroup>
+</Project>

--- a/dotnet/Kopano.Kpgs.Realtime/Realtime.cs
+++ b/dotnet/Kopano.Kpgs.Realtime/Realtime.cs
@@ -1,0 +1,73 @@
+using Kopano.Kpgs.Contracts;
+
+namespace Kopano.Kpgs.Realtime;
+
+public enum RealtimeTransportKind
+{
+    WebSocket,
+    ServerSentEvents,
+    Polling,
+}
+
+public interface IKpgsRealtimeTransport
+{
+    RealtimeTransportKind Kind { get; }
+    Task<bool> ConnectAsync(string taskId, CancellationToken cancellationToken);
+    IAsyncEnumerable<RealtimeEvent> ReadAsync(string taskId, long afterSequence, CancellationToken cancellationToken);
+}
+
+public interface IKpgsSnapshotSource
+{
+    Task<RealtimeSnapshot> GetSnapshotAsync(string taskId, CancellationToken cancellationToken);
+}
+
+public sealed record RealtimeConnection(
+    RealtimeTransportKind Transport,
+    RealtimeSnapshot Snapshot,
+    IAsyncEnumerable<RealtimeEvent> Events);
+
+public sealed class KpgsRealtimeClient(
+    IKpgsSnapshotSource snapshotSource,
+    IEnumerable<IKpgsRealtimeTransport> transports)
+{
+    private readonly IReadOnlyList<IKpgsRealtimeTransport> _transports = transports
+        .OrderBy(t => t.Kind switch
+        {
+            RealtimeTransportKind.WebSocket => 0,
+            RealtimeTransportKind.ServerSentEvents => 1,
+            _ => 2,
+        })
+        .ToArray();
+
+    public async Task<RealtimeConnection> ConnectAsync(string taskId, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(taskId)) throw new ArgumentException("taskId is required", nameof(taskId));
+
+        // Recovery is source-first: snapshot canonical state before accepting deltas.
+        var snapshot = await snapshotSource.GetSnapshotAsync(taskId, cancellationToken);
+        foreach (var transport in _transports)
+        {
+            if (!await transport.ConnectAsync(taskId, cancellationToken)) continue;
+            return new RealtimeConnection(
+                transport.Kind,
+                snapshot,
+                Deduplicate(transport.ReadAsync(taskId, snapshot.Version, cancellationToken), snapshot.Version, cancellationToken));
+        }
+
+        throw new InvalidOperationException("No governed realtime transport is available.");
+    }
+
+    private static async IAsyncEnumerable<RealtimeEvent> Deduplicate(
+        IAsyncEnumerable<RealtimeEvent> source,
+        long floor,
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        var last = floor;
+        await foreach (var item in source.WithCancellation(cancellationToken))
+        {
+            if (item.Sequence <= last) continue;
+            last = item.Sequence;
+            yield return item;
+        }
+    }
+}

--- a/dotnet/Kopano.Kpgs.ReferenceAdapter/Kopano.Kpgs.ReferenceAdapter.csproj
+++ b/dotnet/Kopano.Kpgs.ReferenceAdapter/Kopano.Kpgs.ReferenceAdapter.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Kopano.Kpgs.Adapter/Kopano.Kpgs.Adapter.csproj" />
+    <ProjectReference Include="../Kopano.Kpgs.Contracts/Kopano.Kpgs.Contracts.csproj" />
+    <ProjectReference Include="../Kopano.Kpgs.Evidence/Kopano.Kpgs.Evidence.csproj" />
+  </ItemGroup>
+</Project>

--- a/dotnet/Kopano.Kpgs.ReferenceAdapter/Program.cs
+++ b/dotnet/Kopano.Kpgs.ReferenceAdapter/Program.cs
@@ -1,0 +1,73 @@
+using System.Collections.Concurrent;
+using Kopano.Kpgs.Adapter;
+using Kopano.Kpgs.Contracts;
+using Kopano.Kpgs.Evidence;
+
+var builder = WebApplication.CreateBuilder(args);
+var manifest = new DomainManifest(
+    builder.Configuration["KPGS_ESTATE_PROPERTY"] ?? "localhost.kpgs",
+    "reference-dotnet-adapter",
+    "0.1.0-preview.1",
+    KpgsProtocol.Current,
+    "kpgs://spec/dotnet-domain-adapter-v1");
+var options = new KpgsAdapterOptions(manifest, TimeSpan.FromSeconds(5), 2, 3);
+var hub = new LocalMockHub();
+var evidence = new InMemoryEvidenceSink();
+var adapter = new KpgsDomainAdapter(options, hub, evidence);
+await adapter.RegisterAsync();
+
+var app = builder.Build();
+
+HubContext Context(HttpContext http)
+{
+    var taskId = http.Request.RouteValues["id"]?.ToString() ?? http.Request.Headers["X-KPGS-Task"].FirstOrDefault() ?? "new-task";
+    var correlation = http.Request.Headers["X-Correlation-ID"].FirstOrDefault() ?? Guid.NewGuid().ToString("n");
+    return new HubContext(
+        manifest.EstateProperty,
+        "reference-tenant",
+        "reference-domain",
+        taskId,
+        correlation,
+        new DomainIdentity("reference-user", "human", "reference-tenant", new Dictionary<string, string>()),
+        manifest.GoverningSpecRef);
+}
+
+app.MapKpgsAdapter(adapter, Context);
+app.MapGet("/kpgs/evidence", () => Results.Ok(evidence.Items));
+app.Run();
+
+sealed class LocalMockHub : IKpgsHubClient
+{
+    private readonly ConcurrentDictionary<string, GovernedTaskSnapshot> _tasks = new(StringComparer.Ordinal);
+
+    public Task<bool> RegisterAsync(DomainManifest manifest, CancellationToken cancellationToken) => Task.FromResult(true);
+    public Task<bool> IsReadyAsync(CancellationToken cancellationToken) => Task.FromResult(true);
+
+    public Task<CapabilityDecision> RequestCapabilityAsync(HubContext context, CapabilityRequest request, CancellationToken cancellationToken) =>
+        Task.FromResult(new CapabilityDecision(true, $"policy://local/{request.Capability}", "local-short-lived-lease", DateTimeOffset.UtcNow.AddMinutes(5), "Allowed by local development policy."));
+
+    public Task<GovernedTaskSnapshot> CreateTaskAsync(HubContext context, GovernedTaskRequest request, string leaseToken, CancellationToken cancellationToken)
+    {
+        var snapshot = new GovernedTaskSnapshot(request.TaskId, "created", 1, ["continue", "cancel"], "Task created through the local KPGS mock.", request.CorrelationId);
+        _tasks[request.TaskId] = snapshot;
+        return Task.FromResult(snapshot);
+    }
+
+    public Task<GovernedTaskSnapshot> ExecuteCommandAsync(HubContext context, GovernedCommand command, string leaseToken, CancellationToken cancellationToken)
+    {
+        var prior = _tasks.TryGetValue(context.TaskId, out var found)
+            ? found
+            : new GovernedTaskSnapshot(context.TaskId, "missing", 0, [], "Task does not exist.", command.CorrelationId);
+        var next = prior with { Status = command.Name, Version = prior.Version + 1, CorrelationId = command.CorrelationId };
+        _tasks[context.TaskId] = next;
+        return Task.FromResult(next);
+    }
+
+    public Task<GovernedTaskSnapshot?> GetSessionAsync(HubContext context, CancellationToken cancellationToken) =>
+        Task.FromResult(_tasks.TryGetValue(context.TaskId, out var value) ? value : null);
+
+    public Task<EvidenceSummary> GetEvidenceAsync(HubContext context, CancellationToken cancellationToken) =>
+        Task.FromResult(new EvidenceSummary(context.TaskId, context.CorrelationId, [$"kpgs://task/{context.TaskId}"], "local-development"));
+}
+
+public partial class Program;

--- a/governance/kpgs-vnext/dotnet/DOMAIN_ADAPTER.md
+++ b/governance/kpgs-vnext/dotnet/DOMAIN_ADAPTER.md
@@ -10,7 +10,7 @@ The .NET adapter is the stable service/control-plane boundary between an existin
 Existing PWA / Domain UI
         |
         v
-KPGS Domain Adapter (.NET reference implementation)
+KPGS Domain Adapter (.NET)
         |
         v
 Kopano Sovereign Hub
@@ -22,95 +22,130 @@ Kopano Sovereign Hub
         `--> Stateless Renters
 ```
 
-## Proposed package split
+## Executable preview packages
 
 ```text
-Kopano.Kpgs.Contracts
-  DTOs and protocol/version contracts only
+dotnet/Kopano.Kpgs.Contracts
+  DTOs + protocol/version negotiation
 
-Kopano.Kpgs.Adapter
-  ASP.NET Core middleware and Hub client
+dotnet/Kopano.Kpgs.Adapter
+  lease/policy membrane, idempotency, resilience and ASP.NET route mapper
 
-Kopano.Kpgs.Realtime
-  realtime session/event-plane client and fallback semantics
+dotnet/Kopano.Kpgs.Realtime
+  snapshot-first WS → SSE → polling fallback contract
 
-Kopano.Kpgs.Evidence
-  evidence emission and correlation helpers
+dotnet/Kopano.Kpgs.Evidence
+  correlation + evidence digest emission
+
+dotnet/Kopano.Kpgs.ReferenceAdapter
+  local ASP.NET Core reference service + mock Hub
+
+dotnet/Kopano.Kpgs.Adapter.Tests
+  dependency-free executable lifecycle/auth/realtime/rollback proof
 ```
 
-The split keeps domain applications from depending on the complete Hub implementation.
+All four reusable class libraries are configured as versioned NuGet-packable projects. They are preview artifacts; repository build proof does not mean a public NuGet feed publication has occurred.
 
 ## Required HTTP surface
 
-A reference adapter SHOULD expose:
+The reference adapter exposes:
 
 - `GET /kpgs/health` — liveness/readiness summary
 - `GET /kpgs/version` — adapter + protocol compatibility
-- `GET /kpgs/session/{id}` — canonical user-safe workflow snapshot
-- `POST /kpgs/tasks` — create a governed task from an accepted spec/input
-- `POST /kpgs/tasks/{id}/commands` — idempotent user commands/approvals
-- `GET /kpgs/tasks/{id}/evidence` — authorized evidence summary/reference
+- `GET /kpgs/session/{id}` — user-safe workflow snapshot
+- `POST /kpgs/tasks` — governed task creation
+- `POST /kpgs/tasks/{id}/commands` — idempotent governed user commands
+- `GET /kpgs/tasks/{id}/evidence` — authorized evidence summary
 
 Domain-specific routes remain domain-specific.
 
 ## Hub client responsibilities
 
-The adapter MUST:
+`IKpgsHubClient` keeps the adapter bounded to Hub-owned authority. The adapter:
 
-1. register/resolve its estate property;
-2. translate authenticated domain identity into Hub context without inventing authority;
-3. request short-lived capability leases for privileged operations;
-4. bind task requests to a governing specification;
-5. pass renter/skill events through canonical correlation identifiers;
-6. recover live state after transport reconnect from Hub/canonical sources;
-7. emit evidence and release/version metadata;
-8. fail closed when policy/lease verification is unavailable for a privileged action.
+1. registers its estate/domain manifest;
+2. translates authenticated domain identity into `HubContext` without inventing authority;
+3. requests a short-lived capability decision before privileged create/command paths;
+4. binds task requests to governing spec, task, tenant and correlation identity;
+5. emits evidence after admitted operations;
+6. restores realtime state from snapshot before deltas;
+7. exposes health/version compatibility;
+8. fails closed when the Hub rejects registration, readiness or capability admission.
 
-## Resilience primitives
+The adapter itself carries no durable canonical business state. Its process-local idempotency cache is only a front-line duplicate suppressor; the Hub/domain authority remains responsible for durable replay semantics.
 
-The reference package SHOULD provide bounded defaults for:
+## Resilience and idempotency
 
-- request timeout;
-- retry of safe/idempotent operations;
-- idempotency keys;
-- circuit breaker;
-- reconnect/backoff;
-- cancellation;
-- correlation/log context.
+`KpgsResiliencePolicy` provides bounded timeout/retry/circuit behavior only for operations classified as safe reads/control checks. Privileged task creation and commands are **not transparently retried** by the adapter. They carry caller idempotency keys and rely on the Hub/domain authority for durable replay protection.
 
-Retries MUST NOT turn a non-idempotent side effect into duplicate durable work.
+```text
+SAFE READ / HEALTH → bounded retry permitted
+PRIVILEGED MUTATION → capability lease + idempotency key + one Hub call
+TRANSPORT RETRY != PERMISSION TO REPEAT SIDE EFFECT
+```
+
+## Realtime
+
+`KpgsRealtimeClient` follows the canonical event-plane posture:
+
+```text
+canonical snapshot
+→ WebSocket attempt
+→ SSE fallback
+→ governed polling fallback
+→ deduplicate monotonically by sequence
+```
+
+Reconnect obtains a fresh snapshot before consuming deltas. Transport availability never becomes business authority.
 
 ## Authentication and secrets
 
-- No long-lived user/service secret is stored in browser-readable configuration.
-- The adapter may use a server-side secret provider reference.
-- Renter capabilities are short-lived and task/resource scoped.
-- Browser clients never become trusted merely because they possess a UI session.
+- No long-lived user/service secret belongs in browser-readable configuration.
+- `IKpgsSecretProvider` is the server-side secret-provider abstraction; consumers pass references rather than browser secrets.
+- Renter capabilities are task/resource scoped and resolved through the Hub.
+- Browser clients remain untrusted input even when they have an authenticated UI session.
 
-## TypeScript/front-end interoperability
+## Existing JS/TS PWA integration
 
-Canonical JSON schemas under `governance/kpgs-vnext/` are the language-neutral truth. TypeScript types MAY be generated from those schemas or exposed through a tiny client package.
+`governance/kpgs-vnext/dotnet/typescript/kpgs-adapter-client.ts` is the small frontend binding. An existing PWA imports/ports this client and continues using its current React/Next/Vite stack.
 
-The frontend should consume simple concepts such as:
+The browser sees everyday concepts:
 
 - current task status;
 - next available actions;
 - user-safe explanation;
-- approval requirement;
-- offline/reconnect state.
+- approval commands;
+- connectivity/recovery state.
 
-It should not need to implement KPGS policy itself.
+It does not implement KPGS policy and it does not receive Hub authority merely because it can call the adapter.
 
-## Verification before runtime promotion
+## Local reference profile
 
-Actual NuGet/runtime implementation MUST remain unreleased until:
+Run the reference adapter after restoring/building the projects:
 
-- the project builds on its target .NET SDK;
-- contract/schema tests pass;
-- unauthorized capability tests fail closed;
-- retry/idempotency tests pass;
-- realtime reconnect tests pass;
-- at least one existing JS/TS PWA integrates without a frontend rewrite;
-- rollback/removal of the adapter is demonstrated.
+```bash
+dotnet run --project dotnet/Kopano.Kpgs.ReferenceAdapter/Kopano.Kpgs.ReferenceAdapter.csproj
+```
 
-The current GitHub Actions billing lock prevents producing that executable evidence, so this file is a contract, not a claim that the .NET runtime package is already verified.
+The local profile uses an explicit `LocalMockHub` and `localhost.kpgs` estate default. It is development proof only, not a production Sovereign Hub.
+
+## Verification and packaging
+
+The exact-head `.NET Domain Adapter Proof` workflow must:
+
+```text
+dotnet restore
+→ dotnet build -warnaserror
+→ run lifecycle/auth/idempotency/realtime/rollback proof
+→ dotnet pack four reusable packages
+```
+
+Acceptance remains bounded:
+
+```text
+ADAPTER BUILD != PUBLIC NUGET RELEASE
+MOCK HUB != PRODUCTION HUB
+PROCESS IDEMPOTENCY CACHE != DURABLE BUSINESS AUTHORITY
+REALTIME TRANSPORT != AUTHORITY
+PWA INTEGRATION != FRONTEND REWRITE
+```

--- a/governance/kpgs-vnext/dotnet/typescript/kpgs-adapter-client.ts
+++ b/governance/kpgs-vnext/dotnet/typescript/kpgs-adapter-client.ts
@@ -1,0 +1,78 @@
+export type KpgsAdapterVersion = {
+  adapterId: string;
+  adapterVersion: string;
+  protocolVersion: string;
+  compatible: boolean;
+};
+
+export type KpgsTaskSnapshot = {
+  taskId: string;
+  status: string;
+  version: number;
+  nextActions: string[];
+  userSafeExplanation: string;
+  correlationId: string;
+};
+
+export type KpgsTaskRequest = {
+  taskId: string;
+  correlationId: string;
+  governingSpecRef: string;
+  input: unknown;
+  idempotencyKey: string;
+};
+
+export class KpgsAdapterClient {
+  constructor(
+    private readonly baseUrl: string,
+    private readonly fetcher: typeof fetch = fetch,
+  ) {}
+
+  async version(protocol = '1.0'): Promise<KpgsAdapterVersion> {
+    return this.json(`/kpgs/version?protocol=${encodeURIComponent(protocol)}`);
+  }
+
+  async getSession(taskId: string, correlationId: string): Promise<KpgsTaskSnapshot | null> {
+    return this.json(`/kpgs/session/${encodeURIComponent(taskId)}`, {
+      headers: { 'X-Correlation-ID': correlationId },
+    });
+  }
+
+  async createTask(request: KpgsTaskRequest): Promise<KpgsTaskSnapshot> {
+    return this.json('/kpgs/tasks', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-KPGS-Task': request.taskId,
+        'X-Correlation-ID': request.correlationId,
+      },
+      body: JSON.stringify(request),
+    });
+  }
+
+  async command(
+    taskId: string,
+    correlationId: string,
+    command: { commandId: string; name: string; payload?: unknown; idempotencyKey: string },
+  ): Promise<KpgsTaskSnapshot> {
+    return this.json(`/kpgs/tasks/${encodeURIComponent(taskId)}/commands`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-KPGS-Task': taskId,
+        'X-Correlation-ID': correlationId,
+      },
+      body: JSON.stringify({ ...command, correlationId }),
+    });
+  }
+
+  private async json<T>(path: string, init?: RequestInit): Promise<T> {
+    const response = await this.fetcher(new URL(path, this.baseUrl), init);
+    const body = await response.json();
+    if (!response.ok) {
+      const message = body && typeof body === 'object' && 'error' in body ? String(body.error) : `KPGS adapter HTTP ${response.status}`;
+      throw new Error(message);
+    }
+    return body as T;
+  }
+}


### PR DESCRIPTION
## Purpose

Close #36 with an executable, reusable .NET adapter boundary that existing React/Next/Vite/MERN PWAs can consume without being rewritten in .NET.

```text
Existing PWA
→ tiny TS binding / domain adapter HTTP
→ Kopano.Kpgs.Adapter
→ capability/policy lease membrane
→ Sovereign Hub
→ renters / skills / realtime / evidence
```

## Packages

Adds versioned `net10.0` preview packages:

- `Kopano.Kpgs.Contracts` — protocol/version and language-neutral DTO contracts;
- `Kopano.Kpgs.Adapter` — Hub registration, capability-gated mutations, health/version endpoints, idempotency front line and bounded resilience;
- `Kopano.Kpgs.Realtime` — snapshot-first `WebSocket → SSE → polling` fallback with sequence deduplication;
- `Kopano.Kpgs.Evidence` — correlation/evidence digest emission with `authority_effect=none`.

Also adds:

- `Kopano.Kpgs.ReferenceAdapter` local ASP.NET Core reference service + mock Hub;
- dependency-free executable proof harness;
- TypeScript adapter client for existing PWAs;
- exact-head GitHub Actions build/run/pack proof.

## Authority boundaries

The adapter never owns durable canonical business state. Privileged create/command paths require a Hub capability decision and are not transparently retried. The process-local idempotency map is a duplicate-suppression front line only; durable replay authority remains with Hub/domain state.

```text
PWA SESSION != HUB AUTHORITY
ADAPTER != BUSINESS DATABASE
TRANSPORT != AUTHORITY
PROCESS CACHE != DURABLE IDEMPOTENCY
MOCK HUB != PRODUCTION HUB
BUILD/PACK != PUBLIC NUGET RELEASE
```

## Realtime recovery

Reconnect restores a canonical snapshot before deltas and prefers:

`WebSocket → SSE → governed polling`.

Old/duplicate sequence numbers are suppressed. Realtime transport never decides business truth.

## Existing PWA integration

`governance/kpgs-vnext/dotnet/typescript/kpgs-adapter-client.ts` exposes ordinary web concepts (`version`, `session`, `createTask`, `command`) without moving policy into the browser or replacing the frontend stack.

## Exact-head proof

The `.NET Domain Adapter Proof` workflow must:

1. restore the package graph;
2. build with warnings as errors;
3. build the reference ASP.NET adapter;
4. run lifecycle/auth/idempotency/realtime/rollback proof;
5. pack the four reusable preview NuGet artifacts.

Closes #36 only if that exact-head proof passes.