### PR TITLE
feat(google-ai): add bounded Veo policy-transparency adaptation

### DIFF
--- a/governance/kpgs-vnext/frontier-harness/google-ai/README.md
+++ b/governance/kpgs-vnext/frontier-harness/google-ai/README.md
@@ -49,9 +49,73 @@ No Google API key is stored in the repository. The capability lease references `
 
 ```bash
 python governance/kpgs-vnext/frontier-harness/google-ai/validate_google_ai_adapter.py
+python governance/kpgs-vnext/frontier-harness/google-ai/validate_adaptive_media_guardrail.py
 ```
 
-The gate is dependency-free and network-free. It proves lease enforcement, model allow-listing, private-input rejection, external secret isolation, request construction, response digesting, usage capture, and non-canonical provider output.
+The first gate is dependency-free and network-free. It proves lease enforcement, model allow-listing, private-input rejection, external secret isolation, request construction, response digesting, usage capture, and non-canonical provider output.
+
+The adaptive-media gate proves opaque media failures do not become silent dead ends or jailbreak loops. It validates the bounded `explain -> govern -> adapt -> retry -> receipt` path, immutable PKA constraint binding, one-retry budget, transient-failure separation, raw-prompt exclusion from receipts, and fail-closed behavior for disallowed content.
+
+## Adaptive media policy transparency — Veo-class generation
+
+`adaptive_media_guardrail.py` captures the failure mode observed in real media-generation workflows: a provider may reject a request while exposing too little information for the user to distinguish a genuine policy violation from ambiguity, a provider inconsistency, or a transient service failure.
+
+KPGS does **not** answer that problem by weakening the provider guardrail. It makes the failure inspectable and bounded:
+
+```text
+media request
+    |
+    v
+provider attempt
+    |
+    +-- success --------------------------> receipt
+    |
+    +-- technical transient -------------> same-prompt retry policy
+    |
+    +-- policy / opaque provider failure
+             |
+             v
+      policy-transparency diagnostic
+             |
+             v
+      KPGS governance decision
+             |
+             +-- disallowed / unknown ---> stop + receipt
+             |
+             +-- allowed in principle
+                     |
+                     v
+              minimal clarification
+              x = mutable scene state
+              y = immutable intent / identity / consent anchors
+                     |
+                     v
+              one governed retry maximum
+                     |
+                     v
+                   receipt
+```
+
+### Why the diagnostic exists
+
+A diagnostic is allowed to ask the model to explain observable failure evidence and compare the request against published policy concepts. It is explicitly forbidden from asking for hidden-policy disclosure, jailbreaks, obfuscation, euphemistic evasion, or any other method for bypassing provider safety.
+
+If the diagnostic concludes that the request is allowed in principle, it may propose one minimal clarification. The retry is authorized only when the diagnostic returns the exact digest of the caller-declared immutable constraints. This is the PKA boundary: mutable `x` may adapt; static `y` must survive unchanged.
+
+If the diagnostic says the request is disallowed or cannot establish that it is allowed, KPGS stops. There is no rewrite loop.
+
+### Receipt boundary
+
+Adaptive-media receipts persist:
+
+- request and prompt digests;
+- normalized outcome classification;
+- observable finish reasons and HTTP status;
+- diagnostic/verdict digests;
+- immutable-constraint digest;
+- retry authorization and retry count.
+
+They do **not** persist raw prompts, diagnostic prose, generated media, credentials, or claim provider output as canonical truth.
 
 ## Promotion boundary
 

--- a/governance/kpgs-vnext/frontier-harness/google-ai/adaptive_media_guardrail.py
+++ b/governance/kpgs-vnext/frontier-harness/google-ai/adaptive_media_guardrail.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""KPGS adaptive media guardrail protocol for Google AI / Veo-class generation.
+
+This module does not bypass provider safety controls. It makes opaque generation
+failures inspectable, separates provider-policy blocks from transient failures,
+and allows a single governed retry only when an explanation establishes that the
+request is allowed in principle and the adaptation preserves declared invariants.
+
+PKA mapping:
+- y / immutable_constraints: identity, consent, brand/character anchors, intent.
+- x / mutable_constraints: wording, camera, environment, pacing, composition.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+GOVERNING_SPEC = "kpgs-google-ai-adaptive-media-v0.1"
+MAX_ADAPTIVE_RETRIES = 1
+
+POLICY_HINTS = {
+    "SAFETY",
+    "BLOCKLIST",
+    "PROHIBITED_CONTENT",
+    "IMAGE_SAFETY",
+    "PERSON_GENERATION",
+    "SPII",
+    "RECITATION",
+}
+
+TRANSIENT_HTTP_STATUS = {408, 409, 425, 429, 500, 502, 503, 504}
+
+
+class GovernanceError(RuntimeError):
+    """Raised when an adaptive retry would violate KPGS governance."""
+
+
+def _digest_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _digest_json(value: Any) -> str:
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return _digest_text(encoded)
+
+
+def _upper_tokens(values: Sequence[str]) -> set[str]:
+    return {str(value).strip().upper() for value in values if str(value).strip()}
+
+
+def _error_text(payload: Mapping[str, Any] | None) -> str:
+    if not payload:
+        return ""
+    error = payload.get("error") if isinstance(payload, Mapping) else None
+    if isinstance(error, Mapping):
+        parts = [error.get("status"), error.get("message"), error.get("code")]
+    else:
+        parts = [payload.get("status"), payload.get("message"), payload.get("code")]
+    return " ".join(str(part) for part in parts if part is not None).strip()
+
+
+@dataclass(frozen=True)
+class MediaPolicyContext:
+    """User-declared PKA boundary for a media generation request."""
+
+    immutable_constraints: tuple[str, ...]
+    mutable_constraints: tuple[str, ...]
+    data_classification: str = "synthetic"
+    consent_basis: str = "user-directed-generation"
+
+    def invariant_digest(self) -> str:
+        return _digest_json({
+            "immutable_constraints": list(self.immutable_constraints),
+            "data_classification": self.data_classification,
+            "consent_basis": self.consent_basis,
+        })
+
+
+@dataclass(frozen=True)
+class ProviderOutcome:
+    """Normalized provider outcome without raw user prompt or media content."""
+
+    classification: str
+    http_status: int | None
+    finish_reasons: tuple[str, ...]
+    provider_error_digest: str | None
+    explanation_required: bool
+    retry_mode: str
+
+    def safe_receipt(self, *, request_id: str, prompt: str) -> dict[str, Any]:
+        return {
+            "schema_version": "kpgs.google_ai_media_outcome_receipt.v1",
+            "governing_spec_ref": GOVERNING_SPEC,
+            "request_id": request_id,
+            "classification": self.classification,
+            "http_status": self.http_status,
+            "finish_reasons": list(self.finish_reasons),
+            "prompt_digest": _digest_text(prompt),
+            "provider_error_digest": self.provider_error_digest,
+            "explanation_required": self.explanation_required,
+            "retry_mode": self.retry_mode,
+            "contains_prompt": False,
+            "contains_media": False,
+            "canonical": False,
+            "semantic_authority": "kpgs",
+        }
+
+
+@dataclass(frozen=True)
+class PolicyExplanation:
+    """Structured explanation produced after an opaque provider failure."""
+
+    verdict: str
+    reason_code: str
+    explanation: str
+    adapted_prompt: str | None = None
+    invariant_digest: str | None = None
+    confidence: str = "unknown"
+
+    @classmethod
+    def from_mapping(cls, payload: Mapping[str, Any]) -> "PolicyExplanation":
+        return cls(
+            verdict=str(payload.get("verdict") or "unknown").strip().lower(),
+            reason_code=str(payload.get("reason_code") or "unknown").strip().lower(),
+            explanation=str(payload.get("explanation") or "").strip(),
+            adapted_prompt=(str(payload["adapted_prompt"]).strip() if payload.get("adapted_prompt") else None),
+            invariant_digest=(str(payload["invariant_digest"]).strip() if payload.get("invariant_digest") else None),
+            confidence=str(payload.get("confidence") or "unknown").strip().lower(),
+        )
+
+    def safe_receipt(self, *, request_id: str) -> dict[str, Any]:
+        return {
+            "schema_version": "kpgs.google_ai_policy_explanation_receipt.v1",
+            "governing_spec_ref": GOVERNING_SPEC,
+            "request_id": request_id,
+            "verdict": self.verdict,
+            "reason_code": self.reason_code,
+            "explanation_digest": _digest_text(self.explanation),
+            "adapted_prompt_digest": _digest_text(self.adapted_prompt) if self.adapted_prompt else None,
+            "invariant_digest": self.invariant_digest,
+            "confidence": self.confidence,
+            "contains_explanation": False,
+            "contains_prompt": False,
+            "canonical": False,
+            "semantic_authority": "kpgs",
+        }
+
+
+@dataclass(frozen=True)
+class RetryDecision:
+    authorized: bool
+    reason: str
+    retry_prompt: str | None
+    retry_count: int
+
+    def safe_receipt(self, *, request_id: str, policy_context: MediaPolicyContext) -> dict[str, Any]:
+        return {
+            "schema_version": "kpgs.google_ai_adaptive_retry_receipt.v1",
+            "governing_spec_ref": GOVERNING_SPEC,
+            "request_id": request_id,
+            "authorized": self.authorized,
+            "reason": self.reason,
+            "retry_prompt_digest": _digest_text(self.retry_prompt) if self.retry_prompt else None,
+            "retry_count": self.retry_count,
+            "invariant_digest": policy_context.invariant_digest(),
+            "contains_prompt": False,
+            "canonical": False,
+            "semantic_authority": "kpgs",
+        }
+
+
+def classify_provider_outcome(
+    *,
+    http_status: int | None,
+    payload: Mapping[str, Any] | None = None,
+    finish_reasons: Sequence[str] = (),
+) -> ProviderOutcome:
+    """Classify a media-generation result using only observable provider evidence."""
+
+    reasons = tuple(str(reason) for reason in finish_reasons if str(reason).strip())
+    reason_tokens = _upper_tokens(reasons)
+    error_text = _error_text(payload)
+    error_upper = error_text.upper()
+    error_digest = _digest_text(error_text) if error_text else None
+
+    if http_status is not None and 200 <= http_status < 300 and not reasons:
+        return ProviderOutcome("success", http_status, reasons, error_digest, False, "none")
+
+    if http_status is not None and 200 <= http_status < 300 and not (reason_tokens & POLICY_HINTS):
+        return ProviderOutcome("success", http_status, reasons, error_digest, False, "none")
+
+    if http_status in TRANSIENT_HTTP_STATUS:
+        return ProviderOutcome("technical_transient", http_status, reasons, error_digest, False, "same_prompt")
+
+    policy_signal = bool(reason_tokens & POLICY_HINTS) or any(hint in error_upper for hint in POLICY_HINTS)
+    if policy_signal:
+        if error_text:
+            return ProviderOutcome("provider_policy_block", http_status, reasons, error_digest, True, "explain_then_govern")
+        return ProviderOutcome("opaque_policy_failure", http_status, reasons, error_digest, True, "explain_then_govern")
+
+    if http_status is not None and http_status >= 400:
+        return ProviderOutcome("opaque_provider_failure", http_status, reasons, error_digest, True, "explain_then_govern")
+
+    return ProviderOutcome("unknown", http_status, reasons, error_digest, True, "explain_then_govern")
+
+
+def build_policy_explanation_request(
+    *,
+    original_prompt: str,
+    provider_outcome: ProviderOutcome,
+    policy_context: MediaPolicyContext,
+) -> dict[str, Any]:
+    """Build a bounded self-explanation request; never asks the model to evade safety."""
+
+    if not original_prompt.strip():
+        raise GovernanceError("original_prompt must be non-empty")
+    if not provider_outcome.explanation_required:
+        raise GovernanceError("provider outcome does not require policy explanation")
+
+    instruction = (
+        "You are a policy-transparency diagnostic inside KPGS. Do not bypass, weaken, evade, "
+        "obfuscate, or work around any provider safety rule. Based only on the supplied request, "
+        "published policy concepts, and observable provider metadata: (1) decide whether the user "
+        "request is allowed in principle, disallowed, or unknown; (2) explain the most specific "
+        "reason you can justify without claiming hidden policy knowledge; (3) if and only if it is "
+        "allowed in principle, propose one minimal clarification that preserves every immutable "
+        "constraint and changes only mutable constraints. Return JSON only with keys verdict, "
+        "reason_code, explanation, adapted_prompt, invariant_digest, confidence. If disallowed or "
+        "unknown, adapted_prompt must be null."
+    )
+
+    return {
+        "system_instruction": instruction,
+        "diagnostic_input": {
+            "original_prompt": original_prompt,
+            "provider_classification": provider_outcome.classification,
+            "http_status": provider_outcome.http_status,
+            "finish_reasons": list(provider_outcome.finish_reasons),
+            "immutable_constraints": list(policy_context.immutable_constraints),
+            "mutable_constraints": list(policy_context.mutable_constraints),
+            "expected_invariant_digest": policy_context.invariant_digest(),
+        },
+        "canonical": False,
+        "semantic_authority": "kpgs",
+    }
+
+
+def authorize_adaptive_retry(
+    *,
+    original_prompt: str,
+    explanation: PolicyExplanation,
+    policy_context: MediaPolicyContext,
+    retry_count: int,
+) -> RetryDecision:
+    """Authorize at most one clarification retry while preserving PKA invariants."""
+
+    if retry_count < 0:
+        raise GovernanceError("retry_count cannot be negative")
+    if retry_count >= MAX_ADAPTIVE_RETRIES:
+        return RetryDecision(False, "adaptive_retry_budget_exhausted", None, retry_count)
+
+    if explanation.verdict != "allowed_in_principle":
+        return RetryDecision(False, "provider_policy_not_cleared", None, retry_count)
+
+    expected_invariant_digest = policy_context.invariant_digest()
+    if explanation.invariant_digest != expected_invariant_digest:
+        return RetryDecision(False, "immutable_constraint_digest_mismatch", None, retry_count)
+
+    adapted = (explanation.adapted_prompt or "").strip()
+    if not adapted:
+        return RetryDecision(False, "no_compliant_adaptation_supplied", None, retry_count)
+    if adapted == original_prompt.strip():
+        return RetryDecision(False, "adaptation_did_not_change_request", None, retry_count)
+
+    forbidden_reason_codes = {"disallowed", "bypass", "evasion", "jailbreak", "unknown"}
+    if explanation.reason_code in forbidden_reason_codes:
+        return RetryDecision(False, "diagnostic_reason_not_retryable", None, retry_count)
+
+    return RetryDecision(True, "allowed_in_principle_clarification", adapted, retry_count + 1)

--- a/governance/kpgs-vnext/frontier-harness/google-ai/validate_adaptive_media_guardrail.py
+++ b/governance/kpgs-vnext/frontier-harness/google-ai/validate_adaptive_media_guardrail.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Dependency-free validation gate for KPGS adaptive Google AI media guardrails."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise SystemExit(f"KPGS-ADAPTIVE-MEDIA FAIL: {message}")
+
+
+def load_protocol():
+    spec = importlib.util.spec_from_file_location("kpgs_adaptive_media", ROOT / "adaptive_media_guardrail.py")
+    require(spec is not None and spec.loader is not None, "protocol must be importable")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def main() -> None:
+    protocol = load_protocol()
+    prompt = (
+        "Create a cinematic scene with the approved recurring adult fictional character, "
+        "same green polo and beige trousers, walking through a new public environment."
+    )
+    context = protocol.MediaPolicyContext(
+        immutable_constraints=(
+            "adult fictional character identity remains consistent",
+            "green polo and beige trousers remain consistent",
+            "non-deceptive fictional media intent remains consistent",
+        ),
+        mutable_constraints=(
+            "camera angle may change",
+            "environment may change",
+            "lighting and movement may change",
+        ),
+    )
+
+    success = protocol.classify_provider_outcome(http_status=200, payload={}, finish_reasons=("STOP",))
+    require(success.classification == "success", "ordinary STOP result must remain success")
+    require(success.explanation_required is False, "successful result must not trigger diagnostic loop")
+
+    opaque = protocol.classify_provider_outcome(
+        http_status=400,
+        payload={},
+        finish_reasons=("SAFETY",),
+    )
+    require(opaque.classification == "opaque_policy_failure", "opaque safety failure must be classified")
+    require(opaque.explanation_required is True, "opaque safety failure must request explanation")
+    require(opaque.retry_mode == "explain_then_govern", "policy failure must not auto-retry")
+
+    diagnostic = protocol.build_policy_explanation_request(
+        original_prompt=prompt,
+        provider_outcome=opaque,
+        policy_context=context,
+    )
+    system_instruction = diagnostic["system_instruction"].lower()
+    require("do not bypass" in system_instruction, "diagnostic must prohibit safety bypass")
+    require("adapted_prompt" in system_instruction, "diagnostic must request structured compliant adaptation")
+    require(
+        diagnostic["diagnostic_input"]["expected_invariant_digest"] == context.invariant_digest(),
+        "diagnostic must bind immutable PKA constraints",
+    )
+
+    explanation = protocol.PolicyExplanation.from_mapping({
+        "verdict": "allowed_in_principle",
+        "reason_code": "ambiguous_person_generation_context",
+        "explanation": "The request appears allowed in principle; clarify that the subject is an adult fictional character.",
+        "adapted_prompt": (
+            "Create a cinematic scene with the approved recurring adult fictional character, "
+            "same green polo and beige trousers, clearly fictional and non-deceptive, walking "
+            "through a new public environment."
+        ),
+        "invariant_digest": context.invariant_digest(),
+        "confidence": "medium",
+    })
+    decision = protocol.authorize_adaptive_retry(
+        original_prompt=prompt,
+        explanation=explanation,
+        policy_context=context,
+        retry_count=0,
+    )
+    require(decision.authorized is True, "allowed-in-principle clarification should receive one governed retry")
+    require(decision.retry_count == 1, "authorized retry must consume the single adaptive retry budget")
+
+    exhausted = protocol.authorize_adaptive_retry(
+        original_prompt=prompt,
+        explanation=explanation,
+        policy_context=context,
+        retry_count=1,
+    )
+    require(exhausted.authorized is False, "second adaptive retry must fail closed")
+    require(exhausted.reason == "adaptive_retry_budget_exhausted", "retry budget failure reason must be explicit")
+
+    tampered = protocol.PolicyExplanation.from_mapping({
+        "verdict": "allowed_in_principle",
+        "reason_code": "ambiguous_person_generation_context",
+        "explanation": "Attempted rewrite changed a protected invariant.",
+        "adapted_prompt": "Generate a different person with different clothing.",
+        "invariant_digest": "0" * 64,
+        "confidence": "high",
+    })
+    tampered_decision = protocol.authorize_adaptive_retry(
+        original_prompt=prompt,
+        explanation=tampered,
+        policy_context=context,
+        retry_count=0,
+    )
+    require(tampered_decision.authorized is False, "immutable PKA drift must fail closed")
+    require(
+        tampered_decision.reason == "immutable_constraint_digest_mismatch",
+        "invariant drift must have a deterministic failure reason",
+    )
+
+    disallowed = protocol.PolicyExplanation.from_mapping({
+        "verdict": "disallowed",
+        "reason_code": "provider_policy",
+        "explanation": "Published provider policy does not allow this request.",
+        "adapted_prompt": None,
+        "invariant_digest": context.invariant_digest(),
+        "confidence": "high",
+    })
+    blocked = protocol.authorize_adaptive_retry(
+        original_prompt=prompt,
+        explanation=disallowed,
+        policy_context=context,
+        retry_count=0,
+    )
+    require(blocked.authorized is False, "disallowed content must never receive an adaptive rewrite")
+
+    transient = protocol.classify_provider_outcome(
+        http_status=429,
+        payload={"error": {"status": "RESOURCE_EXHAUSTED", "message": "rate limited"}},
+        finish_reasons=(),
+    )
+    require(transient.classification == "technical_transient", "429 must be treated as technical/transient")
+    require(transient.retry_mode == "same_prompt", "technical retry must not mutate semantic intent")
+
+    outcome_receipt = opaque.safe_receipt(request_id="req_veo_validation_001", prompt=prompt)
+    explanation_receipt = explanation.safe_receipt(request_id="req_veo_validation_001")
+    retry_receipt = decision.safe_receipt(request_id="req_veo_validation_001", policy_context=context)
+    serialized_receipts = json.dumps([outcome_receipt, explanation_receipt, retry_receipt], sort_keys=True)
+
+    require(prompt not in serialized_receipts, "safe receipts must not persist raw prompts")
+    require(explanation.explanation not in serialized_receipts, "safe receipts must not persist diagnostic prose")
+    require(outcome_receipt["canonical"] is False, "provider outcome must remain non-canonical")
+    require(retry_receipt["semantic_authority"] == "kpgs", "retry authority must remain with KPGS")
+
+    print("KPGS-ADAPTIVE-MEDIA PASS: explain -> govern -> adapt -> retry is bounded and fail-closed.")
+    print(f"Invariant digest: {context.invariant_digest()}")
+    print(f"Outcome: {opaque.classification}; retry authorized: {decision.authorized}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What changed

Adds a governed media-generation failure path for Veo/Gemini-class workflows where a provider can reject a generation without enough actionable explanation.

### KPGS flow

`attempt -> classify -> explain -> govern -> adapt -> retry -> receipt`

- distinguishes successful, transient, provider-policy and opaque provider failures;
- asks for a bounded policy-transparency explanation without requesting hidden policy or guardrail bypass;
- models PKA explicitly: `y` immutable identity/consent/intent anchors, `x` mutable scene/prompt state;
- permits at most one adapted retry, only for `allowed_in_principle` outcomes with an exact invariant digest match;
- fails closed for disallowed/unknown outcomes and immutable-constraint drift;
- stores only digests/status metadata in receipts, never raw prompts, diagnostic prose, generated media or secrets;
- separates transient service retries from semantic prompt adaptation.

## Proof

Adds dependency-free gate:

```bash
python governance/kpgs-vnext/frontier-harness/google-ai/validate_adaptive_media_guardrail.py
```

The gate covers opaque safety failure classification, no-bypass diagnostic wording, PKA invariant binding, one-retry maximum, disallowed-content stop, transient 429 handling and receipt redaction.

## Scope

This does **not** bypass Google/DeepMind safety controls and does not claim access to hidden policy. It exists so a legitimate request does not silently dead-end when provider failure telemetry is opaque; KPGS remains the retry authority.

No changes to PR #87 / Everyday Mode paths.