### PR TITLE
feat(migration): add canonical DNS estate migration playbook

### DIFF
--- a/.github/workflows/kpgs-estate-migration-proof.yml
+++ b/.github/workflows/kpgs-estate-migration-proof.yml
@@ -1,0 +1,77 @@
+name: KPGS Estate Migration Proof
+
+on:
+  push:
+    branches:
+      - "feat/estate-migration-playbook-close-44"
+    paths:
+      - "governance/kpgs-vnext/migration/**"
+      - "tests/test_estate_migration.py"
+      - ".github/workflows/kpgs-estate-migration-proof.yml"
+  pull_request:
+    branches: [master]
+    paths:
+      - "governance/kpgs-vnext/migration/**"
+      - "tests/test_estate_migration.py"
+      - ".github/workflows/kpgs-estate-migration-proof.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: kpgs-estate-migration-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  proof:
+    name: Compile · Reuse · Canonical HOLD
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout exact head
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Compile migration runtime
+        run: |
+          python -m compileall -q governance/kpgs-vnext/migration tests/test_estate_migration.py
+
+      - name: Run migration regression proof
+        run: python -m unittest discover -s tests -p 'test_estate_migration.py' -v
+
+      - name: Assess canonical estate without mutation
+        run: |
+          before="$(sha256sum governance/kpgs-vnext/estate-registry/estate.json | awk '{print $1}')"
+          python governance/kpgs-vnext/migration/assess_estate.py \
+            --workflow-id bounded-pilot \
+            --output artifacts/estate-migration-assessment.json
+          after="$(sha256sum governance/kpgs-vnext/estate-registry/estate.json | awk '{print $1}')"
+          test "$before" = "$after"
+
+      - name: Verify current live estate remains truthful HOLD
+        shell: python
+        run: |
+          import json
+          from pathlib import Path
+
+          payload = json.loads(Path('artifacts/estate-migration-assessment.json').read_text(encoding='utf-8'))
+          assert payload['canonical_registry_changed'] is False
+          assert payload['authority_effect'] == 'none'
+          assert len(payload['assessments']) == 6
+          assert all(item['recommendation'] == 'HOLD' for item in payload['assessments'])
+          assert all(item['ready_for_staging'] is False for item in payload['assessments'])
+          assert all(item['stages']['register']['status'] == 'HOLD' for item in payload['assessments'])
+          print('Canonical estate migration state: HOLD pending authoritative witness evidence')
+
+      - name: Upload migration assessment
+        uses: actions/upload-artifact@v4
+        with:
+          name: kpgs-estate-migration-assessment
+          path: artifacts/estate-migration-assessment.json
+          if-no-files-found: error

--- a/governance/kpgs-vnext/migration/README.md
+++ b/governance/kpgs-vnext/migration/README.md
@@ -1,0 +1,206 @@
+# KPGS Canonical DNS Estate Migration Playbook
+
+Issue: #44
+
+## Purpose
+
+Move one bounded workflow at a time behind the canonical KPGS control plane without rewriting a working frontend or moving durable authority into a Stateless Renter.
+
+The playbook is deliberately two-layered:
+
+1. **readiness assessment** — pure, non-authoritative evaluation of currently witnessed registry/evidence state;
+2. **registry transition** — separately capability-gated mutation performed only through the Sovereign Estate Registry runtime.
+
+`migration.py` implements layer 1. It cannot promote DNS state.
+
+## Canonical sequence
+
+```text
+baseline
+  -> register
+  -> adapter integration
+  -> capability map
+  -> renter integration
+  -> realtime / reconnect verification
+  -> evaluation
+  -> staging eligibility
+  -> rollback drill
+  -> production promotion eligibility
+  -> observe
+```
+
+This maps issue #44's operational flow:
+
+```text
+baseline -> register -> adapter integration -> capability map -> renter integration
+-> realtime wiring -> eval -> staging -> rollback drill -> production promotion -> observe
+```
+
+## Truth boundary
+
+A migration assessment is never an estate-registry mutation.
+
+```text
+MIGRATION ASSESSMENT != REGISTRY AUTHORITY
+CI FIXTURE != DNS OWNERSHIP WITNESS
+STAGING READY != STAGING TRANSITION
+PRODUCTION READY != PRODUCTION TRANSITION
+TRANSPORT SUCCESS != CANONICAL STATE
+```
+
+The output always carries:
+
+```json
+{
+  "canonical_registry_changed": false,
+  "authority_effect": "none"
+}
+```
+
+## Baseline gate
+
+Before migration, record at minimum:
+
+- repository/ref;
+- deployment provider + target;
+- health/evidence endpoint;
+- rollback target + procedure.
+
+A real operator should additionally capture the critical user journey, auth/session boundary, APIs/data stores, offline/PWA behavior and known mobile defects in `migration-template.json`.
+
+## Registration gate
+
+The migration engine respects the canonical Estate Registry. `declared_pending_witness` is HOLD.
+
+A property may not be considered registered from memory, public search, repository visibility, or an application screenshot. The canonical registry requires witnessed ownership/domain-control evidence and the registration completeness contract from `../estate-registry/`.
+
+## Adapter gate
+
+A property must declare a versioned adapter implementation. The reference implementation is:
+
+```text
+Kopano.Kpgs.Adapter
+```
+
+Existing React/Next/Vite/MERN/PWA frontends remain in place. The adapter is a service/control-plane boundary, not a UI rewrite requirement.
+
+## Capability gate
+
+A migrated workflow must declare the bounded capabilities it needs. The migration planner only verifies that a capability map exists; actual authorization remains the responsibility of the capability-lease authority at execution time.
+
+## Stateless Renter gate
+
+`renter_compatibility.status` must be `conformant` with an explicit protocol version before staging eligibility.
+
+A renter remains disposable. Migration must survive renter destruction/recreation from governed Hub/context state.
+
+## Realtime gate
+
+Realtime improves immersion and recovery. It is not canonical storage.
+
+The planner requires at least one governed health/evidence endpoint so reconnect behavior can be verified against authoritative state.
+
+## Evaluation gate
+
+The migration planner accepts the exact-commit receipt produced by the canonical evaluation loop. It requires:
+
+- exact 40-character commit SHA;
+- zero hard-gate failures;
+- governance-admitted evidence bundle;
+- a valid promotion decision (`hold` or `promote`).
+
+A `HOLD` caused only by missing high-risk human approval may still be sufficient to prove **software/evidence staging readiness**. It is never sufficient for production promotion.
+
+## Staging eligibility
+
+A property becomes `ELIGIBLE_FOR_STAGING_TRANSITION` only when all of these software/evidence gates pass:
+
+- baseline;
+- canonical registration completeness;
+- adapter version;
+- capability map;
+- conformant Stateless Renter protocol;
+- health/reconnect evidence endpoint;
+- exact-commit evaluation evidence.
+
+The actual transition still requires the Estate Registry's `estate.release.transition` capability.
+
+## Rollback drill
+
+Rollback proof uses `kpgs.estate-rollback-drill.v1`.
+
+A passing drill must:
+
+- explicitly record `passed=true`;
+- preserve `automatic_execution=false`;
+- include evidence references.
+
+The drill proves recoverability. It does not grant rollback authority.
+
+## Production eligibility
+
+Production remains `NOT_REACHED` until all of the following are present:
+
+- property is currently `staging`;
+- staging readiness is still valid;
+- rollback drill passed;
+- release live ref exists;
+- release evidence ref exists;
+- rollback target exists;
+- rollback procedure exists;
+- promotion decision is `promote`;
+- the promotion decision contains the required human approval reference.
+
+Only then does the planner return:
+
+```text
+ELIGIBLE_FOR_PRODUCTION_TRANSITION
+```
+
+The capability-gated Estate Registry still owns the production transition.
+
+## Current canonical estate behavior
+
+The six declared properties in `../estate-registry/estate.json` are intentionally `declared_pending_witness`.
+
+Therefore, running the migration assessor against the live canonical registry must currently produce **HOLD**, not auto-enrichment or migration claims.
+
+This is expected governance behavior until authoritative witness data is supplied.
+
+## CI reference proof
+
+Tests use clearly labelled **CI reference fixtures** for two domains to prove the software playbook is reusable:
+
+- `KasiLink.com`
+- `starfallsalvage.kopanolabs.com`
+
+These fixtures are not production registry state and are not DNS ownership evidence. They demonstrate that the same planner can:
+
+- reach staging eligibility when the required contracts/evidence exist;
+- refuse production while human approval/rollback evidence is absent;
+- reach production-transition eligibility only in an explicitly simulated approved fixture;
+- preserve `canonical_registry_changed=false` throughout;
+- produce deterministic migration IDs for the same property/workflow;
+- apply the identical playbook to a second property.
+
+## Operator workflow
+
+1. Copy `migration-template.json` for the bounded workflow.
+2. Populate baseline references from witnessed/current systems.
+3. Update the canonical Estate Registry only through its capability-gated witness/register operations.
+4. Add adapter/renter/capability/health declarations to the registered property.
+5. Run the exact-commit evaluation/evidence loop.
+6. Run migration assessment.
+7. If staging-eligible, request the separately authorized staging transition.
+8. Execute and receipt the rollback drill.
+9. Re-evaluate the exact staging release.
+10. Obtain required human approval for high/critical-risk promotion.
+11. Request the separately authorized production transition.
+12. Observe the declared window and issue a governed rollback recommendation if policy thresholds fail.
+
+## Proof commands
+
+```bash
+python -m unittest discover -s tests -p 'test_estate_migration.py' -v
+python governance/kpgs-vnext/migration/assess_estate.py
+```

--- a/governance/kpgs-vnext/migration/assess_estate.py
+++ b/governance/kpgs-vnext/migration/assess_estate.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Assess the canonical estate for migration readiness without mutating it."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[3]
+MIGRATION_PATH = ROOT / "governance/kpgs-vnext/migration/migration.py"
+ESTATE_PATH = ROOT / "governance/kpgs-vnext/estate-registry/estate.json"
+
+
+def load_migration_module():
+    spec = importlib.util.spec_from_file_location("kpgs_estate_migration", MIGRATION_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("cannot load migration runtime")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--estate", type=Path, default=ESTATE_PATH)
+    parser.add_argument("--workflow-id", default="bounded-pilot")
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args(argv)
+
+    migration = load_migration_module()
+    estate = json.loads(args.estate.read_text(encoding="utf-8"))
+    assessments = migration.assess_estate(estate, workflow_id=args.workflow_id)
+    payload = {
+        "schema": "kpgs.estate-migration-estate-assessment.v1",
+        "estate_id": estate["estate_id"],
+        "workflow_id": args.workflow_id,
+        "assessments": assessments,
+        "canonical_registry_changed": False,
+        "authority_effect": "none",
+    }
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(text, encoding="utf-8")
+    else:
+        print(text, end="")
+
+    # Current canonical estate is allowed to be all HOLD. This CLI is an assessor,
+    # not a deployment gate that fabricates witness data.
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/governance/kpgs-vnext/migration/migration-template.json
+++ b/governance/kpgs-vnext/migration/migration-template.json
@@ -1,0 +1,38 @@
+{
+  "schema": "kpgs.estate-migration-plan.v1",
+  "estate_id": "kopano-sovereign-estate",
+  "domain": "example.kopanolabs.com",
+  "workflow_id": "bounded-workflow-id",
+  "classification": "TEMPLATE_NOT_EVIDENCE",
+  "baseline": {
+    "repository_ref": null,
+    "deployment_provider": null,
+    "deployment_target": null,
+    "critical_journey_ref": null,
+    "auth_session_ref": null,
+    "api_data_ref": null,
+    "offline_pwa_ref": null,
+    "health_ref": null,
+    "known_mobile_defects_ref": null,
+    "rollback_target_ref": null,
+    "rollback_procedure_ref": null
+  },
+  "adapter": {
+    "implementation": "Kopano.Kpgs.Adapter",
+    "version": null,
+    "protocol_version": "1.0"
+  },
+  "renter": {
+    "status": "unknown",
+    "protocol_version": null
+  },
+  "capability_map": [],
+  "evaluation_receipt_ref": null,
+  "rollback_drill_ref": null,
+  "production_promotion_ref": null,
+  "notes": [
+    "This template is not witness evidence and cannot promote an estate property.",
+    "Migrate one bounded workflow before expanding domain coverage.",
+    "Rollback must be proven before production promotion."
+  ]
+}

--- a/governance/kpgs-vnext/migration/migration.py
+++ b/governance/kpgs-vnext/migration/migration.py
@@ -1,0 +1,367 @@
+"""KPGS canonical DNS estate migration readiness engine.
+
+This module does not mutate the Sovereign Estate Registry and does not promote a
+DNS property. It evaluates whether a bounded workflow has enough witnessed
+state/evidence to ask the separately capability-gated registry runtime for the
+next lifecycle transition.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+import hashlib
+import json
+from typing import Any, Mapping
+
+MIGRATION_STAGES = (
+    "baseline",
+    "register",
+    "adapter_integration",
+    "capability_map",
+    "renter_integration",
+    "realtime_wiring",
+    "evaluation",
+    "staging",
+    "rollback_drill",
+    "production_promotion",
+    "observe",
+)
+
+ALLOWED_STAGE_STATUS = {"PASS", "HOLD", "NOT_REACHED"}
+
+
+class MigrationError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class StageResult:
+    status: str
+    detail: str
+    evidence_refs: tuple[str, ...] = ()
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "detail": self.detail,
+            "evidence_refs": list(self.evidence_refs),
+        }
+
+
+def _hash(value: Any) -> str:
+    return hashlib.sha256(
+        json.dumps(value, sort_keys=True, separators=(",", ":"), default=str).encode()
+    ).hexdigest()
+
+
+def _refs(*values: Any) -> tuple[str, ...]:
+    return tuple(str(value) for value in values if isinstance(value, str) and value.strip())
+
+
+def _stage(status: str, detail: str, *evidence_refs: str) -> StageResult:
+    if status not in ALLOWED_STAGE_STATUS:
+        raise MigrationError(f"unknown stage status: {status}")
+    return StageResult(status, detail, _refs(*evidence_refs))
+
+
+def _property_complete_for_registration(record: Mapping[str, Any]) -> bool:
+    owner = record.get("owner")
+    deployment = record.get("deployment") or {}
+    governance = record.get("governance") or {}
+    return all(
+        (
+            isinstance(record.get("ownership_evidence"), list)
+            and bool(record.get("ownership_evidence")),
+            isinstance(record.get("repositories"), list)
+            and bool(record.get("repositories")),
+            isinstance(owner, Mapping) and bool(owner.get("ref")),
+            bool(deployment.get("provider")),
+            bool(deployment.get("target")),
+            bool(governance.get("policy_ref")),
+            bool(governance.get("risk_class")),
+            bool(governance.get("tier")),
+            isinstance(record.get("capabilities"), list)
+            and bool(record.get("capabilities")),
+            isinstance(record.get("health_endpoints"), list)
+            and bool(record.get("health_endpoints")),
+        )
+    )
+
+
+def _baseline_evidence(record: Mapping[str, Any]) -> tuple[bool, list[str], list[str]]:
+    deployment = record.get("deployment") or {}
+    rollback = record.get("rollback") or {}
+    required = {
+        "repository": bool(record.get("repositories")),
+        "deployment": bool(deployment.get("provider") and deployment.get("target")),
+        "health": bool(record.get("health_endpoints")),
+        "rollback": bool(rollback.get("target_ref") and rollback.get("procedure_ref")),
+    }
+    missing = [name for name, present in required.items() if not present]
+    refs: list[str] = []
+    for repository in record.get("repositories") or []:
+        if isinstance(repository, Mapping) and repository.get("ref"):
+            refs.append(str(repository["ref"]))
+    refs.extend(str(item) for item in record.get("health_endpoints") or [] if item)
+    refs.extend(
+        str(value)
+        for value in (rollback.get("target_ref"), rollback.get("procedure_ref"))
+        if value
+    )
+    return not missing, missing, refs
+
+
+def _evaluation_status(evaluation_receipt: Mapping[str, Any] | None) -> StageResult:
+    if not isinstance(evaluation_receipt, Mapping):
+        return _stage("HOLD", "No exact-commit evaluation receipt is attached.")
+
+    commit_sha = evaluation_receipt.get("commit_sha")
+    scorecard = evaluation_receipt.get("scorecard") or {}
+    bundle = evaluation_receipt.get("evidence_bundle") or {}
+    promotion = evaluation_receipt.get("promotion_decision") or {}
+    if not isinstance(commit_sha, str) or len(commit_sha) != 40:
+        return _stage("HOLD", "Evaluation receipt does not bind an exact 40-character commit SHA.")
+    if scorecard.get("hard_gate_failures"):
+        return _stage("HOLD", "Evaluation hard gates failed.")
+    if (bundle.get("governance_decision") or {}).get("decision") not in {"allow", "promote"}:
+        return _stage("HOLD", "Evaluation evidence bundle is not governance-admitted.")
+
+    decision = promotion.get("decision")
+    if decision not in {"hold", "promote"}:
+        return _stage("HOLD", "Promotion decision is missing or invalid.")
+
+    return _stage(
+        "PASS",
+        f"Exact-commit evaluation evidence is admitted; release recommendation is {decision.upper()}.",
+        f"commit://{commit_sha}",
+        str(bundle.get("bundle_id") or ""),
+        str(promotion.get("decision_id") or ""),
+    )
+
+
+def _rollback_status(rollback_drill: Mapping[str, Any] | None) -> StageResult:
+    if not isinstance(rollback_drill, Mapping):
+        return _stage("HOLD", "Rollback drill receipt is missing.")
+    if rollback_drill.get("schema") != "kpgs.estate-rollback-drill.v1":
+        return _stage("HOLD", "Rollback drill receipt schema is not canonical.")
+    if rollback_drill.get("passed") is not True:
+        return _stage("HOLD", "Rollback drill did not pass.")
+    if rollback_drill.get("automatic_execution") is not False:
+        return _stage("HOLD", "Rollback drill must not imply automatic rollback authority.")
+    refs = rollback_drill.get("evidence_refs") or []
+    if not isinstance(refs, list) or not refs:
+        return _stage("HOLD", "Rollback drill has no evidence references.")
+    return _stage("PASS", "Rollback drill passed without granting rollback authority.", *refs)
+
+
+def assess_migration(
+    *,
+    estate_id: str,
+    property_record: Mapping[str, Any],
+    workflow_id: str,
+    evaluation_receipt: Mapping[str, Any] | None = None,
+    rollback_drill: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Return a truthful migration recommendation for one bounded workflow."""
+    if not estate_id or not workflow_id:
+        raise MigrationError("estate_id and workflow_id are required")
+    domain = property_record.get("domain")
+    if not isinstance(domain, str) or "." not in domain:
+        raise MigrationError("property_record.domain is invalid")
+
+    stages: dict[str, StageResult] = {}
+    baseline_ok, baseline_missing, baseline_refs = _baseline_evidence(property_record)
+    stages["baseline"] = (
+        _stage("PASS", "Repository/deployment/health/rollback baseline is recorded.", *baseline_refs)
+        if baseline_ok
+        else _stage(
+            "HOLD",
+            "Baseline is incomplete: " + ", ".join(baseline_missing),
+            *baseline_refs,
+        )
+    )
+
+    status = property_record.get("status")
+    witnessed = bool(property_record.get("ownership_evidence"))
+    registration_complete = _property_complete_for_registration(property_record)
+    if status == "declared_pending_witness" or not witnessed:
+        stages["register"] = _stage(
+            "HOLD",
+            "Authoritative ownership/domain-control witness is required before registration.",
+        )
+    elif status in {"witnessed", "registered", "staging", "production"} and registration_complete:
+        stages["register"] = _stage(
+            "PASS",
+            f"Property lifecycle state {status} has the required registration contract fields.",
+            *[
+                str(item.get("ref"))
+                for item in property_record.get("ownership_evidence") or []
+                if isinstance(item, Mapping) and item.get("ref")
+            ],
+        )
+    else:
+        stages["register"] = _stage(
+            "HOLD",
+            "Property cannot enter the migration lane until registration completeness is satisfied.",
+        )
+
+    adapter = property_record.get("adapter") or {}
+    adapter_ok = bool(adapter.get("implementation") and adapter.get("version"))
+    stages["adapter_integration"] = (
+        _stage(
+            "PASS",
+            "Versioned domain adapter is declared.",
+            f"adapter://{adapter.get('implementation')}@{adapter.get('version')}",
+        )
+        if adapter_ok
+        else _stage("HOLD", "Versioned domain adapter implementation is not recorded.")
+    )
+
+    capabilities = property_record.get("capabilities") or []
+    stages["capability_map"] = (
+        _stage("PASS", "Property has an explicit capability map.", *[f"capability://{item}" for item in capabilities])
+        if capabilities
+        else _stage("HOLD", "No property capability map is recorded.")
+    )
+
+    renter = property_record.get("renter_compatibility") or {}
+    renter_ok = renter.get("status") == "conformant" and bool(renter.get("protocol_version"))
+    stages["renter_integration"] = (
+        _stage(
+            "PASS",
+            "Stateless Renter protocol is conformant.",
+            f"renter-protocol://{renter.get('protocol_version')}",
+        )
+        if renter_ok
+        else _stage("HOLD", "Stateless Renter compatibility is not conformant and versioned.")
+    )
+
+    health = property_record.get("health_endpoints") or []
+    stages["realtime_wiring"] = (
+        _stage(
+            "PASS",
+            "At least one governed health/evidence endpoint is available for reconnect verification.",
+            *health,
+        )
+        if health
+        else _stage("HOLD", "No health/evidence endpoint is recorded for reconnect verification.")
+    )
+
+    stages["evaluation"] = _evaluation_status(evaluation_receipt)
+
+    prerequisites_for_staging = (
+        "baseline",
+        "register",
+        "adapter_integration",
+        "capability_map",
+        "renter_integration",
+        "realtime_wiring",
+        "evaluation",
+    )
+    staging_ready = all(stages[name].status == "PASS" for name in prerequisites_for_staging)
+    stages["staging"] = (
+        _stage(
+            "PASS",
+            "Software/evidence prerequisites are ready for a separately capability-gated staging transition.",
+        )
+        if staging_ready
+        else _stage("NOT_REACHED", "Staging transition is not reachable until all prior gates pass.")
+    )
+
+    stages["rollback_drill"] = (
+        _rollback_status(rollback_drill)
+        if staging_ready
+        else _stage("NOT_REACHED", "Rollback drill is not reached before staging prerequisites pass.")
+    )
+
+    release = property_record.get("release") or {}
+    rollback = property_record.get("rollback") or {}
+    promotion_decision = (evaluation_receipt or {}).get("promotion_decision") or {}
+    production_ready = all(
+        (
+            stages["staging"].status == "PASS",
+            stages["rollback_drill"].status == "PASS",
+            status == "staging",
+            bool(release.get("live_ref")),
+            bool(release.get("evidence_ref")),
+            bool(rollback.get("target_ref")),
+            bool(rollback.get("procedure_ref")),
+            promotion_decision.get("decision") == "promote",
+            bool(promotion_decision.get("human_approval_ref")),
+        )
+    )
+    stages["production_promotion"] = (
+        _stage(
+            "PASS",
+            "Production promotion prerequisites are complete; registry transition still requires release capability authority.",
+            str(release.get("live_ref")),
+            str(release.get("evidence_ref")),
+            str(rollback.get("target_ref")),
+            str(rollback.get("procedure_ref")),
+            str(promotion_decision.get("human_approval_ref")),
+        )
+        if production_ready
+        else _stage(
+            "NOT_REACHED",
+            "Production remains blocked until staging, rollback drill, exact release evidence and required human approval are all present.",
+        )
+    )
+    stages["observe"] = (
+        _stage("PASS", "Production observation may begin after a separately authorized production transition.")
+        if stages["production_promotion"].status == "PASS"
+        else _stage("NOT_REACHED", "Observation is not reached before production promotion eligibility.")
+    )
+
+    migration_id = "migration_" + _hash(
+        {"estate_id": estate_id, "domain": domain.casefold(), "workflow_id": workflow_id}
+    )[:24]
+    return {
+        "schema": "kpgs.estate-migration-assessment.v1",
+        "migration_id": migration_id,
+        "estate_id": estate_id,
+        "domain": domain,
+        "workflow_id": workflow_id,
+        "source_property_status": status,
+        "stages": {name: stages[name].as_dict() for name in MIGRATION_STAGES},
+        "ready_for_staging": staging_ready,
+        "ready_for_production": production_ready,
+        "recommendation": (
+            "ELIGIBLE_FOR_PRODUCTION_TRANSITION"
+            if production_ready
+            else "ELIGIBLE_FOR_STAGING_TRANSITION"
+            if staging_ready
+            else "HOLD"
+        ),
+        "canonical_registry_changed": False,
+        "authority_effect": "none",
+        "next_action": (
+            "Use the capability-gated estate registry transition only after this exact evidence set is reviewed."
+            if staging_ready
+            else next(
+                result.detail
+                for name in MIGRATION_STAGES
+                if (result := stages[name]).status == "HOLD"
+            )
+        ),
+    }
+
+
+def assess_estate(
+    estate_document: Mapping[str, Any],
+    *,
+    workflow_id: str,
+) -> list[dict[str, Any]]:
+    """Assess every property without enriching or mutating canonical registry state."""
+    estate_id = estate_document.get("estate_id")
+    properties = estate_document.get("properties")
+    if not isinstance(estate_id, str) or not isinstance(properties, list):
+        raise MigrationError("invalid estate document")
+    return [
+        assess_migration(
+            estate_id=estate_id,
+            property_record=deepcopy(record),
+            workflow_id=workflow_id,
+        )
+        for record in properties
+    ]

--- a/tests/test_estate_migration.py
+++ b/tests/test_estate_migration.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import sys
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "governance/kpgs-vnext/migration/migration.py"
+ESTATE_PATH = ROOT / "governance/kpgs-vnext/estate-registry/estate.json"
+
+spec = importlib.util.spec_from_file_location("kpgs_estate_migration_test", MODULE_PATH)
+assert spec and spec.loader
+migration = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = migration
+spec.loader.exec_module(migration)
+
+
+def property_record(domain: str, *, status: str = "registered"):
+    slug = domain.lower().replace(".", "-")
+    return {
+        "domain": domain,
+        "status": status,
+        "owner": {"ref": "owner://robynawesome", "kind": "human"},
+        "ownership_evidence": [
+            {
+                "kind": "domain-control",
+                "ref": f"evidence://domain-control/{slug}",
+                "verified_at": "2026-08-20T00:00:00Z",
+            }
+        ],
+        "repositories": [
+            {
+                "repository": f"RobynAwesome/{slug}",
+                "role": "application",
+                "ref": f"commit://{'a' * 40}",
+            }
+        ],
+        "deployment": {
+            "provider": "reference-host",
+            "environment": "staging",
+            "target": f"https://staging.{domain.lower()}",
+        },
+        "adapter": {
+            "required": True,
+            "implementation": "Kopano.Kpgs.Adapter",
+            "version": "0.1.0-preview.1",
+        },
+        "renter_compatibility": {"status": "conformant", "protocol_version": "1.0"},
+        "governance": {
+            "policy_ref": "policy://kpgs/reference-migration",
+            "risk_class": "R1",
+            "tier": "reference",
+        },
+        "capabilities": ["task.create", "task.command", "evidence.read"],
+        "health_endpoints": [f"https://staging.{domain.lower()}/kpgs/health"],
+        "release": {"live_ref": None, "evidence_ref": None},
+        "rollback": {
+            "target_ref": f"release://{slug}/previous",
+            "procedure_ref": "repo://governance/kpgs-vnext/migration/README.md#rollback-drill",
+        },
+        "notes": ["CI reference fixture only; not canonical estate state."],
+    }
+
+
+def evaluation_receipt(*, decision: str = "hold", hard_failures=None, human_approval_ref=None):
+    return {
+        "schema": "kpgs.evaluation-live-reference-receipt.v1",
+        "commit_sha": "b" * 40,
+        "scorecard": {"hard_gate_failures": list(hard_failures or [])},
+        "evidence_bundle": {
+            "bundle_id": "evidence_reference_001",
+            "governance_decision": {"decision": "allow"},
+        },
+        "promotion_decision": {
+            "decision_id": "promotion_reference_001",
+            "decision": decision,
+            "human_approval_ref": human_approval_ref,
+        },
+    }
+
+
+def rollback_receipt(*, passed=True, automatic_execution=False):
+    return {
+        "schema": "kpgs.estate-rollback-drill.v1",
+        "passed": passed,
+        "automatic_execution": automatic_execution,
+        "evidence_refs": ["ci://migration/rollback-drill"],
+    }
+
+
+class EstateMigrationTests(unittest.TestCase):
+    def test_live_canonical_estate_remains_truthful_hold_without_witness_enrichment(self):
+        estate = json.loads(ESTATE_PATH.read_text(encoding="utf-8"))
+        before = json.dumps(estate, sort_keys=True)
+        assessments = migration.assess_estate(estate, workflow_id="bounded-pilot")
+
+        self.assertEqual(len(assessments), 6)
+        self.assertTrue(all(item["recommendation"] == "HOLD" for item in assessments))
+        self.assertTrue(all(item["ready_for_staging"] is False for item in assessments))
+        self.assertTrue(all(item["canonical_registry_changed"] is False for item in assessments))
+        self.assertTrue(
+            all(
+                item["stages"]["register"]["status"] == "HOLD"
+                for item in assessments
+            )
+        )
+        self.assertEqual(json.dumps(estate, sort_keys=True), before)
+
+    def test_kasilink_reference_workflow_reaches_staging_eligibility_but_not_production(self):
+        record = property_record("KasiLink.com")
+        result = migration.assess_migration(
+            estate_id="kopano-sovereign-estate",
+            property_record=record,
+            workflow_id="gig-create",
+            evaluation_receipt=evaluation_receipt(decision="hold"),
+        )
+
+        self.assertTrue(result["ready_for_staging"])
+        self.assertFalse(result["ready_for_production"])
+        self.assertEqual(result["recommendation"], "ELIGIBLE_FOR_STAGING_TRANSITION")
+        self.assertEqual(result["stages"]["evaluation"]["status"], "PASS")
+        self.assertEqual(result["stages"]["production_promotion"]["status"], "NOT_REACHED")
+        self.assertFalse(result["canonical_registry_changed"])
+        self.assertEqual(result["authority_effect"], "none")
+
+    def test_same_playbook_is_reusable_on_second_property(self):
+        first = migration.assess_migration(
+            estate_id="kopano-sovereign-estate",
+            property_record=property_record("KasiLink.com"),
+            workflow_id="bounded-create",
+            evaluation_receipt=evaluation_receipt(),
+        )
+        second = migration.assess_migration(
+            estate_id="kopano-sovereign-estate",
+            property_record=property_record("starfallsalvage.kopanolabs.com"),
+            workflow_id="bounded-create",
+            evaluation_receipt=evaluation_receipt(),
+        )
+        replay = migration.assess_migration(
+            estate_id="kopano-sovereign-estate",
+            property_record=property_record("KasiLink.com"),
+            workflow_id="bounded-create",
+            evaluation_receipt=evaluation_receipt(),
+        )
+
+        self.assertTrue(first["ready_for_staging"])
+        self.assertTrue(second["ready_for_staging"])
+        self.assertNotEqual(first["migration_id"], second["migration_id"])
+        self.assertEqual(first["migration_id"], replay["migration_id"])
+
+    def test_hard_evaluation_failure_blocks_staging(self):
+        result = migration.assess_migration(
+            estate_id="kopano-sovereign-estate",
+            property_record=property_record("KasiLink.com"),
+            workflow_id="gig-create",
+            evaluation_receipt=evaluation_receipt(
+                hard_failures=["renter-capability-denial"]
+            ),
+        )
+        self.assertFalse(result["ready_for_staging"])
+        self.assertEqual(result["stages"]["evaluation"]["status"], "HOLD")
+        self.assertEqual(result["stages"]["staging"]["status"], "NOT_REACHED")
+
+    def test_production_eligibility_requires_staging_release_rollback_and_human_approval(self):
+        record = property_record("KasiLink.com", status="staging")
+        record["release"] = {
+            "live_ref": "release://kasilink/candidate",
+            "evidence_ref": "evidence://kasilink/candidate",
+        }
+        result = migration.assess_migration(
+            estate_id="kopano-sovereign-estate",
+            property_record=record,
+            workflow_id="gig-create",
+            evaluation_receipt=evaluation_receipt(
+                decision="promote", human_approval_ref="human://approval/reference"
+            ),
+            rollback_drill=rollback_receipt(),
+        )
+
+        self.assertTrue(result["ready_for_staging"])
+        self.assertTrue(result["ready_for_production"])
+        self.assertEqual(result["recommendation"], "ELIGIBLE_FOR_PRODUCTION_TRANSITION")
+        self.assertEqual(result["stages"]["rollback_drill"]["status"], "PASS")
+        self.assertEqual(result["stages"]["production_promotion"]["status"], "PASS")
+        self.assertFalse(result["canonical_registry_changed"])
+
+    def test_production_remains_blocked_without_human_approval(self):
+        record = property_record("KasiLink.com", status="staging")
+        record["release"] = {
+            "live_ref": "release://kasilink/candidate",
+            "evidence_ref": "evidence://kasilink/candidate",
+        }
+        result = migration.assess_migration(
+            estate_id="kopano-sovereign-estate",
+            property_record=record,
+            workflow_id="gig-create",
+            evaluation_receipt=evaluation_receipt(decision="promote"),
+            rollback_drill=rollback_receipt(),
+        )
+        self.assertFalse(result["ready_for_production"])
+        self.assertEqual(result["stages"]["production_promotion"]["status"], "NOT_REACHED")
+
+    def test_rollback_receipt_cannot_claim_automatic_authority(self):
+        record = property_record("KasiLink.com", status="staging")
+        result = migration.assess_migration(
+            estate_id="kopano-sovereign-estate",
+            property_record=record,
+            workflow_id="gig-create",
+            evaluation_receipt=evaluation_receipt(),
+            rollback_drill=rollback_receipt(automatic_execution=True),
+        )
+        self.assertEqual(result["stages"]["rollback_drill"]["status"], "HOLD")
+        self.assertFalse(result["ready_for_production"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Advances #44 without fabricating live DNS/ownership evidence.

## What this adds

- reusable bounded-workflow migration template;
- pure/read-only migration readiness engine;
- canonical sequence: baseline → register → adapter → capability map → renter → reconnect/health → evaluation → staging → rollback drill → production eligibility → observe;
- exact distinction between assessment and the separately capability-gated Estate Registry transition;
- read-only canonical-estate assessor;
- regression proof that the same playbook is reusable on `KasiLink.com` and `starfallsalvage.kopanolabs.com` reference fixtures;
- explicit rollback-drill contract that cannot claim automatic authority;
- dedicated CI proving the real six-property estate remains HOLD and unchanged while authoritative witness evidence is absent.

## Truth boundary

This PR does **not** change `estate.json`, witness DNS ownership, invent repository/deployment refs, or claim a production migration.

Current canonical estate members remain `declared_pending_witness`, so the exact live-estate assessment is expected to produce:

`HOLD → staging NOT_REACHED → production NOT_REACHED`

Reference fixtures are CI-only and prove the software playbook, not ownership or live deployment state.

## Staging eligibility

Requires baseline + registration completeness + versioned `.NET` adapter + capability map + conformant Stateless Renter + health/reconnect endpoint + exact-commit evaluation evidence.

An evaluation release decision of HOLD caused by missing high-risk human approval may still prove the *software/evidence* path is staging-ready; it cannot promote production.

## Production eligibility

Additionally requires property already in staging, passing rollback drill, release live/evidence refs, rollback target/procedure, promotion decision `promote`, and human approval ref. The actual registry transition still requires `estate.release.transition` authority.

## Exact-head promotion receipt

Head: `284ed1f020d43a65904a12b6c7ba5a46792f7a4d`

- KPGS Estate Migration Proof `32308308893` ✅
  - current six-property canonical estate remained byte-for-byte unchanged;
  - all six live properties truthfully evaluated `HOLD` pending authoritative witness evidence;
  - reusable KasiLink + Starfall reference migration tests passed;
  - assessment artifact `kpgs-estate-migration-assessment`, digest `sha256:189f60c0c71e070e584f9d01f91f79ec8d17b86d9f3142397a1b623a43286ef9`.
- KPGS vNext Contract Gate `32308308878` ✅
- CodeQL Advanced `32308308963` ✅
- Kopano CI Pipeline `32308308914` ✅
  - Python 3.11/3.12, GUI, CLI, Agent/KPEFS all green.

## Issue state after merge

Issue #44 must remain **OPEN/HOLD** after this software merge. Completion still requires real authoritative witness/baseline/deployment evidence, a capability-gated staging transition, real rollback-drill receipt, required human approval, production transition, and observation evidence for at least one bounded low-risk estate workflow.

Any head movement invalidates this receipt until re-proven.