### PR TITLE
feat(dotnet): ship canonical KPGS domain adapter runtime

### DIFF
--- a/.github/workflows/kpgs-dotnet-adapter-proof.yml
+++ b/.github/workflows/kpgs-dotnet-adapter-proof.yml
@@ -1,0 +1,85 @@
+name: KPGS .NET Domain Adapter Proof
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - "dotnet/**"
+      - "governance/kpgs-vnext/dotnet/**"
+      - ".github/workflows/kpgs-dotnet-adapter-proof.yml"
+  push:
+    branches:
+      - "agent/dotnet-domain-adapter-*"
+    paths:
+      - "dotnet/**"
+      - "governance/kpgs-vnext/dotnet/**"
+      - ".github/workflows/kpgs-dotnet-adapter-proof.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: kpgs-dotnet-adapter-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  proof:
+    name: Build · Runtime proof · NuGet pack
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout exact head
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 10 LTS
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Show SDK identity
+        run: dotnet --info
+
+      - name: Build reference adapter and package graph
+        run: dotnet build dotnet/Kopano.Kpgs.Reference/Kopano.Kpgs.Reference.csproj -c Release
+
+      - name: Execute governed adapter proof harness
+        run: dotnet run --project dotnet/Kopano.Kpgs.Tests/Kopano.Kpgs.Tests.csproj -c Release
+
+      - name: Pack canonical adapter packages
+        shell: bash
+        run: |
+          mkdir -p artifacts/nuget
+          for project in Contracts Evidence Realtime Adapter; do
+            dotnet pack "dotnet/Kopano.Kpgs.${project}/Kopano.Kpgs.${project}.csproj" \
+              -c Release \
+              --output artifacts/nuget
+          done
+          test "$(find artifacts/nuget -name '*.nupkg' | wc -l)" -eq 4
+
+      - name: Prove removable PWA binding and docs
+        shell: python
+        run: |
+          from pathlib import Path
+
+          client = Path('dotnet/client/kpgs-client.ts').read_text(encoding='utf-8')
+          docs = Path('governance/kpgs-vnext/dotnet/DOMAIN_ADAPTER.md').read_text(encoding='utf-8')
+          adapter = Path('dotnet/Kopano.Kpgs.Adapter/Adapter.cs').read_text(encoding='utf-8')
+
+          assert 'class KpgsClient' in client
+          assert '/kpgs/tasks' in client
+          assert 'boundaryMarker: "#NB"' in client
+          assert 'The PWA remains a PWA' in docs
+          assert 'Rollback / removal' in docs
+          assert 'RequireCapabilityAsync' in adapter
+          assert 'KpgsIdempotencyConflictException' in adapter
+          assert 'CircuitFailureThreshold' in adapter
+          print('KPGS .NET removable PWA integration proof: PASS')
+
+      - name: Upload NuGet proof artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: kpgs-dotnet-packages
+          path: artifacts/nuget/*.nupkg
+          if-no-files-found: error

--- a/dotnet/Kopano.Kpgs.Adapter/Adapter.cs
+++ b/dotnet/Kopano.Kpgs.Adapter/Adapter.cs
@@ -1,0 +1,539 @@
+using System.Collections.Concurrent;
+using System.Net;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Kopano.Kpgs.Contracts;
+using Kopano.Kpgs.Evidence;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Kopano.Kpgs.Adapter;
+
+public sealed class KpgsAdapterOptions
+{
+    public string EstateProperty { get; set; } = "unconfigured";
+    public string AdapterVersion { get; set; } = "0.1.0";
+    public string ProtocolVersion { get; set; } = KpgsProtocol.Version;
+    public TimeSpan RequestTimeout { get; set; } = TimeSpan.FromSeconds(8);
+    public int SafeRetryCount { get; set; } = 2;
+    public int CircuitFailureThreshold { get; set; } = 3;
+    public TimeSpan CircuitBreakDuration { get; set; } = TimeSpan.FromSeconds(20);
+}
+
+public sealed record DomainRegistration(
+    string EstateProperty,
+    string DomainId,
+    Uri PublicBaseUri,
+    string ProtocolVersion);
+
+public interface IKpgsSecretProvider
+{
+    ValueTask<string?> GetSecretAsync(string reference, CancellationToken cancellationToken = default);
+}
+
+public interface IKpgsIdentityTranslator
+{
+    ValueTask<KpgsIdentityContext> TranslateAsync(HttpContext context, CancellationToken cancellationToken = default);
+}
+
+public interface IKpgsHubClient : ICanonicalSessionReader
+{
+    Task<bool> IsReadyAsync(CancellationToken cancellationToken = default);
+    Task RegisterDomainAsync(DomainRegistration registration, CapabilityDecision decision, CancellationToken cancellationToken = default);
+    Task<CapabilityDecision> ResolveCapabilityAsync(KpgsIdentityContext identity, CapabilityRequest request, CancellationToken cancellationToken = default);
+    Task<TaskSnapshot> CreateTaskAsync(TaskCreateRequest request, KpgsIdentityContext identity, CapabilityDecision decision, CancellationToken cancellationToken = default);
+    Task<TaskSnapshot> SendCommandAsync(string taskId, TaskCommandRequest request, KpgsIdentityContext identity, CapabilityDecision decision, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<EvidenceRecord>> GetEvidenceAsync(string taskId, KpgsIdentityContext identity, CapabilityDecision decision, CancellationToken cancellationToken = default);
+}
+
+public sealed class KpgsAuthorizationException(string message) : InvalidOperationException(message);
+public sealed class KpgsIdempotencyConflictException(string message) : InvalidOperationException(message);
+public sealed class KpgsHubUnavailableException(string message, Exception? inner = null) : Exception(message, inner);
+public sealed class KpgsCircuitOpenException(string message) : Exception(message);
+
+public sealed class InMemoryIdempotencyGate
+{
+    private sealed record Entry(string Fingerprint, Lazy<Task<object?>> Operation);
+    private readonly ConcurrentDictionary<string, Entry> _entries = new(StringComparer.Ordinal);
+
+    public async Task<T> ExecuteOnceAsync<T>(
+        string operationKey,
+        string fingerprint,
+        Func<Task<T>> action)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(operationKey);
+        ArgumentException.ThrowIfNullOrWhiteSpace(fingerprint);
+
+        while (true)
+        {
+            if (_entries.TryGetValue(operationKey, out var existing))
+            {
+                if (!string.Equals(existing.Fingerprint, fingerprint, StringComparison.Ordinal))
+                {
+                    throw new KpgsIdempotencyConflictException(
+                        "Idempotency key is already bound to different governed content.");
+                }
+
+                return (T)(await existing.Operation.Value.ConfigureAwait(false))!;
+            }
+
+            var candidate = new Entry(
+                fingerprint,
+                new Lazy<Task<object?>>(
+                    async () => await action().ConfigureAwait(false),
+                    LazyThreadSafetyMode.ExecutionAndPublication));
+
+            if (_entries.TryAdd(operationKey, candidate))
+            {
+                try
+                {
+                    return (T)(await candidate.Operation.Value.ConfigureAwait(false))!;
+                }
+                catch
+                {
+                    _entries.TryRemove(new KeyValuePair<string, Entry>(operationKey, candidate));
+                    throw;
+                }
+            }
+        }
+    }
+}
+
+/// <summary>
+/// Small dependency-free resilience membrane. Only callers explicitly marked
+/// idempotent are retried. A circuit breaker stops repeated transport pressure.
+/// </summary>
+public sealed class KpgsHubInvoker
+{
+    private readonly KpgsAdapterOptions _options;
+    private readonly object _circuitLock = new();
+    private int _consecutiveFailures;
+    private DateTimeOffset? _circuitOpenUntil;
+
+    public KpgsHubInvoker(KpgsAdapterOptions options) => _options = options;
+
+    public async Task<T> ExecuteAsync<T>(
+        Func<CancellationToken, Task<T>> operation,
+        bool idempotent,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfCircuitOpen();
+        var attempts = idempotent ? Math.Max(1, _options.SafeRetryCount + 1) : 1;
+        Exception? last = null;
+
+        for (var attempt = 1; attempt <= attempts; attempt++)
+        {
+            using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeout.CancelAfter(_options.RequestTimeout);
+            try
+            {
+                var result = await operation(timeout.Token).ConfigureAwait(false);
+                ResetCircuit();
+                return result;
+            }
+            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+            {
+                last = new TimeoutException("KPGS Hub operation exceeded the bounded request timeout.");
+            }
+            catch (HttpRequestException ex) when (ex.StatusCode is null || (int)ex.StatusCode >= 500)
+            {
+                last = ex;
+            }
+
+            RegisterFailure();
+            if (attempt < attempts)
+            {
+                var delay = TimeSpan.FromMilliseconds(100 * Math.Pow(2, attempt - 1));
+                await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        throw new KpgsHubUnavailableException("KPGS Hub operation failed after bounded retry policy.", last);
+    }
+
+    private void ThrowIfCircuitOpen()
+    {
+        lock (_circuitLock)
+        {
+            if (_circuitOpenUntil is { } until)
+            {
+                if (until > DateTimeOffset.UtcNow)
+                {
+                    throw new KpgsCircuitOpenException("KPGS Hub circuit is temporarily open.");
+                }
+                _circuitOpenUntil = null;
+                _consecutiveFailures = 0;
+            }
+        }
+    }
+
+    private void RegisterFailure()
+    {
+        lock (_circuitLock)
+        {
+            _consecutiveFailures++;
+            if (_consecutiveFailures >= Math.Max(1, _options.CircuitFailureThreshold))
+            {
+                _circuitOpenUntil = DateTimeOffset.UtcNow.Add(_options.CircuitBreakDuration);
+            }
+        }
+    }
+
+    private void ResetCircuit()
+    {
+        lock (_circuitLock)
+        {
+            _consecutiveFailures = 0;
+            _circuitOpenUntil = null;
+        }
+    }
+}
+
+public sealed class KpgsAdapterService : ICanonicalSessionReader
+{
+    private readonly IKpgsHubClient _hub;
+    private readonly IKpgsEvidenceSink _evidence;
+    private readonly InMemoryIdempotencyGate _idempotency;
+    private readonly KpgsHubInvoker _invoker;
+    private readonly KpgsAdapterOptions _options;
+
+    public KpgsAdapterService(
+        IKpgsHubClient hub,
+        IKpgsEvidenceSink evidence,
+        InMemoryIdempotencyGate idempotency,
+        KpgsHubInvoker invoker,
+        KpgsAdapterOptions options)
+    {
+        _hub = hub;
+        _evidence = evidence;
+        _idempotency = idempotency;
+        _invoker = invoker;
+        _options = options;
+    }
+
+    public AdapterVersion GetVersion() =>
+        new(
+            Adapter: _options.AdapterVersion,
+            Protocol: _options.ProtocolVersion,
+            TargetFramework: "net10.0",
+            CompatibleProtocols: [KpgsProtocol.Version]);
+
+    public async Task<AdapterHealth> GetHealthAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var ready = await _invoker.ExecuteAsync(
+                ct => _hub.IsReadyAsync(ct),
+                idempotent: true,
+                cancellationToken).ConfigureAwait(false);
+            return new AdapterHealth(
+                ready ? "ready" : "degraded",
+                ready,
+                _options.ProtocolVersion,
+                _options.AdapterVersion,
+                DateTimeOffset.UtcNow);
+        }
+        catch (Exception ex) when (ex is KpgsHubUnavailableException or KpgsCircuitOpenException)
+        {
+            return new AdapterHealth(
+                "degraded",
+                false,
+                _options.ProtocolVersion,
+                _options.AdapterVersion,
+                DateTimeOffset.UtcNow);
+        }
+    }
+
+    public async Task RegisterDomainAsync(
+        DomainRegistration registration,
+        KpgsIdentityContext identity,
+        CancellationToken cancellationToken = default)
+    {
+        var decision = await RequireCapabilityAsync(
+            identity,
+            capability: "domain.register",
+            resourceScope: $"estate:{registration.EstateProperty}",
+            taskId: $"domain:{registration.DomainId}",
+            cancellationToken).ConfigureAwait(false);
+
+        await _invoker.ExecuteAsync(
+            async ct =>
+            {
+                await _hub.RegisterDomainAsync(registration, decision, ct).ConfigureAwait(false);
+                return true;
+            },
+            idempotent: true,
+            cancellationToken).ConfigureAwait(false);
+
+        await EmitAsync(identity.CorrelationId, "domain.register", "PASS", registration.DomainId, decision.LeaseId!, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<TaskSnapshot> GetSessionSnapshotAsync(
+        string sessionId,
+        KpgsIdentityContext identity,
+        CancellationToken cancellationToken = default)
+    {
+        var decision = await RequireCapabilityAsync(
+            identity,
+            "session.read",
+            $"session:{sessionId}",
+            sessionId,
+            cancellationToken).ConfigureAwait(false);
+
+        var snapshot = await _invoker.ExecuteAsync(
+            ct => _hub.GetSessionSnapshotAsync(sessionId, identity, ct),
+            idempotent: true,
+            cancellationToken).ConfigureAwait(false);
+        await EmitAsync(identity.CorrelationId, "session.read", "PASS", snapshot.TaskId, decision.LeaseId!, cancellationToken).ConfigureAwait(false);
+        return snapshot;
+    }
+
+    public async Task<TaskSnapshot> CreateTaskAsync(
+        TaskCreateRequest request,
+        KpgsIdentityContext identity,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateProgressiveCreate(request.BoundaryMarker, request.CrudIntent);
+        var decision = await RequireCapabilityAsync(
+            identity,
+            "task.create",
+            $"domain:{identity.DomainId}",
+            request.UpdateId,
+            cancellationToken).ConfigureAwait(false);
+
+        var fingerprint = Fingerprint(new { identity.TenantId, identity.DomainId, request });
+        var snapshot = await _idempotency.ExecuteOnceAsync(
+            $"task.create:{identity.TenantId}:{request.IdempotencyKey}",
+            fingerprint,
+            () => _invoker.ExecuteAsync(
+                ct => _hub.CreateTaskAsync(request, identity, decision, ct),
+                idempotent: true,
+                cancellationToken)).ConfigureAwait(false);
+
+        await EmitAsync(identity.CorrelationId, "task.create", "PASS", snapshot.TaskId, decision.LeaseId!, cancellationToken).ConfigureAwait(false);
+        return snapshot;
+    }
+
+    public async Task<TaskSnapshot> SendCommandAsync(
+        string taskId,
+        TaskCommandRequest request,
+        KpgsIdentityContext identity,
+        CancellationToken cancellationToken = default)
+    {
+        if (!string.Equals(request.BoundaryMarker, "#NB", StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException("Literal #NB boundary is required before task command mutation.");
+        }
+
+        var decision = await RequireCapabilityAsync(
+            identity,
+            "task.command",
+            $"task:{taskId}",
+            taskId,
+            cancellationToken).ConfigureAwait(false);
+
+        var fingerprint = Fingerprint(new { identity.TenantId, taskId, request });
+        var snapshot = await _idempotency.ExecuteOnceAsync(
+            $"task.command:{identity.TenantId}:{taskId}:{request.IdempotencyKey}",
+            fingerprint,
+            () => _invoker.ExecuteAsync(
+                ct => _hub.SendCommandAsync(taskId, request, identity, decision, ct),
+                idempotent: true,
+                cancellationToken)).ConfigureAwait(false);
+
+        await EmitAsync(identity.CorrelationId, "task.command", "PASS", taskId, decision.LeaseId!, cancellationToken).ConfigureAwait(false);
+        return snapshot;
+    }
+
+    public async Task<IReadOnlyList<EvidenceRecord>> GetEvidenceAsync(
+        string taskId,
+        KpgsIdentityContext identity,
+        CancellationToken cancellationToken = default)
+    {
+        var decision = await RequireCapabilityAsync(
+            identity,
+            "evidence.read",
+            $"task:{taskId}",
+            taskId,
+            cancellationToken).ConfigureAwait(false);
+
+        return await _invoker.ExecuteAsync(
+            ct => _hub.GetEvidenceAsync(taskId, identity, decision, ct),
+            idempotent: true,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<CapabilityDecision> RequireCapabilityAsync(
+        KpgsIdentityContext identity,
+        string capability,
+        string resourceScope,
+        string taskId,
+        CancellationToken cancellationToken)
+    {
+        CapabilityDecision decision;
+        try
+        {
+            decision = await _invoker.ExecuteAsync(
+                ct => _hub.ResolveCapabilityAsync(
+                    identity,
+                    new CapabilityRequest(capability, resourceScope, taskId, identity.CorrelationId),
+                    ct),
+                idempotent: true,
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is KpgsHubUnavailableException or KpgsCircuitOpenException)
+        {
+            await EmitAsync(identity.CorrelationId, capability, "HOLD", "policy-unavailable", "no-lease", cancellationToken).ConfigureAwait(false);
+            throw new KpgsAuthorizationException("Privileged action held because Hub capability/policy verification is unavailable.");
+        }
+
+        if (!decision.IsUsable(DateTimeOffset.UtcNow))
+        {
+            await EmitAsync(identity.CorrelationId, capability, "REJECT", decision.Reason, decision.LeaseId ?? "no-lease", cancellationToken).ConfigureAwait(false);
+            throw new KpgsAuthorizationException($"Capability denied: {capability}.");
+        }
+
+        return decision;
+    }
+
+    private async Task EmitAsync(
+        string correlationId,
+        string action,
+        string outcome,
+        string detail,
+        string leaseId,
+        CancellationToken cancellationToken) =>
+        await _evidence.EmitAsync(
+            EvidenceFactory.Create(
+                correlationId,
+                source: "Kopano.Kpgs.Adapter",
+                action,
+                outcome,
+                detail,
+                $"lease:{leaseId}",
+                $"estate:{_options.EstateProperty}",
+                $"protocol:{_options.ProtocolVersion}"),
+            cancellationToken).ConfigureAwait(false);
+
+    private static void ValidateProgressiveCreate(string boundaryMarker, string crudIntent)
+    {
+        if (!string.Equals(boundaryMarker, "#NB", StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException("Literal #NB boundary is required before task mutation.");
+        }
+        if (!string.Equals(crudIntent, "CREATE", StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException("Reference task pilot is bounded to CREATE.");
+        }
+    }
+
+    private static string Fingerprint(object value)
+    {
+        var json = JsonSerializer.Serialize(value);
+        return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(json))).ToLowerInvariant();
+    }
+}
+
+public static class KpgsAdapterServiceCollectionExtensions
+{
+    public static IServiceCollection AddKpgsAdapter(
+        this IServiceCollection services,
+        KpgsAdapterOptions options)
+    {
+        services.AddSingleton(options);
+        services.AddSingleton<InMemoryIdempotencyGate>();
+        services.AddSingleton<KpgsHubInvoker>();
+        services.AddScoped<KpgsAdapterService>();
+        return services;
+    }
+}
+
+public static class KpgsAdapterEndpointExtensions
+{
+    public static IEndpointRouteBuilder MapKpgsAdapterEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapGet("/kpgs/health", async (KpgsAdapterService adapter, CancellationToken ct) =>
+            Results.Ok(await adapter.GetHealthAsync(ct)));
+
+        endpoints.MapGet("/kpgs/version", (KpgsAdapterService adapter) =>
+            Results.Ok(adapter.GetVersion()));
+
+        endpoints.MapGet("/kpgs/session/{id}", async (
+            string id,
+            HttpContext context,
+            IKpgsIdentityTranslator identityTranslator,
+            KpgsAdapterService adapter,
+            CancellationToken ct) =>
+            await ExecuteAsync(async () =>
+            {
+                var identity = await identityTranslator.TranslateAsync(context, ct);
+                return Results.Ok(await adapter.GetSessionSnapshotAsync(id, identity, ct));
+            }));
+
+        endpoints.MapPost("/kpgs/tasks", async (
+            TaskCreateRequest request,
+            HttpContext context,
+            IKpgsIdentityTranslator identityTranslator,
+            KpgsAdapterService adapter,
+            CancellationToken ct) =>
+            await ExecuteAsync(async () =>
+            {
+                var identity = await identityTranslator.TranslateAsync(context, ct);
+                return Results.Ok(await adapter.CreateTaskAsync(request, identity, ct));
+            }));
+
+        endpoints.MapPost("/kpgs/tasks/{id}/commands", async (
+            string id,
+            TaskCommandRequest request,
+            HttpContext context,
+            IKpgsIdentityTranslator identityTranslator,
+            KpgsAdapterService adapter,
+            CancellationToken ct) =>
+            await ExecuteAsync(async () =>
+            {
+                var identity = await identityTranslator.TranslateAsync(context, ct);
+                return Results.Ok(await adapter.SendCommandAsync(id, request, identity, ct));
+            }));
+
+        endpoints.MapGet("/kpgs/tasks/{id}/evidence", async (
+            string id,
+            HttpContext context,
+            IKpgsIdentityTranslator identityTranslator,
+            KpgsAdapterService adapter,
+            CancellationToken ct) =>
+            await ExecuteAsync(async () =>
+            {
+                var identity = await identityTranslator.TranslateAsync(context, ct);
+                return Results.Ok(await adapter.GetEvidenceAsync(id, identity, ct));
+            }));
+
+        return endpoints;
+    }
+
+    private static async Task<IResult> ExecuteAsync(Func<Task<IResult>> action)
+    {
+        try
+        {
+            return await action().ConfigureAwait(false);
+        }
+        catch (KpgsAuthorizationException ex)
+        {
+            return Results.Problem(ex.Message, statusCode: StatusCodes.Status403Forbidden);
+        }
+        catch (KpgsIdempotencyConflictException ex)
+        {
+            return Results.Problem(ex.Message, statusCode: StatusCodes.Status409Conflict);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return Results.Problem(ex.Message, statusCode: StatusCodes.Status422UnprocessableEntity);
+        }
+        catch (KpgsHubUnavailableException ex)
+        {
+            return Results.Problem(ex.Message, statusCode: StatusCodes.Status503ServiceUnavailable);
+        }
+    }
+}

--- a/dotnet/Kopano.Kpgs.Adapter/Kopano.Kpgs.Adapter.csproj
+++ b/dotnet/Kopano.Kpgs.Adapter/Kopano.Kpgs.Adapter.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>Kopano.Kpgs.Adapter</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Kopano Labs</Authors>
+    <Description>ASP.NET Core KPGS domain adapter with capability, idempotency and evidence boundaries.</Description>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <ProjectReference Include="../Kopano.Kpgs.Contracts/Kopano.Kpgs.Contracts.csproj" />
+    <ProjectReference Include="../Kopano.Kpgs.Evidence/Kopano.Kpgs.Evidence.csproj" />
+    <ProjectReference Include="../Kopano.Kpgs.Realtime/Kopano.Kpgs.Realtime.csproj" />
+  </ItemGroup>
+</Project>

--- a/dotnet/Kopano.Kpgs.Contracts/Contracts.cs
+++ b/dotnet/Kopano.Kpgs.Contracts/Contracts.cs
@@ -1,0 +1,120 @@
+using System.Text.Json;
+
+namespace Kopano.Kpgs.Contracts;
+
+public static class KpgsProtocol
+{
+    public const string Name = "kpgs.domain-adapter.v1";
+    public const string Version = "1.0.0";
+    public const string ProgressiveUpdate = "APU -> Progressive Update -> #NB -> bounded CRUD -> SWFUS";
+}
+
+public sealed record KpgsIdentityContext(
+    string SubjectId,
+    string TenantId,
+    string DomainId,
+    string SessionId,
+    string CorrelationId);
+
+public sealed record CapabilityRequest(
+    string Capability,
+    string ResourceScope,
+    string TaskId,
+    string CorrelationId);
+
+public sealed record CapabilityDecision(
+    bool Allowed,
+    string? LeaseId,
+    DateTimeOffset? ExpiresAt,
+    string PolicyDecisionRef,
+    string Reason)
+{
+    public bool IsUsable(DateTimeOffset now) =>
+        Allowed &&
+        !string.IsNullOrWhiteSpace(LeaseId) &&
+        ExpiresAt is not null &&
+        ExpiresAt > now;
+}
+
+public sealed record TaskCreateRequest(
+    string GoverningSpecRef,
+    JsonElement Input,
+    string IdempotencyKey,
+    string UpdateId,
+    string BoundaryMarker = "#NB",
+    string CrudIntent = "CREATE");
+
+public sealed record TaskCommandRequest(
+    string Command,
+    JsonElement Input,
+    string IdempotencyKey,
+    string UpdateId,
+    string BoundaryMarker = "#NB");
+
+public sealed record TaskSnapshot(
+    string TaskId,
+    string Status,
+    string GoverningSpecRef,
+    string CorrelationId,
+    IReadOnlyList<string> NextActions,
+    string UserSafeExplanation,
+    bool ApprovalRequired,
+    DateTimeOffset UpdatedAt);
+
+public sealed record RenterRequestEnvelope(
+    string TaskId,
+    string SkillName,
+    string SkillVersion,
+    string CorrelationId,
+    string CapabilityLeaseId,
+    JsonElement Input);
+
+public sealed record RenterResponseEnvelope(
+    string TaskId,
+    string CorrelationId,
+    string Outcome,
+    JsonElement Output,
+    string EvidenceRef,
+    bool Canonical = false,
+    string AuthorityEffect = "none");
+
+public sealed record EvidenceRecord(
+    string EvidenceId,
+    string CorrelationId,
+    string Source,
+    string Action,
+    string Outcome,
+    string Detail,
+    IReadOnlyList<string> References,
+    DateTimeOffset CreatedAt,
+    bool Canonical = false,
+    string AuthorityEffect = "none");
+
+public sealed record AdapterHealth(
+    string Status,
+    bool HubReachable,
+    string Protocol,
+    string AdapterVersion,
+    DateTimeOffset CheckedAt);
+
+public sealed record AdapterVersion(
+    string Adapter,
+    string Protocol,
+    string TargetFramework,
+    IReadOnlyList<string> CompatibleProtocols);
+
+public sealed record RealtimeEvent(
+    string SessionId,
+    string EventId,
+    string CorrelationId,
+    string Kind,
+    JsonElement Payload,
+    DateTimeOffset OccurredAt);
+
+public interface ICanonicalSessionReader
+{
+    Task<TaskSnapshot> GetSessionSnapshotAsync(
+        string sessionId,
+        KpgsIdentityContext identity,
+        CancellationToken cancellationToken = default);
+}

--- a/dotnet/Kopano.Kpgs.Contracts/Kopano.Kpgs.Contracts.csproj
+++ b/dotnet/Kopano.Kpgs.Contracts/Kopano.Kpgs.Contracts.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>Kopano.Kpgs.Contracts</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Kopano Labs</Authors>
+    <Description>Language-neutral KPGS domain adapter contracts for existing applications.</Description>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+</Project>

--- a/dotnet/Kopano.Kpgs.Evidence/Evidence.cs
+++ b/dotnet/Kopano.Kpgs.Evidence/Evidence.cs
@@ -1,0 +1,62 @@
+using System.Collections.Concurrent;
+using Kopano.Kpgs.Contracts;
+
+namespace Kopano.Kpgs.Evidence;
+
+public interface IKpgsEvidenceSink
+{
+    Task EmitAsync(EvidenceRecord record, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<EvidenceRecord>> QueryAsync(string correlationId, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Reference-only transient sink. It is observability evidence, never durable canonical business state.
+/// Production domains should inject their governed evidence transport.
+/// </summary>
+public sealed class InMemoryEvidenceSink : IKpgsEvidenceSink
+{
+    private readonly ConcurrentQueue<EvidenceRecord> _records = new();
+
+    public Task EmitAsync(EvidenceRecord record, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (record.Canonical || !string.Equals(record.AuthorityEffect, "none", StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException("Adapter evidence cannot claim canonical authority.");
+        }
+        _records.Enqueue(record);
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyList<EvidenceRecord>> QueryAsync(string correlationId, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        IReadOnlyList<EvidenceRecord> result = _records
+            .Where(record => string.Equals(record.CorrelationId, correlationId, StringComparison.Ordinal))
+            .OrderBy(record => record.CreatedAt)
+            .ToArray();
+        return Task.FromResult(result);
+    }
+}
+
+public static class EvidenceFactory
+{
+    public static EvidenceRecord Create(
+        string correlationId,
+        string source,
+        string action,
+        string outcome,
+        string detail,
+        params string[] references) =>
+        new(
+            EvidenceId: $"evidence_{Guid.NewGuid():N}",
+            CorrelationId: correlationId,
+            Source: source,
+            Action: action,
+            Outcome: outcome,
+            Detail: detail,
+            References: references,
+            CreatedAt: DateTimeOffset.UtcNow,
+            Canonical: false,
+            AuthorityEffect: "none");
+}

--- a/dotnet/Kopano.Kpgs.Evidence/Kopano.Kpgs.Evidence.csproj
+++ b/dotnet/Kopano.Kpgs.Evidence/Kopano.Kpgs.Evidence.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>Kopano.Kpgs.Evidence</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Kopano Labs</Authors>
+    <Description>Correlation and evidence emission helpers for KPGS domain adapters.</Description>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Kopano.Kpgs.Contracts/Kopano.Kpgs.Contracts.csproj" />
+  </ItemGroup>
+</Project>

--- a/dotnet/Kopano.Kpgs.Realtime/Kopano.Kpgs.Realtime.csproj
+++ b/dotnet/Kopano.Kpgs.Realtime/Kopano.Kpgs.Realtime.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>Kopano.Kpgs.Realtime</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Kopano Labs</Authors>
+    <Description>Realtime event-plane and canonical recovery semantics for KPGS domain adapters.</Description>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Kopano.Kpgs.Contracts/Kopano.Kpgs.Contracts.csproj" />
+  </ItemGroup>
+</Project>

--- a/dotnet/Kopano.Kpgs.Realtime/Realtime.cs
+++ b/dotnet/Kopano.Kpgs.Realtime/Realtime.cs
@@ -1,0 +1,42 @@
+using Kopano.Kpgs.Contracts;
+
+namespace Kopano.Kpgs.Realtime;
+
+public interface IKpgsRealtimeTransport
+{
+    Task ConnectAsync(string sessionId, CancellationToken cancellationToken = default);
+    IAsyncEnumerable<RealtimeEvent> ReadEventsAsync(CancellationToken cancellationToken = default);
+    Task DisconnectAsync(CancellationToken cancellationToken = default);
+}
+
+public sealed class KpgsRealtimeClient
+{
+    private readonly IKpgsRealtimeTransport _transport;
+    private readonly ICanonicalSessionReader _canonicalReader;
+
+    public KpgsRealtimeClient(IKpgsRealtimeTransport transport, ICanonicalSessionReader canonicalReader)
+    {
+        _transport = transport;
+        _canonicalReader = canonicalReader;
+    }
+
+    public Task ConnectAsync(string sessionId, CancellationToken cancellationToken = default) =>
+        _transport.ConnectAsync(sessionId, cancellationToken);
+
+    public IAsyncEnumerable<RealtimeEvent> ReadEventsAsync(CancellationToken cancellationToken = default) =>
+        _transport.ReadEventsAsync(cancellationToken);
+
+    /// <summary>
+    /// Reconnect never treats missed socket events as canonical state. After the
+    /// transport reconnects, the client reloads the session from the canonical reader.
+    /// </summary>
+    public async Task<TaskSnapshot> ReconnectAndRecoverAsync(
+        string sessionId,
+        KpgsIdentityContext identity,
+        CancellationToken cancellationToken = default)
+    {
+        await _transport.DisconnectAsync(cancellationToken);
+        await _transport.ConnectAsync(sessionId, cancellationToken);
+        return await _canonicalReader.GetSessionSnapshotAsync(sessionId, identity, cancellationToken);
+    }
+}

--- a/dotnet/Kopano.Kpgs.Reference/Kopano.Kpgs.Reference.csproj
+++ b/dotnet/Kopano.Kpgs.Reference/Kopano.Kpgs.Reference.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Kopano.Kpgs.Adapter/Kopano.Kpgs.Adapter.csproj" />
+    <ProjectReference Include="../Kopano.Kpgs.Contracts/Kopano.Kpgs.Contracts.csproj" />
+    <ProjectReference Include="../Kopano.Kpgs.Evidence/Kopano.Kpgs.Evidence.csproj" />
+  </ItemGroup>
+</Project>

--- a/dotnet/Kopano.Kpgs.Reference/Program.cs
+++ b/dotnet/Kopano.Kpgs.Reference/Program.cs
@@ -1,0 +1,183 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using Kopano.Kpgs.Adapter;
+using Kopano.Kpgs.Contracts;
+using Kopano.Kpgs.Evidence;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddSingleton<IKpgsEvidenceSink, InMemoryEvidenceSink>();
+builder.Services.AddSingleton<IKpgsHubClient, DevelopmentMockHubClient>();
+builder.Services.AddSingleton<IKpgsIdentityTranslator, HeaderIdentityTranslator>();
+builder.Services.AddSingleton<IKpgsSecretProvider, EnvironmentSecretProvider>();
+builder.Services.AddKpgsAdapter(new KpgsAdapterOptions
+{
+    EstateProperty = builder.Configuration["KPGS_ESTATE_PROPERTY"] ?? "local.reference",
+    AdapterVersion = "0.1.0",
+    ProtocolVersion = KpgsProtocol.Version,
+});
+
+var app = builder.Build();
+app.MapGet("/", () => Results.Ok(new
+{
+    service = "Kopano.Kpgs.Reference",
+    authority = "adapter-only",
+    canonical_business_state = false,
+    protocol = KpgsProtocol.Name,
+}));
+app.MapKpgsAdapterEndpoints();
+app.Run();
+
+/// <summary>
+/// Reference identity translation only. Real domains replace this with their
+/// authenticated server-side identity integration; browser headers never grant authority.
+/// </summary>
+sealed class HeaderIdentityTranslator : IKpgsIdentityTranslator
+{
+    public ValueTask<KpgsIdentityContext> TranslateAsync(
+        HttpContext context,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var subject = context.User.Identity?.Name ?? context.Request.Headers["X-KPGS-Subject"].FirstOrDefault();
+        if (string.IsNullOrWhiteSpace(subject))
+        {
+            throw new KpgsAuthorizationException("Authenticated domain identity is required.");
+        }
+
+        string RequiredHeader(string name)
+        {
+            var value = context.Request.Headers[name].FirstOrDefault();
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                throw new KpgsAuthorizationException($"Missing server-resolved identity context header: {name}.");
+            }
+            return value;
+        }
+
+        return ValueTask.FromResult(new KpgsIdentityContext(
+            SubjectId: subject,
+            TenantId: RequiredHeader("X-KPGS-Tenant"),
+            DomainId: RequiredHeader("X-KPGS-Domain"),
+            SessionId: RequiredHeader("X-KPGS-Session"),
+            CorrelationId: context.Request.Headers["X-Correlation-Id"].FirstOrDefault() ?? Guid.NewGuid().ToString("N")));
+    }
+}
+
+sealed class EnvironmentSecretProvider : IKpgsSecretProvider
+{
+    public ValueTask<string?> GetSecretAsync(string reference, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (!reference.StartsWith("env:", StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException("Reference service accepts only env: secret references.");
+        }
+        return ValueTask.FromResult(Environment.GetEnvironmentVariable(reference[4..]));
+    }
+}
+
+/// <summary>
+/// Local-development mock only. It demonstrates the adapter contract and is not
+/// Sovereign Hub, not a production policy engine, and not a canonical state store.
+/// </summary>
+sealed class DevelopmentMockHubClient : IKpgsHubClient
+{
+    private readonly ConcurrentDictionary<string, TaskSnapshot> _tasks = new(StringComparer.Ordinal);
+
+    public Task<bool> IsReadyAsync(CancellationToken cancellationToken = default) => Task.FromResult(true);
+
+    public Task<CapabilityDecision> ResolveCapabilityAsync(
+        KpgsIdentityContext identity,
+        CapabilityRequest request,
+        CancellationToken cancellationToken = default) =>
+        Task.FromResult(new CapabilityDecision(
+            Allowed: true,
+            LeaseId: $"dev-lease-{Guid.NewGuid():N}",
+            ExpiresAt: DateTimeOffset.UtcNow.AddMinutes(2),
+            PolicyDecisionRef: "development-mock-only",
+            Reason: "Local reference mock admitted the declared capability."));
+
+    public Task RegisterDomainAsync(
+        DomainRegistration registration,
+        CapabilityDecision decision,
+        CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+    public Task<TaskSnapshot> CreateTaskAsync(
+        TaskCreateRequest request,
+        KpgsIdentityContext identity,
+        CapabilityDecision decision,
+        CancellationToken cancellationToken = default)
+    {
+        var taskId = $"dev-task-{Guid.NewGuid():N}";
+        var snapshot = new TaskSnapshot(
+            taskId,
+            "created",
+            request.GoverningSpecRef,
+            identity.CorrelationId,
+            ["inspect", "approve"],
+            "Development mock created a non-production task snapshot.",
+            ApprovalRequired: true,
+            UpdatedAt: DateTimeOffset.UtcNow);
+        _tasks[taskId] = snapshot;
+        return Task.FromResult(snapshot);
+    }
+
+    public Task<TaskSnapshot> SendCommandAsync(
+        string taskId,
+        TaskCommandRequest request,
+        KpgsIdentityContext identity,
+        CapabilityDecision decision,
+        CancellationToken cancellationToken = default)
+    {
+        if (!_tasks.TryGetValue(taskId, out var previous))
+        {
+            throw new KeyNotFoundException(taskId);
+        }
+        var updated = previous with
+        {
+            Status = $"command:{request.Command}",
+            UserSafeExplanation = "Development mock accepted the command under a short-lived mock lease.",
+            UpdatedAt = DateTimeOffset.UtcNow,
+        };
+        _tasks[taskId] = updated;
+        return Task.FromResult(updated);
+    }
+
+    public Task<TaskSnapshot> GetSessionSnapshotAsync(
+        string sessionId,
+        KpgsIdentityContext identity,
+        CancellationToken cancellationToken = default)
+    {
+        var snapshot = _tasks.Values.OrderByDescending(task => task.UpdatedAt).FirstOrDefault()
+            ?? new TaskSnapshot(
+                $"session:{sessionId}",
+                "idle",
+                "none",
+                identity.CorrelationId,
+                ["create-task"],
+                "No development task exists yet.",
+                ApprovalRequired: false,
+                UpdatedAt: DateTimeOffset.UtcNow);
+        return Task.FromResult(snapshot);
+    }
+
+    public Task<IReadOnlyList<EvidenceRecord>> GetEvidenceAsync(
+        string taskId,
+        KpgsIdentityContext identity,
+        CapabilityDecision decision,
+        CancellationToken cancellationToken = default)
+    {
+        IReadOnlyList<EvidenceRecord> evidence =
+        [
+            EvidenceFactory.Create(
+                identity.CorrelationId,
+                "DevelopmentMockHubClient",
+                "evidence.read",
+                "PASS",
+                $"Reference-only evidence for {taskId}.",
+                decision.PolicyDecisionRef)
+        ];
+        return Task.FromResult(evidence);
+    }
+}

--- a/dotnet/Kopano.Kpgs.Tests/Kopano.Kpgs.Tests.csproj
+++ b/dotnet/Kopano.Kpgs.Tests/Kopano.Kpgs.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Kopano.Kpgs.Adapter/Kopano.Kpgs.Adapter.csproj" />
+    <ProjectReference Include="../Kopano.Kpgs.Contracts/Kopano.Kpgs.Contracts.csproj" />
+    <ProjectReference Include="../Kopano.Kpgs.Evidence/Kopano.Kpgs.Evidence.csproj" />
+    <ProjectReference Include="../Kopano.Kpgs.Realtime/Kopano.Kpgs.Realtime.csproj" />
+  </ItemGroup>
+</Project>

--- a/dotnet/Kopano.Kpgs.Tests/Program.cs
+++ b/dotnet/Kopano.Kpgs.Tests/Program.cs
@@ -1,0 +1,367 @@
+using System.Net;
+using System.Text.Json;
+using Kopano.Kpgs.Adapter;
+using Kopano.Kpgs.Contracts;
+using Kopano.Kpgs.Evidence;
+using Kopano.Kpgs.Realtime;
+
+var proofs = new AdapterProofs();
+await proofs.RunAsync();
+Console.WriteLine("KPGS .NET domain adapter proof: PASS");
+
+sealed class AdapterProofs
+{
+    private readonly KpgsIdentityContext _identity = new(
+        "subject:test",
+        "tenant:test",
+        "domain:test",
+        "session:test",
+        "corr:test");
+
+    public async Task RunAsync()
+    {
+        await HealthAndVersionAreMachineReadable();
+        await AuthorizedCreateIsLeaseBoundAndReplaySafe();
+        await SameIdempotencyKeyWithDifferentPayloadRejects();
+        await DeniedCapabilityBlocksBeforeMutation();
+        await PolicyOutageFailsClosedBeforeMutation();
+        await MissingNbBlocksBeforeCapabilityResolution();
+        await SafeTransientFailureRetriesOnlyInsideIdempotentBoundary();
+        await RealtimeReconnectRecoversFromCanonicalReader();
+        await AdapterReplacementRecoversStateFromHubNotLocalMemory();
+        RenterEnvelopeIsVersionedContractSurface();
+    }
+
+    private async Task HealthAndVersionAreMachineReadable()
+    {
+        var hub = new FakeHub();
+        var (adapter, _) = NewAdapter(hub);
+        var health = await adapter.GetHealthAsync();
+        var version = adapter.GetVersion();
+
+        Assert(health.Status == "ready" && health.HubReachable, "health must reflect Hub readiness");
+        Assert(version.Protocol == KpgsProtocol.Version, "version endpoint must expose canonical protocol version");
+        Assert(version.TargetFramework == "net10.0", "adapter target framework must be machine-verifiable");
+    }
+
+    private async Task AuthorizedCreateIsLeaseBoundAndReplaySafe()
+    {
+        var hub = new FakeHub();
+        var (adapter, evidence) = NewAdapter(hub);
+        var request = CreateRequest("idem-1", "update-1", value: 1);
+
+        var first = await adapter.CreateTaskAsync(request, _identity);
+        var replay = await adapter.CreateTaskAsync(request, _identity);
+
+        Assert(first.TaskId == replay.TaskId, "exact replay must return the same governed result");
+        Assert(hub.CreateSuccesses == 1, "exact replay must not execute Hub CREATE twice");
+        Assert(hub.CapabilityRequests.Count >= 2, "each privileged call must resolve a Hub capability decision");
+        Assert(hub.CapabilityRequests.All(r => r.Capability == "task.create"), "CREATE must request task.create capability");
+
+        var emitted = await evidence.QueryAsync(_identity.CorrelationId);
+        Assert(emitted.Count >= 2, "executions must emit correlation-bound evidence");
+        Assert(emitted.All(record => !record.Canonical && record.AuthorityEffect == "none"), "adapter evidence must never claim canonical authority");
+        Assert(emitted.Any(record => record.References.Any(reference => reference.StartsWith("lease:", StringComparison.Ordinal))), "evidence must bind to a Hub lease decision");
+    }
+
+    private async Task SameIdempotencyKeyWithDifferentPayloadRejects()
+    {
+        var hub = new FakeHub();
+        var (adapter, _) = NewAdapter(hub);
+        await adapter.CreateTaskAsync(CreateRequest("idem-collision", "update-a", value: 1), _identity);
+
+        await ExpectAsync<KpgsIdempotencyConflictException>(
+            () => adapter.CreateTaskAsync(CreateRequest("idem-collision", "update-b", value: 2), _identity),
+            "same idempotency key with changed governed content must reject");
+        Assert(hub.CreateSuccesses == 1, "collision must not reach a second Hub mutation");
+    }
+
+    private async Task DeniedCapabilityBlocksBeforeMutation()
+    {
+        var hub = new FakeHub { DenyCapabilities = true };
+        var (adapter, _) = NewAdapter(hub);
+
+        await ExpectAsync<KpgsAuthorizationException>(
+            () => adapter.CreateTaskAsync(CreateRequest("idem-denied", "update-denied", value: 1), _identity),
+            "denied capability must fail before CREATE");
+        Assert(hub.CreateAttempts == 0, "denied capability must not call Hub CREATE");
+    }
+
+    private async Task PolicyOutageFailsClosedBeforeMutation()
+    {
+        var hub = new FakeHub { FailCapabilityTransport = true };
+        var (adapter, evidence) = NewAdapter(hub, options: new KpgsAdapterOptions
+        {
+            EstateProperty = "test.example",
+            RequestTimeout = TimeSpan.FromSeconds(1),
+            SafeRetryCount = 1,
+            CircuitFailureThreshold = 5,
+        });
+
+        await ExpectAsync<KpgsAuthorizationException>(
+            () => adapter.CreateTaskAsync(CreateRequest("idem-policy", "update-policy", value: 1), _identity),
+            "policy outage must HOLD rather than bypass governance");
+        Assert(hub.CreateAttempts == 0, "policy outage must not call Hub CREATE");
+        var emitted = await evidence.QueryAsync(_identity.CorrelationId);
+        Assert(emitted.Any(record => record.Action == "task.create" && record.Outcome == "HOLD"), "policy outage must emit HOLD evidence");
+    }
+
+    private async Task MissingNbBlocksBeforeCapabilityResolution()
+    {
+        var hub = new FakeHub();
+        var (adapter, _) = NewAdapter(hub);
+        var before = hub.CapabilityRequests.Count;
+        var request = CreateRequest("idem-nb", "update-nb", value: 1) with { BoundaryMarker = "NB" };
+
+        await ExpectAsync<InvalidOperationException>(
+            () => adapter.CreateTaskAsync(request, _identity),
+            "literal #NB is required before mutation");
+        Assert(hub.CapabilityRequests.Count == before, "invalid boundary must stop before capability/mutation work");
+    }
+
+    private async Task SafeTransientFailureRetriesOnlyInsideIdempotentBoundary()
+    {
+        var hub = new FakeHub { TransientCreateFailures = 1 };
+        var (adapter, _) = NewAdapter(hub, options: new KpgsAdapterOptions
+        {
+            EstateProperty = "test.example",
+            RequestTimeout = TimeSpan.FromSeconds(2),
+            SafeRetryCount = 2,
+            CircuitFailureThreshold = 5,
+        });
+
+        var result = await adapter.CreateTaskAsync(CreateRequest("idem-retry", "update-retry", value: 7), _identity);
+        Assert(result.Status == "created", "bounded retry must recover an idempotent transient failure");
+        Assert(hub.CreateAttempts == 2 && hub.CreateSuccesses == 1, "retry must execute one transient failure plus one successful CREATE");
+    }
+
+    private async Task RealtimeReconnectRecoversFromCanonicalReader()
+    {
+        var hub = new FakeHub();
+        var (adapter, _) = NewAdapter(hub);
+        var transport = new FakeRealtimeTransport();
+        var realtime = new KpgsRealtimeClient(transport, adapter);
+
+        await realtime.ConnectAsync(_identity.SessionId);
+        var recovered = await realtime.ReconnectAndRecoverAsync(_identity.SessionId, _identity);
+
+        Assert(transport.ConnectCalls == 2 && transport.DisconnectCalls == 1, "realtime recovery must reconnect transport");
+        Assert(hub.SessionReads == 1, "realtime recovery must reload canonical session state");
+        Assert(recovered.Status == "canonical-recovery", "recovered state must come from canonical session reader");
+    }
+
+    private async Task AdapterReplacementRecoversStateFromHubNotLocalMemory()
+    {
+        var hub = new FakeHub();
+        var (firstAdapter, _) = NewAdapter(hub);
+        var created = await firstAdapter.CreateTaskAsync(CreateRequest("idem-removal", "update-removal", value: 3), _identity);
+
+        // Simulate rollback/removal/restart: discard the entire adapter instance,
+        // including its transient idempotency gate, then rebuild from the same Hub.
+        var (replacementAdapter, _) = NewAdapter(hub);
+        hub.SessionSnapshot = created with { Status = "canonical-after-restart" };
+        var recovered = await replacementAdapter.GetSessionSnapshotAsync(_identity.SessionId, _identity);
+
+        Assert(recovered.Status == "canonical-after-restart", "replacement adapter must recover from Hub rather than local durable business state");
+        Assert(hub.SessionReads == 1, "rollback/restart recovery must perform canonical read");
+    }
+
+    private static void RenterEnvelopeIsVersionedContractSurface()
+    {
+        var input = JsonSerializer.SerializeToElement(new { prompt = "bounded" });
+        var envelope = new RenterRequestEnvelope(
+            "task-1",
+            "demo-skill",
+            "1.0.0",
+            "corr-1",
+            "lease-1",
+            input);
+        Assert(envelope.SkillVersion == "1.0.0" && KpgsProtocol.Name == "kpgs.domain-adapter.v1", "renter envelope and adapter protocol must be explicitly versioned");
+    }
+
+    private (KpgsAdapterService Adapter, InMemoryEvidenceSink Evidence) NewAdapter(
+        FakeHub hub,
+        KpgsAdapterOptions? options = null)
+    {
+        options ??= new KpgsAdapterOptions
+        {
+            EstateProperty = "test.example",
+            AdapterVersion = "0.1.0",
+            ProtocolVersion = KpgsProtocol.Version,
+            RequestTimeout = TimeSpan.FromSeconds(2),
+            SafeRetryCount = 0,
+            CircuitFailureThreshold = 3,
+        };
+        var evidence = new InMemoryEvidenceSink();
+        return (
+            new KpgsAdapterService(
+                hub,
+                evidence,
+                new InMemoryIdempotencyGate(),
+                new KpgsHubInvoker(options),
+                options),
+            evidence);
+    }
+
+    private static TaskCreateRequest CreateRequest(string idempotencyKey, string updateId, int value) =>
+        new(
+            GoverningSpecRef: "spec:test",
+            Input: JsonSerializer.SerializeToElement(new { value }),
+            IdempotencyKey: idempotencyKey,
+            UpdateId: updateId,
+            BoundaryMarker: "#NB",
+            CrudIntent: "CREATE");
+
+    private static async Task ExpectAsync<TException>(Func<Task> action, string message)
+        where TException : Exception
+    {
+        try
+        {
+            await action();
+        }
+        catch (TException)
+        {
+            return;
+        }
+        throw new InvalidOperationException($"PROOF FAILED: {message}");
+    }
+
+    private static void Assert(bool condition, string message)
+    {
+        if (!condition)
+        {
+            throw new InvalidOperationException($"PROOF FAILED: {message}");
+        }
+    }
+}
+
+sealed class FakeHub : IKpgsHubClient
+{
+    public bool DenyCapabilities { get; set; }
+    public bool FailCapabilityTransport { get; set; }
+    public int TransientCreateFailures { get; set; }
+    public int CreateAttempts { get; private set; }
+    public int CreateSuccesses { get; private set; }
+    public int CommandCalls { get; private set; }
+    public int SessionReads { get; private set; }
+    public List<CapabilityRequest> CapabilityRequests { get; } = [];
+    public TaskSnapshot? SessionSnapshot { get; set; }
+
+    public Task<bool> IsReadyAsync(CancellationToken cancellationToken = default) => Task.FromResult(true);
+
+    public Task RegisterDomainAsync(DomainRegistration registration, CapabilityDecision decision, CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+    public Task<CapabilityDecision> ResolveCapabilityAsync(
+        KpgsIdentityContext identity,
+        CapabilityRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        CapabilityRequests.Add(request);
+        if (FailCapabilityTransport)
+        {
+            throw new HttpRequestException("policy unavailable", null, HttpStatusCode.ServiceUnavailable);
+        }
+        return Task.FromResult(new CapabilityDecision(
+            Allowed: !DenyCapabilities,
+            LeaseId: DenyCapabilities ? null : $"lease-{CapabilityRequests.Count}",
+            ExpiresAt: DenyCapabilities ? null : DateTimeOffset.UtcNow.AddMinutes(1),
+            PolicyDecisionRef: "policy:test",
+            Reason: DenyCapabilities ? "denied by test policy" : "allowed by test policy"));
+    }
+
+    public Task<TaskSnapshot> CreateTaskAsync(
+        TaskCreateRequest request,
+        KpgsIdentityContext identity,
+        CapabilityDecision decision,
+        CancellationToken cancellationToken = default)
+    {
+        CreateAttempts++;
+        if (TransientCreateFailures > 0)
+        {
+            TransientCreateFailures--;
+            throw new HttpRequestException("transient", null, HttpStatusCode.ServiceUnavailable);
+        }
+        CreateSuccesses++;
+        var snapshot = new TaskSnapshot(
+            $"task-{CreateSuccesses}",
+            "created",
+            request.GoverningSpecRef,
+            identity.CorrelationId,
+            ["inspect"],
+            "Created by fake Hub under a valid test lease.",
+            ApprovalRequired: false,
+            UpdatedAt: DateTimeOffset.UtcNow);
+        SessionSnapshot = snapshot;
+        return Task.FromResult(snapshot);
+    }
+
+    public Task<TaskSnapshot> SendCommandAsync(
+        string taskId,
+        TaskCommandRequest request,
+        KpgsIdentityContext identity,
+        CapabilityDecision decision,
+        CancellationToken cancellationToken = default)
+    {
+        CommandCalls++;
+        var snapshot = (SessionSnapshot ?? new TaskSnapshot(taskId, "unknown", "spec:test", identity.CorrelationId, [], "", false, DateTimeOffset.UtcNow)) with
+        {
+            Status = $"command:{request.Command}",
+            UpdatedAt = DateTimeOffset.UtcNow,
+        };
+        SessionSnapshot = snapshot;
+        return Task.FromResult(snapshot);
+    }
+
+    public Task<TaskSnapshot> GetSessionSnapshotAsync(
+        string sessionId,
+        KpgsIdentityContext identity,
+        CancellationToken cancellationToken = default)
+    {
+        SessionReads++;
+        return Task.FromResult(SessionSnapshot ?? new TaskSnapshot(
+            $"session:{sessionId}",
+            "canonical-recovery",
+            "spec:test",
+            identity.CorrelationId,
+            ["continue"],
+            "Recovered from canonical fake Hub snapshot.",
+            ApprovalRequired: false,
+            UpdatedAt: DateTimeOffset.UtcNow));
+    }
+
+    public Task<IReadOnlyList<EvidenceRecord>> GetEvidenceAsync(
+        string taskId,
+        KpgsIdentityContext identity,
+        CapabilityDecision decision,
+        CancellationToken cancellationToken = default)
+    {
+        IReadOnlyList<EvidenceRecord> result =
+        [EvidenceFactory.Create(identity.CorrelationId, "FakeHub", "evidence.read", "PASS", taskId, decision.LeaseId ?? "no-lease")];
+        return Task.FromResult(result);
+    }
+}
+
+sealed class FakeRealtimeTransport : IKpgsRealtimeTransport
+{
+    public int ConnectCalls { get; private set; }
+    public int DisconnectCalls { get; private set; }
+
+    public Task ConnectAsync(string sessionId, CancellationToken cancellationToken = default)
+    {
+        ConnectCalls++;
+        return Task.CompletedTask;
+    }
+
+    public async IAsyncEnumerable<RealtimeEvent> ReadEventsAsync(
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        await Task.CompletedTask;
+        yield break;
+    }
+
+    public Task DisconnectAsync(CancellationToken cancellationToken = default)
+    {
+        DisconnectCalls++;
+        return Task.CompletedTask;
+    }
+}

--- a/dotnet/client/kpgs-client.ts
+++ b/dotnet/client/kpgs-client.ts
@@ -1,0 +1,94 @@
+export type KpgsIdentityHeaders = {
+  subject: string;
+  tenant: string;
+  domain: string;
+  session: string;
+  correlationId?: string;
+};
+
+export type KpgsTaskCreate = {
+  governingSpecRef: string;
+  input: unknown;
+  idempotencyKey: string;
+  updateId: string;
+  boundaryMarker?: "#NB";
+  crudIntent?: "CREATE";
+};
+
+export type KpgsTaskCommand = {
+  command: string;
+  input: unknown;
+  idempotencyKey: string;
+  updateId: string;
+  boundaryMarker?: "#NB";
+};
+
+/**
+ * Tiny binding for existing PWAs. It adds KPGS as a service boundary; it does
+ * not require React/Next/Vite/MERN applications to move to .NET.
+ */
+export class KpgsClient {
+  constructor(
+    private readonly baseUrl: string,
+    private readonly identity: () => KpgsIdentityHeaders,
+    private readonly fetcher: typeof fetch = fetch,
+  ) {}
+
+  health() {
+    return this.request("/kpgs/health");
+  }
+
+  version() {
+    return this.request("/kpgs/version");
+  }
+
+  session(id: string) {
+    return this.request(`/kpgs/session/${encodeURIComponent(id)}`, { governed: true });
+  }
+
+  createTask(input: KpgsTaskCreate) {
+    return this.request("/kpgs/tasks", {
+      method: "POST",
+      body: JSON.stringify({ boundaryMarker: "#NB", crudIntent: "CREATE", ...input }),
+      governed: true,
+    });
+  }
+
+  command(taskId: string, input: KpgsTaskCommand) {
+    return this.request(`/kpgs/tasks/${encodeURIComponent(taskId)}/commands`, {
+      method: "POST",
+      body: JSON.stringify({ boundaryMarker: "#NB", ...input }),
+      governed: true,
+    });
+  }
+
+  evidence(taskId: string) {
+    return this.request(`/kpgs/tasks/${encodeURIComponent(taskId)}/evidence`, { governed: true });
+  }
+
+  private async request(
+    path: string,
+    options: { method?: string; body?: string; governed?: boolean } = {},
+  ) {
+    const headers = new Headers({ "Content-Type": "application/json" });
+    if (options.governed) {
+      const identity = this.identity();
+      headers.set("X-KPGS-Subject", identity.subject);
+      headers.set("X-KPGS-Tenant", identity.tenant);
+      headers.set("X-KPGS-Domain", identity.domain);
+      headers.set("X-KPGS-Session", identity.session);
+      if (identity.correlationId) headers.set("X-Correlation-Id", identity.correlationId);
+    }
+
+    const response = await this.fetcher(`${this.baseUrl}${path}`, {
+      method: options.method ?? "GET",
+      headers,
+      body: options.body,
+    });
+    const payload = await response.json().catch(() => null);
+    if (!response.ok) {
+      throw new Error(`KPGS adapter ${response.status}: ${payload?.detail ?? "request failed"}`);
+    }
+    return payload;
+  }
+}

--- a/governance/kpgs-vnext/dotnet/DOMAIN_ADAPTER.md
+++ b/governance/kpgs-vnext/dotnet/DOMAIN_ADAPTER.md
@@ -9,8 +9,9 @@ The .NET adapter is the stable service/control-plane boundary between an existin
 ```text
 Existing PWA / Domain UI
         |
+        | tiny JSON/TypeScript client
         v
-KPGS Domain Adapter (.NET reference implementation)
+KPGS Domain Adapter (.NET 10 reference implementation)
         |
         v
 Kopano Sovereign Hub
@@ -22,95 +23,175 @@ Kopano Sovereign Hub
         `--> Stateless Renters
 ```
 
-## Proposed package split
+The reference implementation targets `net10.0`. Package compatibility is versioned independently from the frontend stack.
+
+## Package split
 
 ```text
-Kopano.Kpgs.Contracts
-  DTOs and protocol/version contracts only
+dotnet/Kopano.Kpgs.Contracts
+  DTOs, renter envelopes and protocol/version contracts only
 
-Kopano.Kpgs.Adapter
-  ASP.NET Core middleware and Hub client
+dotnet/Kopano.Kpgs.Adapter
+  ASP.NET Core service membrane, Hub client contract, capability checks,
+  idempotency, bounded timeout/retry/circuit-breaker and endpoints
 
-Kopano.Kpgs.Realtime
-  realtime session/event-plane client and fallback semantics
+dotnet/Kopano.Kpgs.Realtime
+  realtime event-plane client and canonical reconnect recovery
 
-Kopano.Kpgs.Evidence
-  evidence emission and correlation helpers
+dotnet/Kopano.Kpgs.Evidence
+  non-authoritative evidence emission and correlation helpers
+
+dotnet/Kopano.Kpgs.Reference
+  removable ASP.NET Core reference service + development-only mock Hub
+
+dotnet/client/kpgs-client.ts
+  zero-rewrite TypeScript binding for existing PWAs
 ```
 
-The split keeps domain applications from depending on the complete Hub implementation.
+`Contracts`, `Adapter`, `Realtime` and `Evidence` are packable NuGet projects. The split keeps domain applications from depending on the complete Hub implementation.
 
-## Required HTTP surface
+## Canonical runtime boundary
 
-A reference adapter SHOULD expose:
+The adapter carries **no durable canonical business state**.
 
-- `GET /kpgs/health` — liveness/readiness summary
+- Task/session truth is read from the injected `IKpgsHubClient`.
+- The in-memory idempotency gate is transient duplicate-work coordination only.
+- The reference evidence sink is observability evidence with `canonical=false` and `authorityEffect=none`.
+- Production domains replace the reference evidence sink and mock Hub through dependency injection.
+- Realtime events are transport hints; reconnect uses `ICanonicalSessionReader` before the UI resumes.
+- Removing/restarting the adapter cannot require local business-state recovery; the replacement instance reloads from Hub.
+
+## Privileged operation membrane
+
+Every privileged operation resolves a Hub decision before domain mutation:
+
+| Operation | Capability | Resource scope |
+|---|---|---|
+| register estate property | `domain.register` | `estate:<property>` |
+| read session state | `session.read` | `session:<id>` |
+| create governed task | `task.create` | `domain:<domain-id>` |
+| send task command | `task.command` | `task:<task-id>` |
+| read evidence | `evidence.read` | `task:<task-id>` |
+
+A decision is usable only when the Hub returns `Allowed=true`, a lease ID and a future expiry. Policy/lease transport failure is fail-closed for privileged work.
+
+The adapter never issues its own authority and browser identity headers are translation inputs only. A real domain MUST replace the reference identity translator with its authenticated server-side identity integration.
+
+## Progressive update / bounded CRUD
+
+The first task mutation pilot preserves the canonical sequence:
+
+```text
+APU -> Progressive Update -> #NB -> bounded CRUD -> SWFUS
+```
+
+- Task CREATE requires literal `#NB` and `crudIntent=CREATE`.
+- Commands require literal `#NB`.
+- Idempotency keys are bound to a SHA-256 fingerprint of tenant/domain/task + governed request content.
+- Exact replay returns the same bounded result.
+- Same key + changed governed content rejects with conflict.
+- Only operations explicitly declared safe/idempotent are retried.
+- Transport success is not represented as new canonical authority.
+
+## HTTP surface
+
+The reference adapter exposes:
+
+- `GET /kpgs/health` — Hub readiness + protocol/adapter version
 - `GET /kpgs/version` — adapter + protocol compatibility
-- `GET /kpgs/session/{id}` — canonical user-safe workflow snapshot
-- `POST /kpgs/tasks` — create a governed task from an accepted spec/input
-- `POST /kpgs/tasks/{id}/commands` — idempotent user commands/approvals
-- `GET /kpgs/tasks/{id}/evidence` — authorized evidence summary/reference
+- `GET /kpgs/session/{id}` — capability-gated canonical user-safe workflow snapshot
+- `POST /kpgs/tasks` — capability-gated, idempotent governed CREATE
+- `POST /kpgs/tasks/{id}/commands` — capability-gated idempotent command
+- `GET /kpgs/tasks/{id}/evidence` — capability-gated evidence summary/reference
 
 Domain-specific routes remain domain-specific.
 
-## Hub client responsibilities
+## Resilience defaults
 
-The adapter MUST:
-
-1. register/resolve its estate property;
-2. translate authenticated domain identity into Hub context without inventing authority;
-3. request short-lived capability leases for privileged operations;
-4. bind task requests to a governing specification;
-5. pass renter/skill events through canonical correlation identifiers;
-6. recover live state after transport reconnect from Hub/canonical sources;
-7. emit evidence and release/version metadata;
-8. fail closed when policy/lease verification is unavailable for a privileged action.
-
-## Resilience primitives
-
-The reference package SHOULD provide bounded defaults for:
+`KpgsHubInvoker` provides dependency-free bounded defaults:
 
 - request timeout;
-- retry of safe/idempotent operations;
-- idempotency keys;
-- circuit breaker;
-- reconnect/backoff;
-- cancellation;
-- correlation/log context.
+- retry only for calls declared idempotent;
+- exponential retry delay;
+- circuit breaker after consecutive transient failures;
+- cancellation propagation;
+- fail-closed capability/policy resolution.
 
-Retries MUST NOT turn a non-idempotent side effect into duplicate durable work.
+A retry never creates permission and never turns an unscoped browser request into trusted work.
 
 ## Authentication and secrets
 
-- No long-lived user/service secret is stored in browser-readable configuration.
-- The adapter may use a server-side secret provider reference.
-- Renter capabilities are short-lived and task/resource scoped.
-- Browser clients never become trusted merely because they possess a UI session.
+- No long-lived user/service secret belongs in browser-readable configuration.
+- `IKpgsSecretProvider` is the server-side abstraction for secret references.
+- The reference implementation accepts `env:` references only and is for local development.
+- Capability leases are short-lived and resource/task scoped.
+- Browser UI sessions do not grant Hub authority.
 
-## TypeScript/front-end interoperability
+## Existing PWA migration — no frontend rewrite
 
-Canonical JSON schemas under `governance/kpgs-vnext/` are the language-neutral truth. TypeScript types MAY be generated from those schemas or exposed through a tiny client package.
+1. Deploy the adapter as a sidecar/service for the domain.
+2. Register real implementations of `IKpgsHubClient`, `IKpgsIdentityTranslator`, `IKpgsEvidenceSink` and `IKpgsSecretProvider`.
+3. Map `app.MapKpgsAdapterEndpoints()` in the adapter service.
+4. Copy or package `dotnet/client/kpgs-client.ts` into the existing JS/TS application.
+5. Keep the current React/Next/Vite/MERN routes/components. Replace only the workflow/API call that needs KPGS governance with `KpgsClient`.
+6. Preserve domain-specific rendering and offline behavior; use canonical session reload after realtime reconnect.
+7. Promote only after the exact integration commit passes domain tests and evidence gates.
 
-The frontend should consume simple concepts such as:
+Example:
 
-- current task status;
-- next available actions;
-- user-safe explanation;
-- approval requirement;
-- offline/reconnect state.
+```ts
+const kpgs = new KpgsClient("https://adapter.example", () => serverResolvedIdentity);
+const task = await kpgs.createTask({
+  governingSpecRef: "spec://my-domain/create-order/v1",
+  input: formPayload,
+  idempotencyKey: submissionId,
+  updateId: progressiveUpdateId,
+});
+```
 
-It should not need to implement KPGS policy itself.
+The PWA remains a PWA. It does not reimplement capability policy.
 
-## Verification before runtime promotion
+## Rollback / removal
 
-Actual NuGet/runtime implementation MUST remain unreleased until:
+The adapter is deliberately removable:
 
-- the project builds on its target .NET SDK;
-- contract/schema tests pass;
-- unauthorized capability tests fail closed;
-- retry/idempotency tests pass;
-- realtime reconnect tests pass;
-- at least one existing JS/TS PWA integrates without a frontend rewrite;
-- rollback/removal of the adapter is demonstrated.
+1. Stop routing the governed workflow to `/kpgs/*`.
+2. Restore the previous domain API call or place the workflow in a truthful HOLD state.
+3. Remove the `KpgsClient` call/import if the domain no longer uses the adapter.
+4. Stop the adapter service / remove `MapKpgsAdapterEndpoints()`.
+5. Do **not** migrate canonical task/business records out of the adapter: it never owns them.
+6. On later reinstall, recover task/session state from Hub/canonical sources.
 
-The current GitHub Actions billing lock prevents producing that executable evidence, so this file is a contract, not a claim that the .NET runtime package is already verified.
+Rollback must never copy the transient idempotency cache or reference mock-Hub state into production truth.
+
+## Local reference service
+
+```bash
+dotnet run --project dotnet/Kopano.Kpgs.Reference/Kopano.Kpgs.Reference.csproj
+```
+
+The reference `DevelopmentMockHubClient` exists only to demonstrate the removable integration shape. It is not Sovereign Hub and must not be deployed as a production authority service.
+
+## Verification
+
+The dependency-free proof executable validates:
+
+```bash
+dotnet run --project dotnet/Kopano.Kpgs.Tests/Kopano.Kpgs.Tests.csproj -c Release
+```
+
+It covers:
+
+- machine-readable health/version;
+- lease-bound privileged CREATE;
+- exact replay and changed-payload collision;
+- denied capability before mutation;
+- policy transport outage fail-closed;
+- literal `#NB` before capability/mutation;
+- bounded retry of transient idempotent work;
+- realtime reconnect + canonical recovery;
+- adapter replacement/rollback recovering from Hub;
+- versioned Stateless Renter envelopes;
+- non-authoritative evidence tied to correlation + lease.
+
+CI additionally builds the reference service and packs the four NuGet projects. Runtime promotion is tied to the exact commit that passes those gates.


### PR DESCRIPTION
Closes #36.

## Canonical purpose

Ship the executable `.NET` service/control-plane boundary described by `governance/kpgs-vnext/dotnet/DOMAIN_ADAPTER.md` without rewriting existing React/Next/Vite/MERN/PWA frontends.

## Package graph

- `Kopano.Kpgs.Contracts` — protocol/version DTOs + Stateless Renter envelopes
- `Kopano.Kpgs.Adapter` — ASP.NET Core endpoint/service membrane, capability checks, idempotency, timeout/retry/circuit breaker, secret/identity/Hub abstractions
- `Kopano.Kpgs.Realtime` — event transport + canonical reconnect recovery
- `Kopano.Kpgs.Evidence` — correlation/lease-bound non-authoritative evidence
- `Kopano.Kpgs.Reference` — removable reference service with explicit development-only mock Hub
- `dotnet/client/kpgs-client.ts` — zero-rewrite TypeScript binding for existing PWAs

Target framework: `net10.0`.

## Governance boundary

- adapter stores no durable canonical business state;
- privileged domain registration, session read, task CREATE, command and evidence read resolve Hub capability decisions first;
- policy/lease transport failure fails closed;
- task CREATE requires literal `#NB` + bounded `CREATE` intent;
- task commands require literal `#NB`;
- exact idempotent replay executes once; same key + changed content rejects;
- retries are limited to operations declared idempotent;
- repeated transient failures open a bounded circuit;
- realtime reconnect reloads canonical session state rather than treating socket events as truth;
- evidence remains `canonical=false`, `authorityEffect=none`.

## Existing PWA integration

The existing frontend imports/copies the tiny `KpgsClient` and calls `/kpgs/*`. No .NET UI rewrite and no browser policy engine are required. Removal restores the previous API/HOLD path; canonical state remains in Hub.

## Proof gate

`.github/workflows/kpgs-dotnet-adapter-proof.yml` must pass on the exact head before promotion:

1. setup .NET 10 LTS;
2. build reference service + package graph;
3. execute the dependency-free proof harness covering health/version, lease enforcement, outage HOLD, #NB, replay/collision, safe retry, realtime recovery, adapter replacement/rollback, renter envelopes and evidence;
4. pack exactly four NuGet artifacts;
5. statically prove the removable TypeScript/PWA binding and rollback contract.

This PR stays draft until those exact-head receipts are green.