### PR TITLE
feat(eval): complete KPGS execute verify score promote rollback loop

### DIFF
--- a/.github/workflows/kpgs-vnext-phase0-gate.yml
+++ b/.github/workflows/kpgs-vnext-phase0-gate.yml
@@ -15,6 +15,7 @@ on:
       - "tests/test_evidence_bundles.py"
       - "tests/test_canonical_skill_runtime.py"
       - "tests/test_skill_package_workflow.py"
+      - "tests/test_evaluation_reward_loop.py"
       - "CONTRIBUTING.md"
       - "THIRD_PARTY_NOTICES.md"
       - "LICENSE"
@@ -33,6 +34,7 @@ on:
       - "tests/test_evidence_bundles.py"
       - "tests/test_canonical_skill_runtime.py"
       - "tests/test_skill_package_workflow.py"
+      - "tests/test_evaluation_reward_loop.py"
       - "CONTRIBUTING.md"
       - "THIRD_PARTY_NOTICES.md"
       - "LICENSE"
@@ -103,6 +105,9 @@ jobs:
       - name: Prove canonical skill package developer workflow
         run: python -m unittest discover -s tests -p 'test_skill_package_workflow.py' -v
 
+      - name: Prove evaluation score promote observe rollback loop
+        run: python -m unittest discover -s tests -p 'test_evaluation_reward_loop.py' -v
+
       - name: Compile validators and governed runtimes
         run: >-
           python -m py_compile
@@ -116,6 +121,7 @@ jobs:
           governance/kpgs-vnext/estate-registry/registry.py
           governance/kpgs-vnext/evidence/validate_evidence.py
           governance/kpgs-vnext/evidence/evidence.py
+          governance/kpgs-vnext/evaluation/evaluation.py
           kopano-core/kopano/swfus_engine.py
           kopano-core/kopano/kessa_mmao_api.py
           kopano-core/kopano/skill_runtime.py

--- a/governance/kpgs-vnext/evaluation/README.md
+++ b/governance/kpgs-vnext/evaluation/README.md
@@ -1,0 +1,79 @@
+# KPGS Evaluation & Reward Loop
+
+Issue: #38
+
+```text
+prepare/synthesize
+→ execute
+→ verify/profile
+→ score
+→ improve
+→ promote | hold
+→ observe
+→ rollback recommendation when thresholds regress
+```
+
+## Canonical inputs
+
+- `reference-suite.json` — versioned regression/evaluation cases;
+- `promotion-policy.json` — thresholds declared **before** execution;
+- `evaluation.py` — deterministic scoring, promotion admission and post-release observation;
+- canonical `evidence/evidence.py` — machine-readable evidence bundle, verifier attribution and hard-gate law.
+
+The reference regression suite covers one renter boundary, one skill-runtime boundary and one bounded SWFUS/domain-adapter boundary. The KPGS contract workflow executes those concrete test surfaces before the evaluation-loop test.
+
+## Deterministic versus probabilistic
+
+Every case declares one of:
+
+- `deterministic` — contract/unit/integration result expected to be reproducible;
+- `probabilistic` — bounded statistical result with a declared sample floor;
+- `model-eval` — nondeterministic/model evaluation, also requiring a sample floor.
+
+They remain separate in `kpgs.evaluation-score.v1`. A probabilistic score cannot hide a failed deterministic hard gate.
+
+## Evidence correlation
+
+Production promotion consumes the existing canonical KPGS evidence bundle. The bundle already binds exact repository commit, adapter version, renter protocol version, skill versions, capability-lease references, verifier identity, artifacts, metrics and deployment trace. Environment identity belongs in the `deployment` trace/artifact metadata; it is not inferred from a hostname or CI branch name.
+
+A promotion decision stores the evidence `bundle_id` and exact commit SHA. It is therefore auditable back to the same machine-readable evidence surface used by engineering/everyday scorecards.
+
+## Promotion gates
+
+`promotion-policy.json` declares before evaluation:
+
+- minimum aggregate score;
+- risk classes requiring human approval;
+- observation-window duration;
+- rollback-target requirement;
+- post-release rollback thresholds.
+
+Hard evaluation/security/governance failures force `hold` even if aggregate score is high.
+
+High/critical risk promotion requires a human approval reference. The runtime records the approval reference; it does not fabricate or self-approve it.
+
+## Observation and rollback
+
+Promotion starts a declared observation window. `observe_release()` evaluates measured post-release metrics against the predeclared rollback thresholds.
+
+A trigger produces a recommendation only:
+
+```text
+rollback_recommended = true
+automatic_execution = false
+required_capability = estate.release.rollback
+```
+
+Rollback execution remains a separate governed action with its own capability lease and recorded target.
+
+## Hard laws
+
+```text
+HIGH SCORE != HARD-GATE PASS
+MODEL EVAL != DETERMINISTIC TEST
+PROMOTION != SELF-APPROVAL
+PROMOTION DECISION != EVIDENCE BUNDLE
+OBSERVATION != AUTOMATIC ROLLBACK
+ROLLBACK RECOMMENDATION != ROLLBACK AUTHORITY
+CI BRANCH NAME != DEPLOYMENT ENVIRONMENT
+```

--- a/governance/kpgs-vnext/evaluation/evaluation.py
+++ b/governance/kpgs-vnext/evaluation/evaluation.py
@@ -1,0 +1,231 @@
+"""KPGS evaluation, promotion and rollback decision runtime.
+
+Thresholds are declared before execution. Deterministic hard gates remain
+separate from probabilistic/model scores and can never be averaged away.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from datetime import datetime, timedelta, timezone
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+VALID_METHODS = {"deterministic", "probabilistic", "model-eval"}
+VALID_RISK = {"low", "medium", "high", "critical"}
+
+
+class EvaluationError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class EvaluationResult:
+    case_id: str
+    method: str
+    score: float
+    passed: bool
+    evidence_ref: str
+    verifier_id: str
+    samples: int | None = None
+
+
+def _digest(value: Any) -> str:
+    return hashlib.sha256(json.dumps(value, sort_keys=True, separators=(",", ":"), default=str).encode()).hexdigest()
+
+
+def _iso(value: datetime) -> str:
+    return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise EvaluationError(f"expected object: {path}")
+    return value
+
+
+def validate_suite(suite: Mapping[str, Any]) -> None:
+    if suite.get("schema") != "kpgs.evaluation-suite.v1":
+        raise EvaluationError("unsupported evaluation suite schema")
+    if not suite.get("suite_id") or not suite.get("version"):
+        raise EvaluationError("suite identity/version are required")
+    if suite.get("risk_class") not in VALID_RISK:
+        raise EvaluationError("unknown suite risk class")
+    cases = suite.get("cases")
+    if not isinstance(cases, list) or not cases:
+        raise EvaluationError("evaluation suite requires cases")
+    ids: set[str] = set()
+    for case in cases:
+        if not isinstance(case, Mapping):
+            raise EvaluationError("evaluation case must be an object")
+        case_id = case.get("id")
+        if not isinstance(case_id, str) or not case_id or case_id in ids:
+            raise EvaluationError("evaluation case IDs must be unique and non-empty")
+        ids.add(case_id)
+        if case.get("method") not in VALID_METHODS:
+            raise EvaluationError(f"unknown evaluation method: {case.get('method')}")
+        threshold = case.get("threshold")
+        if not isinstance(threshold, (int, float)) or isinstance(threshold, bool) or not 0 <= threshold <= 1:
+            raise EvaluationError("case threshold must be between 0 and 1")
+        if case.get("method") != "deterministic":
+            minimum = case.get("minimum_samples")
+            if not isinstance(minimum, int) or minimum < 1:
+                raise EvaluationError("probabilistic/model cases require minimum_samples")
+
+
+def validate_policy(policy: Mapping[str, Any]) -> None:
+    if policy.get("schema") != "kpgs.promotion-policy.v1":
+        raise EvaluationError("unsupported promotion policy schema")
+    score = policy.get("minimum_aggregate_score")
+    if not isinstance(score, (int, float)) or isinstance(score, bool) or not 0 <= score <= 1:
+        raise EvaluationError("minimum aggregate score must be between 0 and 1")
+    if not isinstance(policy.get("observation_window_seconds"), int) or policy["observation_window_seconds"] < 1:
+        raise EvaluationError("observation window must be positive")
+    approvals = policy.get("human_approval_required_for", [])
+    if any(item not in VALID_RISK for item in approvals):
+        raise EvaluationError("unknown human-approval risk class")
+
+
+def score_results(suite: Mapping[str, Any], results: Iterable[EvaluationResult]) -> dict[str, Any]:
+    validate_suite(suite)
+    result_map = {result.case_id: result for result in results}
+    cases = suite["cases"]
+    missing = [case["id"] for case in cases if case["id"] not in result_map]
+    if missing:
+        raise EvaluationError("missing evaluation results: " + ", ".join(missing))
+
+    hard_failures: list[str] = []
+    scored: list[dict[str, Any]] = []
+    for case in cases:
+        result = result_map[case["id"]]
+        if result.method != case["method"]:
+            raise EvaluationError(f"method mismatch for {case['id']}")
+        if not 0 <= result.score <= 1:
+            raise EvaluationError(f"score outside 0..1 for {case['id']}")
+        if case["method"] != "deterministic" and (result.samples or 0) < case["minimum_samples"]:
+            raise EvaluationError(f"insufficient samples for {case['id']}")
+        threshold_pass = result.passed and result.score >= case["threshold"]
+        if case.get("hard_gate") is True and not threshold_pass:
+            hard_failures.append(case["id"])
+        scored.append({
+            **asdict(result),
+            "threshold": float(case["threshold"]),
+            "hard_gate": bool(case.get("hard_gate")),
+            "threshold_pass": threshold_pass,
+        })
+
+    aggregate = sum(item["score"] for item in scored) / len(scored)
+    return {
+        "schema": "kpgs.evaluation-score.v1",
+        "suite_id": suite["suite_id"],
+        "suite_version": suite["version"],
+        "suite_digest": _digest(suite),
+        "risk_class": suite["risk_class"],
+        "aggregate_score": round(aggregate, 6),
+        "hard_gate_failures": hard_failures,
+        "deterministic": [item for item in scored if item["method"] == "deterministic"],
+        "probabilistic": [item for item in scored if item["method"] in {"probabilistic", "model-eval"}],
+    }
+
+
+def decide_promotion(
+    *,
+    scorecard: Mapping[str, Any],
+    policy: Mapping[str, Any],
+    evidence_bundle: Mapping[str, Any],
+    rollback_target: str | None,
+    human_approval_ref: str | None = None,
+    clock: datetime | None = None,
+) -> dict[str, Any]:
+    validate_policy(policy)
+    now = clock or datetime.now(timezone.utc)
+    if not evidence_bundle.get("bundle_id") or not evidence_bundle.get("commit_sha"):
+        raise EvaluationError("machine-readable evidence bundle with exact commit is required")
+    if policy.get("rollback_target_required") is True and not rollback_target:
+        raise EvaluationError("predeclared rollback target is required")
+
+    reasons: list[str] = []
+    decision = "promote"
+    if scorecard.get("hard_gate_failures"):
+        decision = "hold"
+        reasons.append("hard evaluation gate failed")
+    if evidence_bundle.get("governance_decision", {}).get("decision") not in {"allow", "promote"}:
+        decision = "hold"
+        reasons.append("evidence bundle is not governance-admitted for promotion")
+    if float(scorecard.get("aggregate_score", -1)) < float(policy["minimum_aggregate_score"]):
+        decision = "hold"
+        reasons.append("aggregate score below predeclared threshold")
+    risk = scorecard.get("risk_class")
+    if risk in policy.get("human_approval_required_for", []) and not human_approval_ref:
+        decision = "hold"
+        reasons.append("human approval required for risk class")
+
+    observation_end = now + timedelta(seconds=int(policy["observation_window_seconds"]))
+    payload = {
+        "schema": "kpgs.promotion-decision.v1",
+        "decision": decision,
+        "reasons": reasons or ["all predeclared promotion gates passed"],
+        "suite_id": scorecard["suite_id"],
+        "suite_version": scorecard["suite_version"],
+        "suite_digest": scorecard["suite_digest"],
+        "policy_id": policy.get("policy_id"),
+        "policy_version": policy.get("version"),
+        "policy_digest": _digest(policy),
+        "evidence_bundle_id": evidence_bundle["bundle_id"],
+        "commit_sha": evidence_bundle["commit_sha"],
+        "aggregate_score": scorecard["aggregate_score"],
+        "hard_gate_failures": list(scorecard.get("hard_gate_failures", [])),
+        "human_approval_ref": human_approval_ref,
+        "rollback_target": rollback_target,
+        "observation_window": {"starts_at": _iso(now), "ends_at": _iso(observation_end)},
+        "automatic_rollback": False,
+        "created_at": _iso(now),
+    }
+    payload["decision_id"] = "promotion_" + _digest(payload)[:24]
+    return payload
+
+
+def observe_release(
+    *,
+    promotion_decision: Mapping[str, Any],
+    policy: Mapping[str, Any],
+    metrics: Mapping[str, float],
+    observed_at: datetime,
+) -> dict[str, Any]:
+    validate_policy(policy)
+    start = datetime.fromisoformat(promotion_decision["observation_window"]["starts_at"].replace("Z", "+00:00"))
+    end = datetime.fromisoformat(promotion_decision["observation_window"]["ends_at"].replace("Z", "+00:00"))
+    if observed_at < start or observed_at > end:
+        raise EvaluationError("observation is outside the declared release window")
+
+    triggers: list[str] = []
+    for name, rule in policy.get("rollback_thresholds", {}).items():
+        if name not in metrics:
+            continue
+        value = metrics[name]
+        operator = rule.get("operator")
+        threshold = rule.get("value")
+        hit = (
+            (operator == "gt" and value > threshold)
+            or (operator == "gte" and value >= threshold)
+            or (operator == "lt" and value < threshold)
+            or (operator == "lte" and value <= threshold)
+        )
+        if hit:
+            triggers.append(f"{name} {operator} {threshold}")
+
+    return {
+        "schema": "kpgs.release-observation.v1",
+        "decision_id": promotion_decision["decision_id"],
+        "evidence_bundle_id": promotion_decision["evidence_bundle_id"],
+        "observed_at": _iso(observed_at),
+        "metrics": dict(metrics),
+        "rollback_recommended": bool(triggers),
+        "rollback_target": promotion_decision.get("rollback_target"),
+        "triggers": triggers,
+        "automatic_execution": False,
+        "required_capability": "estate.release.rollback",
+    }

--- a/governance/kpgs-vnext/evaluation/promotion-policy.json
+++ b/governance/kpgs-vnext/evaluation/promotion-policy.json
@@ -1,0 +1,21 @@
+{
+  "schema": "kpgs.promotion-policy.v1",
+  "policy_id": "kpgs-core-promotion",
+  "version": "1.0.0",
+  "minimum_aggregate_score": 0.9,
+  "human_approval_required_for": ["high", "critical"],
+  "observation_window_seconds": 3600,
+  "rollback_target_required": true,
+  "rollback_thresholds": {
+    "error-rate": { "operator": "gt", "value": 0.05 },
+    "reliability": { "operator": "lt", "value": 0.99 },
+    "task-completion": { "operator": "lt", "value": 0.8 }
+  },
+  "rules": [
+    "hard governance/security/evaluation gates cannot be averaged away",
+    "probabilistic cases must satisfy minimum sample requirements",
+    "promotion evidence bundle must be machine-readable and tied to exact commit",
+    "high and critical risk promotions require recorded human approval",
+    "rollback execution requires its own capability lease"
+  ]
+}

--- a/governance/kpgs-vnext/evaluation/reference-suite.json
+++ b/governance/kpgs-vnext/evaluation/reference-suite.json
@@ -1,0 +1,41 @@
+{
+  "schema": "kpgs.evaluation-suite.v1",
+  "suite_id": "kpgs-core-regression",
+  "version": "1.0.0",
+  "risk_class": "high",
+  "cases": [
+    {
+      "id": "renter-capability-denial",
+      "layer": "renter",
+      "method": "deterministic",
+      "hard_gate": true,
+      "threshold": 1.0,
+      "fixture_ref": "repo://tests/test_capability_lease_runtime.py"
+    },
+    {
+      "id": "skill-lease-bound-execution",
+      "layer": "skill",
+      "method": "deterministic",
+      "hard_gate": true,
+      "threshold": 1.0,
+      "fixture_ref": "repo://tests/test_canonical_skill_runtime.py"
+    },
+    {
+      "id": "domain-adapter-swfus-idempotency",
+      "layer": "domain-adapter",
+      "method": "deterministic",
+      "hard_gate": true,
+      "threshold": 1.0,
+      "fixture_ref": "repo://tests/test_swfus_progressive_updates.py"
+    },
+    {
+      "id": "adaptive-user-outcome",
+      "layer": "user-outcome",
+      "method": "probabilistic",
+      "hard_gate": false,
+      "threshold": 0.8,
+      "minimum_samples": 20,
+      "fixture_ref": "evidence://user-outcome/sample-window"
+    }
+  ]
+}

--- a/tests/test_evaluation_reward_loop.py
+++ b/tests/test_evaluation_reward_loop.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import importlib.util
+import json
+from pathlib import Path
+import sys
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "governance/kpgs-vnext/evaluation/evaluation.py"
+spec = importlib.util.spec_from_file_location("kpgs_evaluation", MODULE_PATH)
+assert spec and spec.loader
+mod = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = mod
+spec.loader.exec_module(mod)
+
+SUITE = json.loads((ROOT / "governance/kpgs-vnext/evaluation/reference-suite.json").read_text(encoding="utf-8"))
+POLICY = json.loads((ROOT / "governance/kpgs-vnext/evaluation/promotion-policy.json").read_text(encoding="utf-8"))
+
+
+def results(user_score=0.9, renter_pass=True):
+    return [
+        mod.EvaluationResult("renter-capability-denial", "deterministic", 1.0 if renter_pass else 0.0, renter_pass, "ci://capability-lease", "capability-verifier"),
+        mod.EvaluationResult("skill-lease-bound-execution", "deterministic", 1.0, True, "ci://skill-runtime", "skill-verifier"),
+        mod.EvaluationResult("domain-adapter-swfus-idempotency", "deterministic", 1.0, True, "ci://swfus", "swfus-verifier"),
+        mod.EvaluationResult("adaptive-user-outcome", "probabilistic", user_score, user_score >= 0.8, "evidence://user-outcome/window", "outcome-profiler", samples=25),
+    ]
+
+
+def bundle(decision="promote"):
+    return {
+        "bundle_id": "evidence_fixture_001",
+        "commit_sha": "a" * 40,
+        "governance_decision": {"decision": decision},
+    }
+
+
+class EvaluationRewardLoopTests(unittest.TestCase):
+    def test_reference_regression_suite_covers_renter_skill_and_domain_adapter(self):
+        mod.validate_suite(SUITE)
+        layers = {case["layer"] for case in SUITE["cases"]}
+        self.assertTrue({"renter", "skill", "domain-adapter"}.issubset(layers))
+        refs = {case["fixture_ref"] for case in SUITE["cases"]}
+        self.assertIn("repo://tests/test_capability_lease_runtime.py", refs)
+        self.assertIn("repo://tests/test_canonical_skill_runtime.py", refs)
+        self.assertIn("repo://tests/test_swfus_progressive_updates.py", refs)
+
+    def test_deterministic_and_probabilistic_results_remain_distinct(self):
+        scored = mod.score_results(SUITE, results())
+        self.assertEqual(len(scored["deterministic"]), 3)
+        self.assertEqual(len(scored["probabilistic"]), 1)
+        self.assertEqual(scored["probabilistic"][0]["samples"], 25)
+        self.assertEqual(scored["hard_gate_failures"], [])
+
+    def test_hard_failure_cannot_be_averaged_away(self):
+        scored = mod.score_results(SUITE, results(user_score=1.0, renter_pass=False))
+        self.assertGreater(scored["aggregate_score"], 0.7)
+        self.assertEqual(scored["hard_gate_failures"], ["renter-capability-denial"])
+        decision = mod.decide_promotion(
+            scorecard=scored,
+            policy=POLICY,
+            evidence_bundle=bundle(),
+            rollback_target="release://previous",
+            human_approval_ref="human://approval/1",
+            clock=datetime(2026, 8, 19, tzinfo=timezone.utc),
+        )
+        self.assertEqual(decision["decision"], "hold")
+        self.assertIn("hard evaluation gate failed", decision["reasons"])
+
+    def test_high_risk_promotion_requires_human_approval(self):
+        scored = mod.score_results(SUITE, results())
+        held = mod.decide_promotion(
+            scorecard=scored,
+            policy=POLICY,
+            evidence_bundle=bundle(),
+            rollback_target="release://previous",
+            clock=datetime(2026, 8, 19, tzinfo=timezone.utc),
+        )
+        self.assertEqual(held["decision"], "hold")
+        self.assertIn("human approval required for risk class", held["reasons"])
+
+        promoted = mod.decide_promotion(
+            scorecard=scored,
+            policy=POLICY,
+            evidence_bundle=bundle(),
+            rollback_target="release://previous",
+            human_approval_ref="human://approval/42",
+            clock=datetime(2026, 8, 19, tzinfo=timezone.utc),
+        )
+        self.assertEqual(promoted["decision"], "promote")
+        self.assertEqual(promoted["evidence_bundle_id"], "evidence_fixture_001")
+        self.assertEqual(promoted["commit_sha"], "a" * 40)
+        self.assertEqual(promoted["automatic_rollback"], False)
+
+    def test_release_observation_recommends_but_does_not_auto_execute_rollback(self):
+        scored = mod.score_results(SUITE, results())
+        start = datetime(2026, 8, 19, tzinfo=timezone.utc)
+        promoted = mod.decide_promotion(
+            scorecard=scored,
+            policy=POLICY,
+            evidence_bundle=bundle(),
+            rollback_target="release://previous",
+            human_approval_ref="human://approval/42",
+            clock=start,
+        )
+        observation = mod.observe_release(
+            promotion_decision=promoted,
+            policy=POLICY,
+            metrics={"error-rate": 0.08, "reliability": 0.995, "task-completion": 0.9},
+            observed_at=start + timedelta(minutes=5),
+        )
+        self.assertTrue(observation["rollback_recommended"])
+        self.assertFalse(observation["automatic_execution"])
+        self.assertEqual(observation["required_capability"], "estate.release.rollback")
+        self.assertIn("error-rate gt 0.05", observation["triggers"])
+
+    def test_probabilistic_case_requires_declared_sample_floor(self):
+        insufficient = results()
+        insufficient[-1] = mod.EvaluationResult("adaptive-user-outcome", "probabilistic", 0.95, True, "evidence://user-outcome/window", "outcome-profiler", samples=5)
+        with self.assertRaisesRegex(mod.EvaluationError, "insufficient samples"):
+            mod.score_results(SUITE, insufficient)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Purpose

Close #38 by connecting the existing canonical evidence-bundle/scorecard substrate to a versioned evaluation, promotion and post-release observation loop.

```text
prepare/synthesize
→ execute
→ verify/profile
→ score
→ improve
→ promote | hold
→ observe
→ rollback recommendation
```

## What changed

### Versioned regression suite
Adds `governance/kpgs-vnext/evaluation/reference-suite.json` with explicit cases for:

- renter capability denial;
- lease-bound skill execution;
- SWFUS/domain-adapter idempotency;
- bounded probabilistic user-outcome evaluation.

The first three point to concrete existing tests already executed by the KPGS contract gate.

### Predeclared promotion policy
Adds `promotion-policy.json` with:

- minimum aggregate score;
- high/critical human-approval requirement;
- explicit observation window;
- required rollback target;
- predeclared error-rate/reliability/task-completion rollback thresholds.

### Evaluation runtime
Adds `evaluation.py`:

- validates suite/policy identity before scoring;
- keeps deterministic versus probabilistic/model evaluations structurally separate;
- enforces minimum sample counts for nondeterministic cases;
- keeps hard-gate failures outside aggregate-score averaging;
- ties promotion decisions to machine-readable evidence `bundle_id` + exact commit;
- requires human approval for configured risk classes;
- records rollback target and observation window;
- recommends rollback on post-release regression but never self-executes it.

### Exact-head CI
The KPGS vNext Contract Gate now runs `test_evaluation_reward_loop.py` after the existing renter, SWFUS, evidence and skill-runtime proofs and compiles the evaluation runtime.

## Acceptance boundaries

```text
HIGH SCORE != HARD-GATE PASS
MODEL EVAL != DETERMINISTIC TEST
PROMOTION != SELF-APPROVAL
OBSERVATION != AUTOMATIC ROLLBACK
ROLLBACK RECOMMENDATION != ROLLBACK AUTHORITY
```

The existing canonical evidence bundle remains the provenance surface for exact commit, adapter/renter/skill versions, verifier/profile inputs, capability leases, deployment trace/environment metadata and artifacts. Promotion references that bundle rather than creating a second evidence model.

Closes #38 only if exact-head KPGS and broader CI gates pass.