### PR TITLE
fix(dotnet): harden replay lease and #NB adapter boundary

### DIFF
--- a/dotnet/Kopano.Kpgs.Adapter.Tests/Program.cs
+++ b/dotnet/Kopano.Kpgs.Adapter.Tests/Program.cs
@@ -8,6 +8,20 @@ static void Assert(bool condition, string message)
     if (!condition) throw new InvalidOperationException(message);
 }
 
+static async Task ExpectAsync<TException>(Func<Task> action, string message)
+    where TException : Exception
+{
+    try
+    {
+        await action();
+    }
+    catch (TException)
+    {
+        return;
+    }
+    throw new InvalidOperationException(message);
+}
+
 var manifest = new DomainManifest("example.kopanolabs.com", "proof-adapter", "0.1.0-preview.1", "1.0", "kpgs://spec/domain-proof");
 var options = new KpgsAdapterOptions(manifest, TimeSpan.FromMilliseconds(100), 1, 2);
 var evidence = new InMemoryEvidenceSink();
@@ -18,6 +32,7 @@ Assert(hub.Registered, "domain registration did not execute");
 Assert((await adapter.HealthAsync()).Ready, "adapter is not ready");
 Assert(adapter.Version("1.9").Compatible, "same protocol major should be compatible");
 Assert(!adapter.Version("2.0").Compatible, "different protocol major must be incompatible");
+Assert(KpgsProtocol.ProgressiveUpdate.Contains("#NB", StringComparison.Ordinal), "progressive-update contract lost #NB");
 
 var identity = new DomainIdentity("human:1", "human", "tenant:1", new Dictionary<string, string>());
 var context = new HubContext(manifest.EstateProperty, "tenant:1", "domain:1", "task:1", "corr:1", identity, manifest.GoverningSpecRef);
@@ -26,19 +41,49 @@ var created = await adapter.CreateTaskAsync(context, request);
 var replay = await adapter.CreateTaskAsync(context, request);
 Assert(created == replay, "idempotent task replay changed the result");
 Assert(hub.CreateCalls == 1, "idempotent task replay executed twice");
+Assert(hub.CapabilityCalls == 2, "exact replay bypassed a fresh capability decision");
 Assert(evidence.Items.Count == 1 && evidence.Items[0].AuthorityEffect == "none", "execution evidence missing or promoted authority");
 
+await ExpectAsync<KpgsIdempotencyConflictException>(
+    () => adapter.CreateTaskAsync(
+        context,
+        request with { Input = new { goal = "different governed content" } }),
+    "changed content reused the same idempotency identity without conflict");
+Assert(hub.CreateCalls == 1, "idempotency collision reached a second CREATE mutation");
+
+var concurrentRequest = new GovernedTaskRequest("task:1", "corr:concurrent", manifest.GoverningSpecRef, new { goal = "concurrent" }, "idem:create:concurrent");
+var concurrent = await Task.WhenAll(
+    adapter.CreateTaskAsync(context, concurrentRequest),
+    adapter.CreateTaskAsync(context, concurrentRequest));
+Assert(concurrent[0] == concurrent[1], "concurrent exact replay returned divergent snapshots");
+Assert(hub.CreateCalls == 2, "concurrent exact replay executed duplicate Hub CREATE work");
+
+var beforeNbCapabilityCalls = hub.CapabilityCalls;
+await ExpectAsync<InvalidOperationException>(
+    () => adapter.CreateTaskAsync(context, request with { IdempotencyKey = "idem:bad-nb", BoundaryMarker = "NB" }),
+    "mutation without literal #NB was admitted");
+Assert(hub.CapabilityCalls == beforeNbCapabilityCalls, "invalid #NB boundary reached capability resolution");
+
 hub.Allow = false;
-try
-{
-    await adapter.ExecuteCommandAsync(context, new GovernedCommand("cmd:deny", "approve", null, "idem:deny:1", "corr:deny"));
-    throw new InvalidOperationException("denied capability executed");
-}
-catch (CapabilityDeniedException)
-{
-    Assert(hub.CommandCalls == 0, "denied command reached the privileged hub operation");
-}
+await ExpectAsync<CapabilityDeniedException>(
+    () => adapter.ExecuteCommandAsync(context, new GovernedCommand("cmd:deny", "approve", null, "idem:deny:1", "corr:deny")),
+    "denied capability executed");
+Assert(hub.CommandCalls == 0, "denied command reached the privileged hub operation");
 hub.Allow = true;
+
+hub.ExpireLeases = true;
+await ExpectAsync<CapabilityDeniedException>(
+    () => adapter.ExecuteCommandAsync(context, new GovernedCommand("cmd:expired", "approve", null, "idem:expired:1", "corr:expired")),
+    "expired capability lease executed");
+Assert(hub.CommandCalls == 0, "expired lease reached the privileged hub operation");
+hub.ExpireLeases = false;
+
+await ExpectAsync<InvalidOperationException>(
+    () => adapter.ExecuteCommandAsync(
+        context,
+        new GovernedCommand("cmd:bad-nb", "approve", null, "idem:bad-nb-command", "corr:bad-nb", "NB")),
+    "command without literal #NB was admitted");
+Assert(hub.CommandCalls == 0, "invalid command #NB reached the privileged hub operation");
 
 var fallbackLog = new List<RealtimeTransportKind>();
 var realtime = new KpgsRealtimeClient(
@@ -73,6 +118,8 @@ sealed class ProofHub : IKpgsHubClient
 {
     public bool Registered { get; private set; }
     public bool Allow { get; set; } = true;
+    public bool ExpireLeases { get; set; }
+    public int CapabilityCalls { get; private set; }
     public int CreateCalls { get; private set; }
     public int CommandCalls { get; private set; }
 
@@ -83,13 +130,25 @@ sealed class ProofHub : IKpgsHubClient
     }
 
     public Task<bool> IsReadyAsync(CancellationToken cancellationToken) => Task.FromResult(true);
-    public Task<CapabilityDecision> RequestCapabilityAsync(HubContext context, CapabilityRequest request, CancellationToken cancellationToken) =>
-        Task.FromResult(new CapabilityDecision(Allow, "policy://proof", Allow ? "lease:proof" : null, Allow ? DateTimeOffset.UtcNow.AddMinutes(1) : null, Allow ? "allowed" : "not permitted for this task"));
+
+    public Task<CapabilityDecision> RequestCapabilityAsync(HubContext context, CapabilityRequest request, CancellationToken cancellationToken)
+    {
+        CapabilityCalls++;
+        var expiry = ExpireLeases
+            ? DateTimeOffset.UtcNow.AddSeconds(-1)
+            : DateTimeOffset.UtcNow.AddMinutes(1);
+        return Task.FromResult(new CapabilityDecision(
+            Allow,
+            "policy://proof",
+            Allow ? "lease:proof" : null,
+            Allow ? expiry : null,
+            !Allow ? "not permitted for this task" : ExpireLeases ? "lease expired" : "allowed"));
+    }
 
     public Task<GovernedTaskSnapshot> CreateTaskAsync(HubContext context, GovernedTaskRequest request, string leaseToken, CancellationToken cancellationToken)
     {
         CreateCalls++;
-        return Task.FromResult(new GovernedTaskSnapshot(request.TaskId, "created", 1, ["continue"], "created", request.CorrelationId));
+        return Task.FromResult(new GovernedTaskSnapshot(request.TaskId, "created", CreateCalls, ["continue"], "created", request.CorrelationId));
     }
 
     public Task<GovernedTaskSnapshot> ExecuteCommandAsync(HubContext context, GovernedCommand command, string leaseToken, CancellationToken cancellationToken)

--- a/dotnet/Kopano.Kpgs.Adapter/Adapter.cs
+++ b/dotnet/Kopano.Kpgs.Adapter/Adapter.cs
@@ -1,4 +1,7 @@
 using System.Collections.Concurrent;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
 using Kopano.Kpgs.Contracts;
 using Kopano.Kpgs.Evidence;
 using Microsoft.AspNetCore.Builder;
@@ -30,6 +33,7 @@ public interface IKpgsHubClient
 }
 
 public sealed class CapabilityDeniedException(string message) : InvalidOperationException(message);
+public sealed class KpgsIdempotencyConflictException(string message) : InvalidOperationException(message);
 
 public sealed class KpgsResiliencePolicy(KpgsAdapterOptions options)
 {
@@ -70,7 +74,11 @@ public sealed class KpgsDomainAdapter(
     IKpgsHubClient hub,
     IKpgsEvidenceSink evidence)
 {
-    private readonly ConcurrentDictionary<string, GovernedTaskSnapshot> _idempotentResults = new(StringComparer.Ordinal);
+    private sealed record IdempotencyEntry(
+        string Fingerprint,
+        Lazy<Task<GovernedTaskSnapshot>> Operation);
+
+    private readonly ConcurrentDictionary<string, IdempotencyEntry> _idempotentResults = new(StringComparer.Ordinal);
     private readonly KpgsResiliencePolicy _resilience = new(options);
 
     public DomainManifest Manifest => options.Manifest;
@@ -94,24 +102,76 @@ public sealed class KpgsDomainAdapter(
 
     public async Task<GovernedTaskSnapshot> CreateTaskAsync(HubContext context, GovernedTaskRequest request, CancellationToken cancellationToken = default)
     {
-        if (_idempotentResults.TryGetValue(request.IdempotencyKey, out var replay)) return replay;
-        var lease = await RequireLeaseAsync(context, new CapabilityRequest("task.create", $"task:{request.TaskId}", request.IdempotencyKey), cancellationToken);
-        // Non-idempotent business execution is never transparently retried here. The
-        // caller-supplied key and Hub remain the durable replay authority.
-        var result = await hub.CreateTaskAsync(context, request, lease, cancellationToken);
-        _idempotentResults.TryAdd(request.IdempotencyKey, result);
-        await evidence.EmitAsync(EvidenceFactory.Create(context, "task-created", $"kpgs://task/{request.TaskId}", result), cancellationToken);
-        return result;
+        ValidateCreateBoundary(request);
+
+        // Replays do not bypass authorization: every privileged invocation resolves
+        // a current Hub decision before it may reuse or execute governed work.
+        var lease = await RequireLeaseAsync(
+            context,
+            new CapabilityRequest("task.create", $"task:{request.TaskId}", request.IdempotencyKey),
+            cancellationToken);
+
+        var scopedKey = $"create:{context.TenantId}:{context.DomainId}:{request.TaskId}:{request.IdempotencyKey}";
+        var fingerprint = Fingerprint(new
+        {
+            context.TenantId,
+            context.DomainId,
+            request.TaskId,
+            request.CorrelationId,
+            request.GoverningSpecRef,
+            request.Input,
+            request.BoundaryMarker,
+            request.CrudIntent,
+        });
+
+        return await ExecuteOnceAsync(
+            scopedKey,
+            fingerprint,
+            async () =>
+            {
+                // Non-idempotent business execution is never transparently retried here.
+                // The caller key + this collision membrane + Hub/domain state form the replay boundary.
+                var result = await hub.CreateTaskAsync(context, request, lease, cancellationToken);
+                await evidence.EmitAsync(
+                    EvidenceFactory.Create(context, "task-created", $"kpgs://task/{request.TaskId}", result),
+                    cancellationToken);
+                return result;
+            });
     }
 
     public async Task<GovernedTaskSnapshot> ExecuteCommandAsync(HubContext context, GovernedCommand command, CancellationToken cancellationToken = default)
     {
-        if (_idempotentResults.TryGetValue(command.IdempotencyKey, out var replay)) return replay;
-        var lease = await RequireLeaseAsync(context, new CapabilityRequest($"task.command.{command.Name}", $"task:{context.TaskId}", command.IdempotencyKey), cancellationToken);
-        var result = await hub.ExecuteCommandAsync(context, command, lease, cancellationToken);
-        _idempotentResults.TryAdd(command.IdempotencyKey, result);
-        await evidence.EmitAsync(EvidenceFactory.Create(context, "task-command", $"kpgs://command/{command.CommandId}", result), cancellationToken);
-        return result;
+        ValidateCommandBoundary(command);
+
+        var lease = await RequireLeaseAsync(
+            context,
+            new CapabilityRequest($"task.command.{command.Name}", $"task:{context.TaskId}", command.IdempotencyKey),
+            cancellationToken);
+
+        var scopedKey = $"command:{context.TenantId}:{context.DomainId}:{context.TaskId}:{command.IdempotencyKey}";
+        var fingerprint = Fingerprint(new
+        {
+            context.TenantId,
+            context.DomainId,
+            context.TaskId,
+            command.CommandId,
+            command.Name,
+            command.Payload,
+            command.CorrelationId,
+            command.BoundaryMarker,
+        });
+
+        return await ExecuteOnceAsync(
+            scopedKey,
+            fingerprint,
+            async () =>
+            {
+                var result = await hub.ExecuteCommandAsync(context, command, lease, cancellationToken);
+                await evidence.EmitAsync(
+                    EvidenceFactory.Create(context, "task-command", $"kpgs://command/{command.CommandId}", result),
+                    cancellationToken);
+                return result;
+            });
     }
 
     public Task<GovernedTaskSnapshot?> GetSessionAsync(HubContext context, CancellationToken cancellationToken = default) =>
@@ -123,9 +183,74 @@ public sealed class KpgsDomainAdapter(
     private async Task<string> RequireLeaseAsync(HubContext context, CapabilityRequest request, CancellationToken cancellationToken)
     {
         var decision = await _resilience.ExecuteSafeAsync(ct => hub.RequestCapabilityAsync(context, request, ct), cancellationToken);
-        if (!decision.Allowed || string.IsNullOrWhiteSpace(decision.LeaseToken))
-            throw new CapabilityDeniedException(decision.UserSafeReason);
+        if (!decision.Allowed ||
+            string.IsNullOrWhiteSpace(decision.LeaseToken) ||
+            decision.ExpiresAt is null ||
+            decision.ExpiresAt <= DateTimeOffset.UtcNow)
+        {
+            throw new CapabilityDeniedException(
+                string.IsNullOrWhiteSpace(decision.UserSafeReason)
+                    ? "Capability lease is missing, denied, or expired."
+                    : decision.UserSafeReason);
+        }
         return decision.LeaseToken;
+    }
+
+    private async Task<GovernedTaskSnapshot> ExecuteOnceAsync(
+        string scopedKey,
+        string fingerprint,
+        Func<Task<GovernedTaskSnapshot>> action)
+    {
+        while (true)
+        {
+            if (_idempotentResults.TryGetValue(scopedKey, out var existing))
+            {
+                if (!string.Equals(existing.Fingerprint, fingerprint, StringComparison.Ordinal))
+                {
+                    throw new KpgsIdempotencyConflictException(
+                        "Idempotency key is already bound to different governed content.");
+                }
+                return await existing.Operation.Value;
+            }
+
+            var candidate = new IdempotencyEntry(
+                fingerprint,
+                new Lazy<Task<GovernedTaskSnapshot>>(
+                    action,
+                    LazyThreadSafetyMode.ExecutionAndPublication));
+
+            if (!_idempotentResults.TryAdd(scopedKey, candidate)) continue;
+
+            try
+            {
+                return await candidate.Operation.Value;
+            }
+            catch
+            {
+                _idempotentResults.TryRemove(scopedKey, out _);
+                throw;
+            }
+        }
+    }
+
+    private static void ValidateCreateBoundary(GovernedTaskRequest request)
+    {
+        if (!string.Equals(request.BoundaryMarker, KpgsProtocol.BoundaryMarker, StringComparison.Ordinal))
+            throw new InvalidOperationException("Literal #NB boundary is required before governed task CREATE.");
+        if (!string.Equals(request.CrudIntent, "CREATE", StringComparison.Ordinal))
+            throw new InvalidOperationException("The reference task mutation is bounded to CRUD CREATE.");
+    }
+
+    private static void ValidateCommandBoundary(GovernedCommand command)
+    {
+        if (!string.Equals(command.BoundaryMarker, KpgsProtocol.BoundaryMarker, StringComparison.Ordinal))
+            throw new InvalidOperationException("Literal #NB boundary is required before governed task command mutation.");
+    }
+
+    private static string Fingerprint(object value)
+    {
+        var json = JsonSerializer.Serialize(value);
+        return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(json))).ToLowerInvariant();
     }
 }
 
@@ -143,11 +268,15 @@ public static class KpgsAdapterEndpointExtensions
         {
             try { return Results.Ok(await adapter.CreateTaskAsync(contextFactory(http), request, ct)); }
             catch (CapabilityDeniedException ex) { return Results.Json(new { error = ex.Message }, statusCode: StatusCodes.Status403Forbidden); }
+            catch (KpgsIdempotencyConflictException ex) { return Results.Json(new { error = ex.Message }, statusCode: StatusCodes.Status409Conflict); }
+            catch (InvalidOperationException ex) { return Results.Json(new { error = ex.Message }, statusCode: StatusCodes.Status422UnprocessableEntity); }
         });
         endpoints.MapPost("/kpgs/tasks/{id}/commands", async (HttpContext http, GovernedCommand command, CancellationToken ct) =>
         {
             try { return Results.Ok(await adapter.ExecuteCommandAsync(contextFactory(http), command, ct)); }
             catch (CapabilityDeniedException ex) { return Results.Json(new { error = ex.Message }, statusCode: StatusCodes.Status403Forbidden); }
+            catch (KpgsIdempotencyConflictException ex) { return Results.Json(new { error = ex.Message }, statusCode: StatusCodes.Status409Conflict); }
+            catch (InvalidOperationException ex) { return Results.Json(new { error = ex.Message }, statusCode: StatusCodes.Status422UnprocessableEntity); }
         });
         return endpoints;
     }

--- a/dotnet/Kopano.Kpgs.Contracts/Contracts.cs
+++ b/dotnet/Kopano.Kpgs.Contracts/Contracts.cs
@@ -3,6 +3,8 @@ namespace Kopano.Kpgs.Contracts;
 public static class KpgsProtocol
 {
     public const string Current = "1.0";
+    public const string BoundaryMarker = "#NB";
+    public const string ProgressiveUpdate = "APU -> Progressive Update -> #NB -> bounded CRUD -> SWFUS";
 
     public static bool IsCompatible(string requested, string supported = Current)
     {
@@ -50,7 +52,9 @@ public sealed record GovernedTaskRequest(
     string CorrelationId,
     string GoverningSpecRef,
     object Input,
-    string IdempotencyKey);
+    string IdempotencyKey,
+    string BoundaryMarker = KpgsProtocol.BoundaryMarker,
+    string CrudIntent = "CREATE");
 
 public sealed record GovernedTaskSnapshot(
     string TaskId,
@@ -65,7 +69,8 @@ public sealed record GovernedCommand(
     string Name,
     object? Payload,
     string IdempotencyKey,
-    string CorrelationId);
+    string CorrelationId,
+    string BoundaryMarker = KpgsProtocol.BoundaryMarker);
 
 public sealed record EvidenceSummary(
     string TaskId,

--- a/governance/kpgs-vnext/dotnet/typescript/kpgs-adapter-client.ts
+++ b/governance/kpgs-vnext/dotnet/typescript/kpgs-adapter-client.ts
@@ -20,6 +20,8 @@ export type KpgsTaskRequest = {
   governingSpecRef: string;
   input: unknown;
   idempotencyKey: string;
+  boundaryMarker?: '#NB';
+  crudIntent?: 'CREATE';
 };
 
 export class KpgsAdapterClient {
@@ -46,14 +48,20 @@ export class KpgsAdapterClient {
         'X-KPGS-Task': request.taskId,
         'X-Correlation-ID': request.correlationId,
       },
-      body: JSON.stringify(request),
+      body: JSON.stringify({ boundaryMarker: '#NB', crudIntent: 'CREATE', ...request }),
     });
   }
 
   async command(
     taskId: string,
     correlationId: string,
-    command: { commandId: string; name: string; payload?: unknown; idempotencyKey: string },
+    command: {
+      commandId: string;
+      name: string;
+      payload?: unknown;
+      idempotencyKey: string;
+      boundaryMarker?: '#NB';
+    },
   ): Promise<KpgsTaskSnapshot> {
     return this.json(`/kpgs/tasks/${encodeURIComponent(taskId)}/commands`, {
       method: 'POST',
@@ -62,7 +70,7 @@ export class KpgsAdapterClient {
         'X-KPGS-Task': taskId,
         'X-Correlation-ID': correlationId,
       },
-      body: JSON.stringify({ ...command, correlationId }),
+      body: JSON.stringify({ boundaryMarker: '#NB', ...command, correlationId }),
     });
   }
 


### PR DESCRIPTION
Follow-up hardening for merged PR #81 / completed #36.

The base .NET adapter is already merged and independently green. During post-merge canonical review I found three replay/lease gaps that the original proof did not exercise:

1. replay was keyed only by idempotency string, so same key + changed governed payload could return a stale prior result;
2. replay was returned before a fresh Hub capability decision, allowing a later invocation to reuse prior work without re-authorizing;
3. capability decisions were accepted without proving the short-lived lease expiry remained in the future.

## Hardened canonical membrane

- every privileged create/command invocation resolves a current Hub capability decision before replay or execution;
- missing/denied/expired lease rejects;
- idempotency is scoped by operation + tenant + domain + task and bound to a SHA-256 fingerprint of governed content;
- exact concurrent replay executes the Hub mutation once;
- same scoped key + changed content rejects with 409 conflict;
- literal `#NB` is required before task CREATE/command mutation;
- first task mutation remains bounded to CRUD `CREATE`;
- TypeScript client emits `#NB` and `CREATE` by default;
- proof harness covers fresh authorization on replay, changed-content collision, concurrent replay, expired leases, and malformed `#NB` before capability/mutation.

No durable canonical business state is added. The merged WebSocket → SSE → polling recovery model is preserved.

## Exact-head promotion receipt

Head: `bd5a232bd9068ee30226c4b8d7d3992ccf7ac866`

- KPGS .NET Domain Adapter Proof run `32201248739` ✅
- KPGS vNext Contract Gate run `32201247694` ✅
- CodeQL Advanced run `32201248784` ✅
- Kopano CI Pipeline run `32201248731` ✅

Full CI passed Python 3.11, Python 3.12, GUI lint/build, CLI package checks and Agent/KPEFS. Any head movement invalidates this receipt until re-proven.