### PR TITLE
fix(evaluation): execute live evidence into profiler loop

### DIFF
--- a/.github/workflows/kpgs-evaluation-live-proof.yml
+++ b/.github/workflows/kpgs-evaluation-live-proof.yml
@@ -1,0 +1,96 @@
+name: KPGS Evaluation Live Evidence Proof
+
+on:
+  push:
+    branches:
+      - "fix/evaluation-live-evidence-loop"
+    paths:
+      - "governance/kpgs-vnext/evaluation/**"
+      - "tests/test_evaluation_reward_loop.py"
+      - ".github/workflows/kpgs-evaluation-live-proof.yml"
+  pull_request:
+    branches: [master]
+    paths:
+      - "governance/kpgs-vnext/evaluation/**"
+      - "tests/test_evaluation_reward_loop.py"
+      - ".github/workflows/kpgs-evaluation-live-proof.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: kpgs-evaluation-live-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  live-evidence:
+    name: Execute fixtures · Bundle evidence · Profile HOLD
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout exact head
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Setup .NET 10 LTS
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Execute live reference suite into canonical evidence bundle
+        run: |
+          python governance/kpgs-vnext/evaluation/run_live_reference_suite.py \
+            --output artifacts/evaluation-live-reference.json
+
+      - name: Run deterministic profiler regression tests
+        run: python -m unittest discover -s tests -p 'test_evaluation_reward_loop.py' -v
+
+      - name: Verify emitted receipt is evidence-bound and truthfully held
+        shell: python
+        run: |
+          import json
+          from pathlib import Path
+
+          receipt = json.loads(Path('artifacts/evaluation-live-reference.json').read_text(encoding='utf-8'))
+          assert receipt['classification'] == 'CI_REGRESSION_EXECUTION_NOT_PRODUCTION_TELEMETRY'
+          assert len(receipt['commit_sha']) == 40
+          assert receipt['evaluation']['hard_gates_passed'] is True
+          assert receipt['profile']['recommendation'] == 'hold'
+          assert 'human approval' in ' '.join(receipt['profile']['reasons']).lower()
+
+          executions = receipt['executions']
+          for case_id in (
+              'renter-capability-denial',
+              'skill-lease-bound-execution',
+              'progressive-update-swfus-contract',
+              'dotnet-adapter-replay-lease-boundary',
+          ):
+              assert executions[case_id]['returncode'] == 0, case_id
+              assert len(executions[case_id]['output_sha256']) == 64, case_id
+
+          bundle = receipt['evidence_bundle']
+          assert bundle['commit_sha'] == receipt['commit_sha']
+          assert bundle['governance_decision']['decision'] == 'allow'
+          assert bundle['adapter']['implementation'] == 'Kopano.Kpgs.Adapter'
+          assert bundle['renter']['protocol_version']
+          assert bundle['skills']
+          assert bundle['authority_effect'] == 'none'
+          assert bundle['canonical'] is False
+          assert bundle['execution_context']['released'] is True
+
+          layers = {hop['layer'] for hop in bundle['trace']['hops']}
+          assert {'pwa', 'adapter', 'sovereign-hub', 'renter', 'skill', 'verifier'} <= layers
+          print('KPGS evaluation live evidence receipt: PASS')
+
+      - name: Upload live evaluation receipt
+        uses: actions/upload-artifact@v4
+        with:
+          name: kpgs-evaluation-live-evidence
+          path: artifacts/evaluation-live-reference.json
+          if-no-files-found: error

--- a/.github/workflows/kpgs-evaluation-live-proof.yml
+++ b/.github/workflows/kpgs-evaluation-live-proof.yml
@@ -60,9 +60,9 @@ jobs:
           receipt = json.loads(Path('artifacts/evaluation-live-reference.json').read_text(encoding='utf-8'))
           assert receipt['classification'] == 'CI_REGRESSION_EXECUTION_NOT_PRODUCTION_TELEMETRY'
           assert len(receipt['commit_sha']) == 40
-          assert receipt['evaluation']['hard_gates_passed'] is True
-          assert receipt['profile']['recommendation'] == 'hold'
-          assert 'human approval' in ' '.join(receipt['profile']['reasons']).lower()
+          assert receipt['scorecard']['hard_gate_failures'] == []
+          assert receipt['promotion_decision']['decision'] == 'hold'
+          assert 'human approval required for risk class' in receipt['promotion_decision']['reasons']
 
           executions = receipt['executions']
           for case_id in (
@@ -72,7 +72,13 @@ jobs:
               'dotnet-adapter-replay-lease-boundary',
           ):
               assert executions[case_id]['returncode'] == 0, case_id
+              assert executions[case_id]['passed'] is True, case_id
               assert len(executions[case_id]['output_sha256']) == 64, case_id
+
+          user = executions['adaptive-user-outcome']
+          assert user['classification'] == 'REGRESSION_FIXTURE_NOT_PRODUCTION_TELEMETRY'
+          assert user['sample_size'] >= 20
+          assert user['passed'] is True
 
           bundle = receipt['evidence_bundle']
           assert bundle['commit_sha'] == receipt['commit_sha']
@@ -80,12 +86,14 @@ jobs:
           assert bundle['adapter']['implementation'] == 'Kopano.Kpgs.Adapter'
           assert bundle['renter']['protocol_version']
           assert bundle['skills']
-          assert bundle['authority_effect'] == 'none'
-          assert bundle['canonical'] is False
-          assert bundle['execution_context']['released'] is True
+          assert bundle['capability_lease_refs']
 
-          layers = {hop['layer'] for hop in bundle['trace']['hops']}
+          layers = {hop['layer'] for hop in bundle['trace_hops']}
           assert {'pwa', 'adapter', 'sovereign-hub', 'renter', 'skill', 'verifier'} <= layers
+          verifier_refs = {hop['ref'] for hop in bundle['trace_hops'] if hop['layer'] == 'verifier'}
+          verification_ids = {item['verifier_id'] for item in bundle['verifications']}
+          assert verifier_refs & verification_ids
+          assert receipt['engineering_scorecard']['hard_gate_clear'] is True
           print('KPGS evaluation live evidence receipt: PASS')
 
       - name: Upload live evaluation receipt

--- a/governance/kpgs-vnext/evaluation/fixtures/adaptive-user-outcome.json
+++ b/governance/kpgs-vnext/evaluation/fixtures/adaptive-user-outcome.json
@@ -1,0 +1,15 @@
+{
+  "schema": "kpgs.evaluation-user-outcome-fixture.v1",
+  "fixture_id": "adaptive-user-outcome-regression-window",
+  "version": "1.0.0",
+  "classification": "REGRESSION_FIXTURE_NOT_PRODUCTION_TELEMETRY",
+  "metric": "task-completion",
+  "samples": [
+    1.0, 1.0, 1.0, 1.0, 1.0,
+    1.0, 1.0, 1.0, 1.0, 1.0,
+    1.0, 1.0, 1.0, 1.0, 1.0,
+    1.0, 1.0, 1.0, 1.0, 1.0,
+    1.0, 1.0, 1.0, 0.0, 0.0
+  ],
+  "notes": "Versioned CI regression fixture only. It proves probabilistic sample-floor/profile mechanics and must never be represented as live user telemetry or production outcome evidence."
+}

--- a/governance/kpgs-vnext/evaluation/reference-suite.json
+++ b/governance/kpgs-vnext/evaluation/reference-suite.json
@@ -1,7 +1,7 @@
 {
   "schema": "kpgs.evaluation-suite.v1",
   "suite_id": "kpgs-core-regression",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "risk_class": "high",
   "cases": [
     {
@@ -21,12 +21,20 @@
       "fixture_ref": "repo://tests/test_canonical_skill_runtime.py"
     },
     {
-      "id": "domain-adapter-swfus-idempotency",
+      "id": "progressive-update-swfus-contract",
       "layer": "domain-adapter",
       "method": "deterministic",
       "hard_gate": true,
       "threshold": 1.0,
       "fixture_ref": "repo://tests/test_swfus_progressive_updates.py"
+    },
+    {
+      "id": "dotnet-adapter-replay-lease-boundary",
+      "layer": "domain-adapter",
+      "method": "deterministic",
+      "hard_gate": true,
+      "threshold": 1.0,
+      "fixture_ref": "repo://dotnet/Kopano.Kpgs.Adapter.Tests/Kopano.Kpgs.Adapter.Tests.csproj"
     },
     {
       "id": "adaptive-user-outcome",
@@ -35,7 +43,7 @@
       "hard_gate": false,
       "threshold": 0.8,
       "minimum_samples": 20,
-      "fixture_ref": "evidence://user-outcome/sample-window"
+      "fixture_ref": "repo://governance/kpgs-vnext/evaluation/fixtures/adaptive-user-outcome.json"
     }
   ]
 }

--- a/governance/kpgs-vnext/evaluation/run_live_reference_suite.py
+++ b/governance/kpgs-vnext/evaluation/run_live_reference_suite.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
-"""Execute the KPGS reference suite and feed real receipts into the profiler.
+"""Execute the KPGS reference suite and feed observed receipts into profiling.
 
-This is a CI/regression live workflow, not production telemetry. Deterministic
-cases execute their repository fixtures; the probabilistic case consumes a
-versioned regression sample window. The resulting canonical evidence bundle is
-then scored by the existing evaluation/profiler engine.
+This is a CI/regression proof path, not production telemetry. Deterministic
+cases execute repository fixtures. The probabilistic case consumes a versioned
+regression sample window that is explicitly labelled as synthetic CI evidence.
 """
 
 from __future__ import annotations
@@ -24,10 +23,12 @@ from typing import Any
 
 ROOT = Path(__file__).resolve().parents[3]
 EVALUATION_DIR = ROOT / "governance/kpgs-vnext/evaluation"
-EVIDENCE_PATH = ROOT / "governance/kpgs-vnext/evidence/evidence.py"
 EVALUATION_PATH = EVALUATION_DIR / "evaluation.py"
+EVIDENCE_PATH = ROOT / "governance/kpgs-vnext/evidence/evidence.py"
 SUITE_PATH = EVALUATION_DIR / "reference-suite.json"
 POLICY_PATH = EVALUATION_DIR / "promotion-policy.json"
+ROLLBACK_TARGET = "release://previous-known-good"
+VERIFIER_ID = "ci://evaluation-reference-suite"
 
 
 def _load_module(name: str, path: Path):
@@ -52,7 +53,8 @@ def _repo_path(ref: str) -> Path:
     if not ref.startswith("repo://"):
         raise ValueError(f"reference is not repository-local: {ref}")
     path = (ROOT / ref.removeprefix("repo://")).resolve()
-    if ROOT.resolve() not in path.parents and path != ROOT.resolve():
+    root = ROOT.resolve()
+    if path != root and root not in path.parents:
         raise ValueError(f"fixture escapes repository root: {ref}")
     if not path.exists():
         raise FileNotFoundError(path)
@@ -101,8 +103,7 @@ def _execute(command: list[str]) -> dict[str, Any]:
 def _adapter_version() -> str:
     project = ROOT / "dotnet/Kopano.Kpgs.Adapter/Kopano.Kpgs.Adapter.csproj"
     tree = ET.parse(project)
-    version = tree.findtext(".//Version")
-    return (version or "0.0.0-unversioned").strip()
+    return (tree.findtext(".//Version") or "0.0.0-unversioned").strip()
 
 
 def _skill_identity() -> tuple[str, str, str]:
@@ -121,16 +122,16 @@ def _skill_identity() -> tuple[str, str, str]:
 
 def _commit_sha() -> str:
     candidate = os.getenv("GITHUB_SHA", "").strip()
-    if len(candidate) == 40:
-        return candidate
-    result = subprocess.run(
+    if len(candidate) == 40 and all(ch in "0123456789abcdefABCDEF" for ch in candidate):
+        return candidate.lower()
+    completed = subprocess.run(
         ["git", "rev-parse", "HEAD"],
         cwd=ROOT,
         text=True,
         capture_output=True,
         check=True,
     )
-    return result.stdout.strip()
+    return completed.stdout.strip().lower()
 
 
 def _utc_now() -> str:
@@ -142,36 +143,62 @@ def _utc_now() -> str:
     )
 
 
+def _case_passed(case: dict[str, Any], *, score: float, samples: int | None) -> bool:
+    """Use the suite contract as the single pass/fail law."""
+    threshold_ok = score >= float(case["threshold"])
+    if case["method"] == "deterministic":
+        return threshold_ok
+    minimum = int(case["minimum_samples"])
+    return threshold_ok and (samples or 0) >= minimum
+
+
+def _result_method(case_id: str, declared_method: str) -> str:
+    if case_id == "dotnet-adapter-replay-lease-boundary":
+        return "integration"
+    if declared_method == "deterministic":
+        return "unit"
+    return "integration"
+
+
 def run(output_path: Path) -> dict[str, Any]:
     evaluation = _load_module("kpgs_live_evaluation", EVALUATION_PATH)
     evidence = _load_module("kpgs_live_evidence", EVIDENCE_PATH)
 
     suite = evaluation.load_json(SUITE_PATH)
     policy = evaluation.load_json(POLICY_PATH)
+    evaluation.validate_suite(suite)
+    evaluation.validate_policy(policy)
+
     results = []
     executions: dict[str, dict[str, Any]] = {}
+    cases_by_id = {str(case["id"]): case for case in suite["cases"]}
 
     for case in suite["cases"]:
         case_id = str(case["id"])
-        fixture_path = _repo_path(str(case["fixture_ref"]))
         method = str(case["method"])
+        fixture_path = _repo_path(str(case["fixture_ref"]))
 
         if method == "deterministic":
             execution = _execute(_command_for_fixture(fixture_path))
             score = 1.0 if execution["returncode"] == 0 else 0.0
+            passed = _case_passed(case, score=score, samples=1)
+            evidence_ref = f"ci://evaluation/{case_id}/{execution['output_sha256']}"
             executions[case_id] = {
                 **execution,
                 "fixture_ref": case["fixture_ref"],
                 "classification": "EXECUTED_REPOSITORY_FIXTURE",
+                "score": score,
+                "passed": passed,
             }
             results.append(
                 evaluation.EvaluationResult(
                     case_id=case_id,
                     method=method,
                     score=score,
-                    sample_size=1,
-                    evidence_ref=f"ci://evaluation/{case_id}/{execution['output_sha256']}",
-                    verifier="ci://evaluation-reference-suite",
+                    passed=passed,
+                    evidence_ref=evidence_ref,
+                    verifier_id=VERIFIER_ID,
+                    samples=None,
                 )
             )
             continue
@@ -182,46 +209,37 @@ def run(output_path: Path) -> dict[str, Any]:
             if not samples:
                 raise RuntimeError(f"probabilistic fixture has no samples: {fixture_path}")
             score = sum(samples) / len(samples)
+            passed = _case_passed(case, score=score, samples=len(samples))
+            evidence_ref = f"repo://{fixture_path.relative_to(ROOT).as_posix()}"
             executions[case_id] = {
                 "fixture_ref": case["fixture_ref"],
                 "fixture_sha256": _sha256_file(fixture_path),
                 "classification": fixture.get("classification"),
                 "sample_size": len(samples),
                 "score": score,
+                "passed": passed,
             }
             results.append(
                 evaluation.EvaluationResult(
                     case_id=case_id,
                     method=method,
                     score=score,
-                    sample_size=len(samples),
-                    evidence_ref=f"repo://{fixture_path.relative_to(ROOT).as_posix()}",
-                    verifier="ci://evaluation-reference-suite",
+                    passed=passed,
+                    evidence_ref=evidence_ref,
+                    verifier_id=VERIFIER_ID,
+                    samples=len(samples),
                 )
             )
             continue
 
         raise RuntimeError(f"live runner has no governed fixture adapter for {method}")
 
-    evidence_refs = {
-        "trace_ref": "ci://evaluation/reference-suite/trace",
-        "task_ref": "task://kpgs-core-regression",
-        "spec_ref": "repo://governance/kpgs-vnext/evaluation/reference-suite.json",
-        "skill_ref": "repo://governance/kpgs-vnext/skills/core/kpgs-audit-verify-govern/skill.json",
-        "renter_ref": "repo://governance/kpgs-vnext/security/capability_lease.py",
-        "verifier_ref": "ci://evaluation-reference-suite",
-    }
-    evaluation_result = evaluation.evaluate_run(
-        suite=suite,
-        results=results,
-        evidence_refs=evidence_refs,
-        governance_admitted=True,
-    )
-
+    scorecard = evaluation.score_results(suite, results)
     commit_sha = _commit_sha()
     run_id = os.getenv("GITHUB_RUN_ID", "local")
     skill_name, skill_version, renter_protocol = _skill_identity()
     correlation_id = f"evaluation:{commit_sha[:12]}"
+
     builder = evidence.EvidenceBundleBuilder(
         estate_property="kopanolabs.com",
         release_ref=f"ci://github-actions/{run_id}",
@@ -248,13 +266,11 @@ def run(output_path: Path) -> dict[str, Any]:
     )
 
     now = _utc_now()
-    deterministic = [
-        result for result in results if result.method == "deterministic"
-    ]
     by_id = {result.case_id: result for result in results}
-    trace_status = lambda case_id: (
-        "succeeded" if by_id[case_id].score >= 1.0 else "failed"
-    )
+
+    def trace_status(case_id: str) -> str:
+        return "succeeded" if by_id[case_id].passed else "failed"
+
     builder.add_trace_hop(
         layer="pwa",
         ref="ci://evaluation/reference-client",
@@ -291,15 +307,15 @@ def run(output_path: Path) -> dict[str, Any]:
     )
     builder.add_trace_hop(
         layer="verifier",
-        ref="ci://evaluation-reference-suite",
-        status="succeeded" if evaluation_result.hard_gates_passed else "failed",
+        ref=VERIFIER_ID,
+        status="succeeded" if not scorecard["hard_gate_failures"] else "failed",
         at=now,
     )
 
-    suite_ref = "repo://governance/kpgs-vnext/evaluation/reference-suite.json"
-    user_fixture_ref = "repo://governance/kpgs-vnext/evaluation/fixtures/adaptive-user-outcome.json"
     builder.add_artifact(
-        kind="specification", ref=suite_ref, sha256=_sha256_file(SUITE_PATH)
+        kind="specification",
+        ref="repo://governance/kpgs-vnext/evaluation/reference-suite.json",
+        sha256=_sha256_file(SUITE_PATH),
     )
     builder.add_artifact(
         kind="capability-lease",
@@ -310,10 +326,10 @@ def run(output_path: Path) -> dict[str, Any]:
         kind="execution",
         ref="repo://dotnet/Kopano.Kpgs.Adapter.Tests/Kopano.Kpgs.Adapter.Tests.csproj",
         sha256=_sha256_file(
-            ROOT
-            / "dotnet/Kopano.Kpgs.Adapter.Tests/Kopano.Kpgs.Adapter.Tests.csproj"
+            ROOT / "dotnet/Kopano.Kpgs.Adapter.Tests/Kopano.Kpgs.Adapter.Tests.csproj"
         ),
     )
+
     result_digest = _sha256_bytes(
         json.dumps(
             [
@@ -321,9 +337,10 @@ def run(output_path: Path) -> dict[str, Any]:
                     "case_id": result.case_id,
                     "method": result.method,
                     "score": result.score,
-                    "sample_size": result.sample_size,
+                    "passed": result.passed,
+                    "samples": result.samples,
                     "evidence_ref": result.evidence_ref,
-                    "verifier": result.verifier,
+                    "verifier_id": result.verifier_id,
                 }
                 for result in results
             ],
@@ -336,37 +353,30 @@ def run(output_path: Path) -> dict[str, Any]:
         ref=f"ci://evaluation/reference-suite/results/{result_digest}",
         sha256=result_digest,
     )
-    user_fixture_path = _repo_path(user_fixture_ref)
+    user_fixture_path = _repo_path(
+        str(cases_by_id["adaptive-user-outcome"]["fixture_ref"])
+    )
     builder.add_artifact(
         kind="user-outcome",
-        ref=user_fixture_ref,
+        ref=f"repo://{user_fixture_path.relative_to(ROOT).as_posix()}",
         sha256=_sha256_file(user_fixture_path),
     )
 
     for result in results:
-        method = (
-            "integration"
-            if result.case_id == "dotnet-adapter-replay-lease-boundary"
-            else "unit"
-            if result.method == "deterministic"
-            else "integration"
-        )
+        case = cases_by_id[result.case_id]
         builder.add_verification(
-            verifier_id="ci://evaluation-reference-suite",
+            verifier_id=VERIFIER_ID,
             criterion_id=result.case_id,
-            method=method,
-            hard_gate=bool(
-                next(case["hard_gate"] for case in suite["cases"] if case["id"] == result.case_id)
-            ),
+            method=_result_method(result.case_id, result.method),
+            hard_gate=bool(case.get("hard_gate")),
             passed=result.passed,
             evidence_ref=result.evidence_ref,
             score=result.score,
         )
 
+    deterministic = [result for result in results if result.method == "deterministic"]
+    hard_pass_ratio = sum(1 for result in deterministic if result.passed) / len(deterministic)
     probabilistic = by_id["adaptive-user-outcome"]
-    hard_pass_ratio = (
-        sum(1 for result in deterministic if result.passed) / len(deterministic)
-    )
     builder.add_metric(
         name="task-completion",
         value=probabilistic.score,
@@ -385,29 +395,28 @@ def run(output_path: Path) -> dict[str, Any]:
         unit="ratio",
         evidence_ref="ci://evaluation/deterministic-error-ratio",
     )
-    builder.set_aggregate_score("deterministic", evaluation_result.deterministic_score)
-    builder.set_aggregate_score("probabilistic", evaluation_result.probabilistic_score)
-    builder.set_aggregate_score("model", evaluation_result.model_score)
+    builder.set_aggregate_score("reference-suite", scorecard["aggregate_score"])
 
-    governance_decision = "allow" if evaluation_result.hard_gates_passed else "hold"
+    evidence_decision = "allow" if not scorecard["hard_gate_failures"] else "hold"
     bundle = builder.finalize(
-        decision=governance_decision,
+        decision=evidence_decision,
         reason=(
-            "Executed CI regression evidence is admitted for profiler evaluation; this is not a release promotion."
-            if governance_decision == "allow"
-            else "One or more executed deterministic hard gates failed; profiler must hold."
+            "Executed CI regression evidence is governance-admitted for profiler evaluation; this is not a release promotion."
+            if evidence_decision == "allow"
+            else "Executed deterministic hard gates failed; promotion evaluation is held."
         ),
         decision_ref=f"ci://github-actions/{run_id}/evaluation",
-        next_action="Apply promotion policy; high-risk release still requires human approval.",
+        next_action="Apply the high-risk promotion policy; human approval remains separate.",
     )
     engineering = evidence.engineering_scorecard(bundle)
-    decision = evaluation.decide_promotion(
-        evaluation=evaluation_result,
+
+    promotion_decision = evaluation.decide_promotion(
+        scorecard=scorecard,
         policy=policy,
         evidence_bundle=bundle,
+        rollback_target=ROLLBACK_TARGET,
         human_approval_ref=None,
     )
-    profile = evaluation.profile_evaluation(evaluation_result, decision)
 
     payload = {
         "schema": "kpgs.evaluation-live-reference-receipt.v1",
@@ -416,28 +425,27 @@ def run(output_path: Path) -> dict[str, Any]:
         "suite_id": suite["suite_id"],
         "suite_version": suite["version"],
         "executions": executions,
-        "evaluation": {
-            "hard_gates_passed": evaluation_result.hard_gates_passed,
-            "deterministic_score": evaluation_result.deterministic_score,
-            "probabilistic_score": evaluation_result.probabilistic_score,
-            "model_score": evaluation_result.model_score,
-            "evidence_refs": evaluation_result.evidence_refs,
-        },
+        "scorecard": scorecard,
         "evidence_bundle": bundle,
         "engineering_scorecard": engineering,
-        "profile": profile,
+        "promotion_decision": promotion_decision,
     }
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    output_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    output_path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
 
-    # The suite is high-risk. Even with every executable regression green, an
-    # unattended CI run must HOLD rather than manufacture human approval.
-    if not evaluation_result.hard_gates_passed:
-        raise SystemExit("executed deterministic hard gate failed")
-    if decision.recommendation != evaluation.Recommendation.HOLD:
+    if scorecard["hard_gate_failures"]:
+        raise SystemExit(
+            "executed deterministic hard gate failed: "
+            + ", ".join(scorecard["hard_gate_failures"])
+        )
+    if promotion_decision["decision"] != "hold":
         raise SystemExit("high-risk CI evaluation unexpectedly bypassed human approval HOLD")
-    if "human approval" not in " ".join(decision.reasons).lower():
-        raise SystemExit("high-risk HOLD did not identify missing human approval")
+    if "human approval required for risk class" not in promotion_decision["reasons"]:
+        raise SystemExit("high-risk HOLD did not identify the missing human approval gate")
+
     return payload
 
 
@@ -453,7 +461,7 @@ def main(argv: list[str] | None = None) -> int:
     print(
         "KPGS evaluation live reference PASS: "
         f"bundle={payload['evidence_bundle']['bundle_id']} "
-        f"recommendation={payload['profile']['recommendation']}"
+        f"decision={payload['promotion_decision']['decision']}"
     )
     return 0
 

--- a/governance/kpgs-vnext/evaluation/run_live_reference_suite.py
+++ b/governance/kpgs-vnext/evaluation/run_live_reference_suite.py
@@ -1,0 +1,462 @@
+#!/usr/bin/env python3
+"""Execute the KPGS reference suite and feed real receipts into the profiler.
+
+This is a CI/regression live workflow, not production telemetry. Deterministic
+cases execute their repository fixtures; the probabilistic case consumes a
+versioned regression sample window. The resulting canonical evidence bundle is
+then scored by the existing evaluation/profiler engine.
+"""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import hashlib
+import importlib.util
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import time
+import xml.etree.ElementTree as ET
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[3]
+EVALUATION_DIR = ROOT / "governance/kpgs-vnext/evaluation"
+EVIDENCE_PATH = ROOT / "governance/kpgs-vnext/evidence/evidence.py"
+EVALUATION_PATH = EVALUATION_DIR / "evaluation.py"
+SUITE_PATH = EVALUATION_DIR / "reference-suite.json"
+POLICY_PATH = EVALUATION_DIR / "promotion-policy.json"
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load module: {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _sha256_file(path: Path) -> str:
+    return _sha256_bytes(path.read_bytes())
+
+
+def _repo_path(ref: str) -> Path:
+    if not ref.startswith("repo://"):
+        raise ValueError(f"reference is not repository-local: {ref}")
+    path = (ROOT / ref.removeprefix("repo://")).resolve()
+    if ROOT.resolve() not in path.parents and path != ROOT.resolve():
+        raise ValueError(f"fixture escapes repository root: {ref}")
+    if not path.exists():
+        raise FileNotFoundError(path)
+    return path
+
+
+def _command_for_fixture(path: Path) -> list[str]:
+    relative = path.relative_to(ROOT).as_posix()
+    if path.suffix == ".py" and path.parent == ROOT / "tests":
+        return [
+            sys.executable,
+            "-m",
+            "unittest",
+            "discover",
+            "-s",
+            "tests",
+            "-p",
+            path.name,
+            "-v",
+        ]
+    if path.suffix == ".csproj":
+        return ["dotnet", "run", "--project", relative, "-c", "Release"]
+    raise ValueError(f"unsupported deterministic fixture: {relative}")
+
+
+def _execute(command: list[str]) -> dict[str, Any]:
+    started = time.perf_counter()
+    completed = subprocess.run(
+        command,
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    duration_ms = round((time.perf_counter() - started) * 1000, 3)
+    combined = (completed.stdout or "") + (completed.stderr or "")
+    return {
+        "command": command,
+        "returncode": completed.returncode,
+        "duration_ms": duration_ms,
+        "output_sha256": _sha256_bytes(combined.encode("utf-8")),
+        "output_tail": combined[-2000:],
+    }
+
+
+def _adapter_version() -> str:
+    project = ROOT / "dotnet/Kopano.Kpgs.Adapter/Kopano.Kpgs.Adapter.csproj"
+    tree = ET.parse(project)
+    version = tree.findtext(".//Version")
+    return (version or "0.0.0-unversioned").strip()
+
+
+def _skill_identity() -> tuple[str, str, str]:
+    manifest = json.loads(
+        (
+            ROOT
+            / "governance/kpgs-vnext/skills/core/kpgs-audit-verify-govern/skill.json"
+        ).read_text(encoding="utf-8")
+    )
+    return (
+        str(manifest["name"]),
+        str(manifest["version"]),
+        str(manifest["runtime"]["renter_protocol"]),
+    )
+
+
+def _commit_sha() -> str:
+    candidate = os.getenv("GITHUB_SHA", "").strip()
+    if len(candidate) == 40:
+        return candidate
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def _utc_now() -> str:
+    return (
+        datetime.now(timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def run(output_path: Path) -> dict[str, Any]:
+    evaluation = _load_module("kpgs_live_evaluation", EVALUATION_PATH)
+    evidence = _load_module("kpgs_live_evidence", EVIDENCE_PATH)
+
+    suite = evaluation.load_json(SUITE_PATH)
+    policy = evaluation.load_json(POLICY_PATH)
+    results = []
+    executions: dict[str, dict[str, Any]] = {}
+
+    for case in suite["cases"]:
+        case_id = str(case["id"])
+        fixture_path = _repo_path(str(case["fixture_ref"]))
+        method = str(case["method"])
+
+        if method == "deterministic":
+            execution = _execute(_command_for_fixture(fixture_path))
+            score = 1.0 if execution["returncode"] == 0 else 0.0
+            executions[case_id] = {
+                **execution,
+                "fixture_ref": case["fixture_ref"],
+                "classification": "EXECUTED_REPOSITORY_FIXTURE",
+            }
+            results.append(
+                evaluation.EvaluationResult(
+                    case_id=case_id,
+                    method=method,
+                    score=score,
+                    sample_size=1,
+                    evidence_ref=f"ci://evaluation/{case_id}/{execution['output_sha256']}",
+                    verifier="ci://evaluation-reference-suite",
+                )
+            )
+            continue
+
+        if method == "probabilistic":
+            fixture = json.loads(fixture_path.read_text(encoding="utf-8"))
+            samples = [float(value) for value in fixture.get("samples", [])]
+            if not samples:
+                raise RuntimeError(f"probabilistic fixture has no samples: {fixture_path}")
+            score = sum(samples) / len(samples)
+            executions[case_id] = {
+                "fixture_ref": case["fixture_ref"],
+                "fixture_sha256": _sha256_file(fixture_path),
+                "classification": fixture.get("classification"),
+                "sample_size": len(samples),
+                "score": score,
+            }
+            results.append(
+                evaluation.EvaluationResult(
+                    case_id=case_id,
+                    method=method,
+                    score=score,
+                    sample_size=len(samples),
+                    evidence_ref=f"repo://{fixture_path.relative_to(ROOT).as_posix()}",
+                    verifier="ci://evaluation-reference-suite",
+                )
+            )
+            continue
+
+        raise RuntimeError(f"live runner has no governed fixture adapter for {method}")
+
+    evidence_refs = {
+        "trace_ref": "ci://evaluation/reference-suite/trace",
+        "task_ref": "task://kpgs-core-regression",
+        "spec_ref": "repo://governance/kpgs-vnext/evaluation/reference-suite.json",
+        "skill_ref": "repo://governance/kpgs-vnext/skills/core/kpgs-audit-verify-govern/skill.json",
+        "renter_ref": "repo://governance/kpgs-vnext/security/capability_lease.py",
+        "verifier_ref": "ci://evaluation-reference-suite",
+    }
+    evaluation_result = evaluation.evaluate_run(
+        suite=suite,
+        results=results,
+        evidence_refs=evidence_refs,
+        governance_admitted=True,
+    )
+
+    commit_sha = _commit_sha()
+    run_id = os.getenv("GITHUB_RUN_ID", "local")
+    skill_name, skill_version, renter_protocol = _skill_identity()
+    correlation_id = f"evaluation:{commit_sha[:12]}"
+    builder = evidence.EvidenceBundleBuilder(
+        estate_property="kopanolabs.com",
+        release_ref=f"ci://github-actions/{run_id}",
+        commit_sha=commit_sha,
+        adapter={
+            "implementation": "Kopano.Kpgs.Adapter",
+            "version": _adapter_version(),
+            "protocol_version": "1.0",
+        },
+        renter={
+            "renter_id": "ci:reference-renter",
+            "protocol_version": renter_protocol,
+        },
+        skills=[{"name": skill_name, "version": skill_version}],
+        task_id="kpgs-core-regression",
+        session_id=f"ci:{run_id}",
+        correlation_id=correlation_id,
+        governing_spec_ref="repo://governance/kpgs-vnext/evaluation/README.md",
+        retention_policy_ref="policy://kpgs/evaluation-ci-retention",
+        redaction_policy_ref="policy://kpgs/evaluation-ci-redaction",
+    )
+    builder.add_capability_lease_ref(
+        f"ci://evaluation/renter-capability-denial/{commit_sha}"
+    )
+
+    now = _utc_now()
+    deterministic = [
+        result for result in results if result.method == "deterministic"
+    ]
+    by_id = {result.case_id: result for result in results}
+    trace_status = lambda case_id: (
+        "succeeded" if by_id[case_id].score >= 1.0 else "failed"
+    )
+    builder.add_trace_hop(
+        layer="pwa",
+        ref="ci://evaluation/reference-client",
+        status="succeeded",
+        at=now,
+        metadata={"classification": "CI_REFERENCE_PATH_NOT_PRODUCTION_PWA"},
+    )
+    builder.add_trace_hop(
+        layer="adapter",
+        ref=f"ci://evaluation/dotnet-adapter/{commit_sha}",
+        status=trace_status("dotnet-adapter-replay-lease-boundary"),
+        at=now,
+        duration_ms=executions["dotnet-adapter-replay-lease-boundary"]["duration_ms"],
+    )
+    builder.add_trace_hop(
+        layer="sovereign-hub",
+        ref=f"ci://evaluation/capability-authority/{commit_sha}",
+        status=trace_status("renter-capability-denial"),
+        at=now,
+    )
+    builder.add_trace_hop(
+        layer="renter",
+        ref=f"ci://evaluation/renter/{commit_sha}",
+        status=trace_status("renter-capability-denial"),
+        at=now,
+        duration_ms=executions["renter-capability-denial"]["duration_ms"],
+    )
+    builder.add_trace_hop(
+        layer="skill",
+        ref=f"ci://evaluation/skill/{commit_sha}",
+        status=trace_status("skill-lease-bound-execution"),
+        at=now,
+        duration_ms=executions["skill-lease-bound-execution"]["duration_ms"],
+    )
+    builder.add_trace_hop(
+        layer="verifier",
+        ref="ci://evaluation-reference-suite",
+        status="succeeded" if evaluation_result.hard_gates_passed else "failed",
+        at=now,
+    )
+
+    suite_ref = "repo://governance/kpgs-vnext/evaluation/reference-suite.json"
+    user_fixture_ref = "repo://governance/kpgs-vnext/evaluation/fixtures/adaptive-user-outcome.json"
+    builder.add_artifact(
+        kind="specification", ref=suite_ref, sha256=_sha256_file(SUITE_PATH)
+    )
+    builder.add_artifact(
+        kind="capability-lease",
+        ref="repo://tests/test_capability_lease_runtime.py",
+        sha256=_sha256_file(ROOT / "tests/test_capability_lease_runtime.py"),
+    )
+    builder.add_artifact(
+        kind="execution",
+        ref="repo://dotnet/Kopano.Kpgs.Adapter.Tests/Kopano.Kpgs.Adapter.Tests.csproj",
+        sha256=_sha256_file(
+            ROOT
+            / "dotnet/Kopano.Kpgs.Adapter.Tests/Kopano.Kpgs.Adapter.Tests.csproj"
+        ),
+    )
+    result_digest = _sha256_bytes(
+        json.dumps(
+            [
+                {
+                    "case_id": result.case_id,
+                    "method": result.method,
+                    "score": result.score,
+                    "sample_size": result.sample_size,
+                    "evidence_ref": result.evidence_ref,
+                    "verifier": result.verifier,
+                }
+                for result in results
+            ],
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    )
+    builder.add_artifact(
+        kind="verification",
+        ref=f"ci://evaluation/reference-suite/results/{result_digest}",
+        sha256=result_digest,
+    )
+    user_fixture_path = _repo_path(user_fixture_ref)
+    builder.add_artifact(
+        kind="user-outcome",
+        ref=user_fixture_ref,
+        sha256=_sha256_file(user_fixture_path),
+    )
+
+    for result in results:
+        method = (
+            "integration"
+            if result.case_id == "dotnet-adapter-replay-lease-boundary"
+            else "unit"
+            if result.method == "deterministic"
+            else "integration"
+        )
+        builder.add_verification(
+            verifier_id="ci://evaluation-reference-suite",
+            criterion_id=result.case_id,
+            method=method,
+            hard_gate=bool(
+                next(case["hard_gate"] for case in suite["cases"] if case["id"] == result.case_id)
+            ),
+            passed=result.passed,
+            evidence_ref=result.evidence_ref,
+            score=result.score,
+        )
+
+    probabilistic = by_id["adaptive-user-outcome"]
+    hard_pass_ratio = (
+        sum(1 for result in deterministic if result.passed) / len(deterministic)
+    )
+    builder.add_metric(
+        name="task-completion",
+        value=probabilistic.score,
+        unit="ratio",
+        evidence_ref=probabilistic.evidence_ref,
+    )
+    builder.add_metric(
+        name="reliability",
+        value=hard_pass_ratio,
+        unit="ratio",
+        evidence_ref="ci://evaluation/deterministic-pass-ratio",
+    )
+    builder.add_metric(
+        name="error-rate",
+        value=1.0 - hard_pass_ratio,
+        unit="ratio",
+        evidence_ref="ci://evaluation/deterministic-error-ratio",
+    )
+    builder.set_aggregate_score("deterministic", evaluation_result.deterministic_score)
+    builder.set_aggregate_score("probabilistic", evaluation_result.probabilistic_score)
+    builder.set_aggregate_score("model", evaluation_result.model_score)
+
+    governance_decision = "allow" if evaluation_result.hard_gates_passed else "hold"
+    bundle = builder.finalize(
+        decision=governance_decision,
+        reason=(
+            "Executed CI regression evidence is admitted for profiler evaluation; this is not a release promotion."
+            if governance_decision == "allow"
+            else "One or more executed deterministic hard gates failed; profiler must hold."
+        ),
+        decision_ref=f"ci://github-actions/{run_id}/evaluation",
+        next_action="Apply promotion policy; high-risk release still requires human approval.",
+    )
+    engineering = evidence.engineering_scorecard(bundle)
+    decision = evaluation.decide_promotion(
+        evaluation=evaluation_result,
+        policy=policy,
+        evidence_bundle=bundle,
+        human_approval_ref=None,
+    )
+    profile = evaluation.profile_evaluation(evaluation_result, decision)
+
+    payload = {
+        "schema": "kpgs.evaluation-live-reference-receipt.v1",
+        "classification": "CI_REGRESSION_EXECUTION_NOT_PRODUCTION_TELEMETRY",
+        "commit_sha": commit_sha,
+        "suite_id": suite["suite_id"],
+        "suite_version": suite["version"],
+        "executions": executions,
+        "evaluation": {
+            "hard_gates_passed": evaluation_result.hard_gates_passed,
+            "deterministic_score": evaluation_result.deterministic_score,
+            "probabilistic_score": evaluation_result.probabilistic_score,
+            "model_score": evaluation_result.model_score,
+            "evidence_refs": evaluation_result.evidence_refs,
+        },
+        "evidence_bundle": bundle,
+        "engineering_scorecard": engineering,
+        "profile": profile,
+    }
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    # The suite is high-risk. Even with every executable regression green, an
+    # unattended CI run must HOLD rather than manufacture human approval.
+    if not evaluation_result.hard_gates_passed:
+        raise SystemExit("executed deterministic hard gate failed")
+    if decision.recommendation != evaluation.Recommendation.HOLD:
+        raise SystemExit("high-risk CI evaluation unexpectedly bypassed human approval HOLD")
+    if "human approval" not in " ".join(decision.reasons).lower():
+        raise SystemExit("high-risk HOLD did not identify missing human approval")
+    return payload
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=ROOT / "artifacts/evaluation-live-reference.json",
+    )
+    args = parser.parse_args(argv)
+    payload = run(args.output)
+    print(
+        "KPGS evaluation live reference PASS: "
+        f"bundle={payload['evidence_bundle']['bundle_id']} "
+        f"recommendation={payload['profile']['recommendation']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_evaluation_reward_loop.py
+++ b/tests/test_evaluation_reward_loop.py
@@ -38,7 +38,7 @@ def results(user_score=0.9, renter_pass=True, dotnet_pass=True):
             "skill-verifier",
         ),
         mod.EvaluationResult(
-            "domain-adapter-swfus-idempotency",
+            "progressive-update-swfus-contract",
             "deterministic",
             1.0,
             True,
@@ -79,7 +79,7 @@ class EvaluationRewardLoopTests(unittest.TestCase):
         cases = {case["id"]: case for case in SUITE["cases"]}
         self.assertEqual(cases["renter-capability-denial"]["layer"], "renter")
         self.assertEqual(cases["skill-lease-bound-execution"]["layer"], "skill")
-        self.assertEqual(cases["domain-adapter-swfus-idempotency"]["layer"], "domain-adapter")
+        self.assertEqual(cases["progressive-update-swfus-contract"]["layer"], "domain-adapter")
         self.assertEqual(cases["dotnet-adapter-replay-lease-boundary"]["layer"], "domain-adapter")
         self.assertEqual(
             cases["dotnet-adapter-replay-lease-boundary"]["fixture_ref"],

--- a/tests/test_evaluation_reward_loop.py
+++ b/tests/test_evaluation_reward_loop.py
@@ -19,12 +19,49 @@ SUITE = json.loads((ROOT / "governance/kpgs-vnext/evaluation/reference-suite.jso
 POLICY = json.loads((ROOT / "governance/kpgs-vnext/evaluation/promotion-policy.json").read_text(encoding="utf-8"))
 
 
-def results(user_score=0.9, renter_pass=True):
+def results(user_score=0.9, renter_pass=True, dotnet_pass=True):
     return [
-        mod.EvaluationResult("renter-capability-denial", "deterministic", 1.0 if renter_pass else 0.0, renter_pass, "ci://capability-lease", "capability-verifier"),
-        mod.EvaluationResult("skill-lease-bound-execution", "deterministic", 1.0, True, "ci://skill-runtime", "skill-verifier"),
-        mod.EvaluationResult("domain-adapter-swfus-idempotency", "deterministic", 1.0, True, "ci://swfus", "swfus-verifier"),
-        mod.EvaluationResult("adaptive-user-outcome", "probabilistic", user_score, user_score >= 0.8, "evidence://user-outcome/window", "outcome-profiler", samples=25),
+        mod.EvaluationResult(
+            "renter-capability-denial",
+            "deterministic",
+            1.0 if renter_pass else 0.0,
+            renter_pass,
+            "ci://capability-lease",
+            "capability-verifier",
+        ),
+        mod.EvaluationResult(
+            "skill-lease-bound-execution",
+            "deterministic",
+            1.0,
+            True,
+            "ci://skill-runtime",
+            "skill-verifier",
+        ),
+        mod.EvaluationResult(
+            "domain-adapter-swfus-idempotency",
+            "deterministic",
+            1.0,
+            True,
+            "ci://swfus",
+            "swfus-verifier",
+        ),
+        mod.EvaluationResult(
+            "dotnet-adapter-replay-lease-boundary",
+            "deterministic",
+            1.0 if dotnet_pass else 0.0,
+            dotnet_pass,
+            "ci://dotnet-adapter",
+            "dotnet-verifier",
+        ),
+        mod.EvaluationResult(
+            "adaptive-user-outcome",
+            "probabilistic",
+            user_score,
+            user_score >= 0.8,
+            "repo://governance/kpgs-vnext/evaluation/fixtures/adaptive-user-outcome.json",
+            "outcome-profiler",
+            samples=25,
+        ),
     ]
 
 
@@ -37,18 +74,21 @@ def bundle(decision="promote"):
 
 
 class EvaluationRewardLoopTests(unittest.TestCase):
-    def test_reference_regression_suite_covers_renter_skill_and_domain_adapter(self):
+    def test_reference_regression_suite_covers_renter_skill_swfus_and_hardened_dotnet_adapter(self):
         mod.validate_suite(SUITE)
-        layers = {case["layer"] for case in SUITE["cases"]}
-        self.assertTrue({"renter", "skill", "domain-adapter"}.issubset(layers))
-        refs = {case["fixture_ref"] for case in SUITE["cases"]}
-        self.assertIn("repo://tests/test_capability_lease_runtime.py", refs)
-        self.assertIn("repo://tests/test_canonical_skill_runtime.py", refs)
-        self.assertIn("repo://tests/test_swfus_progressive_updates.py", refs)
+        cases = {case["id"]: case for case in SUITE["cases"]}
+        self.assertEqual(cases["renter-capability-denial"]["layer"], "renter")
+        self.assertEqual(cases["skill-lease-bound-execution"]["layer"], "skill")
+        self.assertEqual(cases["domain-adapter-swfus-idempotency"]["layer"], "domain-adapter")
+        self.assertEqual(cases["dotnet-adapter-replay-lease-boundary"]["layer"], "domain-adapter")
+        self.assertEqual(
+            cases["dotnet-adapter-replay-lease-boundary"]["fixture_ref"],
+            "repo://dotnet/Kopano.Kpgs.Adapter.Tests/Kopano.Kpgs.Adapter.Tests.csproj",
+        )
 
     def test_deterministic_and_probabilistic_results_remain_distinct(self):
         scored = mod.score_results(SUITE, results())
-        self.assertEqual(len(scored["deterministic"]), 3)
+        self.assertEqual(len(scored["deterministic"]), 4)
         self.assertEqual(len(scored["probabilistic"]), 1)
         self.assertEqual(scored["probabilistic"][0]["samples"], 25)
         self.assertEqual(scored["hard_gate_failures"], [])
@@ -67,6 +107,19 @@ class EvaluationRewardLoopTests(unittest.TestCase):
         )
         self.assertEqual(decision["decision"], "hold")
         self.assertIn("hard evaluation gate failed", decision["reasons"])
+
+    def test_dotnet_adapter_hard_failure_cannot_be_averaged_away(self):
+        scored = mod.score_results(SUITE, results(user_score=1.0, dotnet_pass=False))
+        self.assertEqual(scored["hard_gate_failures"], ["dotnet-adapter-replay-lease-boundary"])
+        decision = mod.decide_promotion(
+            scorecard=scored,
+            policy=POLICY,
+            evidence_bundle=bundle(),
+            rollback_target="release://previous",
+            human_approval_ref="human://approval/1",
+            clock=datetime(2026, 8, 19, tzinfo=timezone.utc),
+        )
+        self.assertEqual(decision["decision"], "hold")
 
     def test_high_risk_promotion_requires_human_approval(self):
         scored = mod.score_results(SUITE, results())
@@ -117,7 +170,15 @@ class EvaluationRewardLoopTests(unittest.TestCase):
 
     def test_probabilistic_case_requires_declared_sample_floor(self):
         insufficient = results()
-        insufficient[-1] = mod.EvaluationResult("adaptive-user-outcome", "probabilistic", 0.95, True, "evidence://user-outcome/window", "outcome-profiler", samples=5)
+        insufficient[-1] = mod.EvaluationResult(
+            "adaptive-user-outcome",
+            "probabilistic",
+            0.95,
+            True,
+            "repo://governance/kpgs-vnext/evaluation/fixtures/adaptive-user-outcome.json",
+            "outcome-profiler",
+            samples=5,
+        )
         with self.assertRaisesRegex(mod.EvaluationError, "insufficient samples"):
             mod.score_results(SUITE, insufficient)
 


### PR DESCRIPTION
Follow-up validation hardening for completed #38 / merged PR #83.

The merged evaluator/profiler decision algebra is retained. This PR closes the proof gap where renter/skill/SWFUS checks ran beside the evaluation tests but successful `EvaluationResult` objects could still be constructed independently of the actual executed fixture receipts.

## Live evidence path

`run_live_reference_suite.py` now executes and records:
- capability-lease / renter fixture;
- canonical lease-bound skill runtime fixture;
- Progressive Update / SWFUS contract fixture;
- hardened `.NET` domain adapter replay/lease/`#NB` proof executable;
- versioned probabilistic regression sample window explicitly classified as **not production telemetry**.

The runner hashes actual command output, derives PASS from the suite threshold/sample-floor contract, builds the canonical `EvidenceBundleBuilder` bundle, binds exact commit + adapter version + renter protocol + skill version + task/spec/lease/verifier refs, scores through the existing `score_results()` API, and applies the existing high-risk promotion policy.

Because this suite is high-risk and unattended CI has no human approval, fully green executed evidence must resolve to **HOLD**, not self-promotion.

## Exact-head promotion receipt

Head: `afe477378d127f51d6c6c83cbf5b56435579ff1c`

- KPGS Evaluation Live Evidence Proof `32307005450` ✅
  - exact repository fixtures executed;
  - evidence bundle built;
  - profiler regression tests passed;
  - truthful high-risk HOLD receipt validated;
  - `kpgs-evaluation-live-evidence` artifact uploaded (`sha256:0901474255f67aad3a137f8d79c11d449671c5f26c6c2d86bc04f839d167f9b6`).
- KPGS vNext Contract Gate `32307005591` ✅
- CodeQL Advanced `32307005575` ✅
- Kopano CI Pipeline `32307005417` ✅

Any head movement invalidates this receipt until re-proven.