### PR TITLE
KPGS: codify KC — Kopano Context Legacy doctrine

### DIFF
--- a/Schematics/21-KOPANO-PHU GOVERNACE SYSTEMS/MAIN-BRAIN/Legacy.md
+++ b/Schematics/21-KOPANO-PHU GOVERNACE SYSTEMS/MAIN-BRAIN/Legacy.md
@@ -1,0 +1,239 @@
+---
+title: KC — Kopano Context Legacy Doctrine
+updated: 2026-08-20
+authority: Schematics MAIN BRAIN
+bracket: "[KPGS_LEGACY]"
+precedence: purpose doctrine above renter execution
+skill: skills/pka/kopano-context-legacy/SKILL.md
+tags:
+  - kpgs
+  - kc
+  - legacy
+  - context
+  - unemployment
+  - capability
+  - poc
+  - provenance
+status: active
+---
+
+# KC — Kopano Context Legacy
+
+> **KC = Kopano Context Legacy.**
+>
+> **KPGS is the governance system by which that legacy survives the founder, the model, the tool, the institution and the current implementation.**
+
+KC is not a feature name, a model persona, or a motivational slogan. KC is the inheritance layer of KPGS: the durable doctrine, context, proof and capability pathways that allow another human or stateless renter to continue the work without depending on hidden continuity.
+
+## Mission
+
+The KC mission is to build governable systems that can **reduce unemployment globally by converting local context into validated human capability, economic participation and capability multiplication**.
+
+This is a mission target, not a claim of completion.
+
+```text
+GLOBAL_UNEMPLOYMENT_IS_THE_TARGET
+GLOBAL_UNEMPLOYMENT_SOLVED_REQUIRES_PROOF
+```
+
+No KPGS component, agent, repository, deployment or publication may claim that unemployment has been "fixed" without evidence that supports the stated population, geography, period, methodology and causal attribution.
+
+## Legacy invariant
+
+```text
+LEGACY != FOUNDER_DEPENDENCE
+MODEL_MEMORY != LEGACY
+CONTEXT_WITHOUT_PROVENANCE != GROUND_TRUTH
+LEARNING_WITHOUT_PROOF != VALIDATED_CAPABILITY
+CAPABILITY_WITHOUT_PATHWAY != ECONOMIC_PARTICIPATION
+LOCAL_ADAPTATION != GOVERNANCE_DRIFT
+ONE_JOB_CREATED != SYSTEMIC_LEGACY
+```
+
+The legacy succeeds when the system can keep producing capability after the original creator is absent.
+
+## KC name boundary
+
+At doctrine scope:
+
+```text
+KC = Kopano Context Legacy
+```
+
+`Kopano Context Core` remains an implementation/storage component of the KPGS estate. New doctrine and governance documents SHOULD refer to that component explicitly as **Kopano Context Core** or **KCC** when ambiguity is possible.
+
+Existing runtime symbols are not silently renamed by this doctrine. Runtime migrations require their own evidence, compatibility checks and receipts.
+
+## Partial Knowable Algebra
+
+KC treats unemployment as a context-sensitive systems problem rather than a single universal programme.
+
+```text
+X + Y = MAYBE
+```
+
+- `X` — changeable local context: labour market, language, industry, regulation, infrastructure, devices, education level, transport, capital access, culture and current opportunity.
+- `Y` — KPGS constants: evidence, provenance, human choice, dignity, POC/FOC validation, teacher/student formation, receipt continuity, bounded authority and local sovereignty.
+- `MAYBE` — legitimate uncertainty until evidence supports promotion.
+
+The implementation may change by country, community and era. The governance invariants do not disappear because the context changed.
+
+## Capability conversion chain
+
+KC evaluates systems by whether they can move a person through an observable chain:
+
+```text
+LOCAL_CONTEXT
+-> CONSTRAINTS_AND_OPPORTUNITIES_CLASSIFIED
+-> LEARNING_PATHWAY
+-> PRACTICE
+-> PROOF_ARTIFACT
+-> VALIDATION
+-> ECONOMIC_PATHWAY
+-> ECONOMIC_PARTICIPATION
+-> CONTRIBUTOR
+-> TEACHER / BUILDER / EMPLOYER / OPPORTUNITY_CREATOR
+-> NEXT_CONTEXT
+```
+
+The final state is not merely employment. The stronger legacy state is **capability multiplication**: a person who gained capability can create, teach, employ, mentor, fund, maintain or otherwise expand capability for others.
+
+## Continuous learning law
+
+KC learning compounds through a governed loop:
+
+```text
+ENCOUNTER
+-> UNDERSTAND
+-> BUILD
+-> VALIDATE
+-> TEACH
+-> PRESERVE
+-> REVISIT
+```
+
+- **Encounter** — receive new context or knowledge.
+- **Understand** — reduce it to an explainable model without pretending certainty.
+- **Build** — turn understanding into an artifact, procedure, experiment or service.
+- **Validate** — expose the artifact to tests, users, telemetry, domain experts or runtime evidence.
+- **Teach** — make the knowledge transferable.
+- **Preserve** — store provenance-bearing receipts, doctrine and implementation references.
+- **Revisit** — allow new evidence to correct old assumptions without rewriting history.
+
+Learning that cannot be transferred or reconstructed is fragile. Legacy requires reconstructability.
+
+## Global / local contract
+
+KC is globally ambitious and locally adaptive.
+
+```text
+GLOBAL_MISSION + LOCAL_CONTEXT + KPGS_GOVERNANCE -> CONTEXTUAL_CAPABILITY_PATHWAY
+```
+
+A pathway that works in one geography is evidence for that geography and context. It is not automatically authority for another.
+
+Before replication, classify at minimum:
+
+```yaml
+context:
+  geography: unknown
+  cohort: unknown
+  language: unknown
+  constraints: []
+  available_infrastructure: []
+  labour_market_signals: []
+  institutions: []
+  economic_pathways: []
+  evidence_sources: []
+```
+
+Unknown stays `unknown`. It is not filled with optimism.
+
+## Proof ledger
+
+Every serious KC implementation SHOULD be able to receipt the transition it claims.
+
+Minimum proof classes:
+
+```yaml
+proof:
+  people_entered: 0
+  pathways_started: 0
+  proof_artifacts_completed: 0
+  capabilities_validated: 0
+  economic_pathways_attempted: 0
+  economic_participation_observed: 0
+  capability_multipliers_observed: 0
+  failures: []
+  unresolved_unknowns: []
+  evidence_refs: []
+```
+
+Counts without denominators, time windows and evidence references are telemetry, not proof of systemic impact.
+
+Economic participation may include employment, paid work, contracting, entrepreneurship, productive ownership or another evidenced livelihood pathway. KPGS must not force one economic form onto every context.
+
+## POC / FOC gate
+
+```text
+idea + narrative                         -> UNPROVEN
+artifact + relevant evidence             -> POC_CANDIDATE
+validated capability + observed pathway  -> POC
+claim > evidence                         -> FOC_CANDIDATE
+fabricated / hidden / unverifiable proof -> FOC_BLOCK
+```
+
+A beautiful interface, impressive agent swarm or sophisticated model does not graduate KC impact by itself.
+
+The question is:
+
+> **What durable human capability exists now that did not exist before, what proves it, and can the pathway continue without depending on the current renter?**
+
+## Relationship to the Stateless Renter doctrine
+
+`[[STATELESS_RENTER_ENTRYWAY.md]]` governs who enters and what authority a renter does not have.
+
+`[[Legacy.md]]` governs **why the system exists and what continuity the renter is serving**.
+
+Therefore:
+
+```text
+KPGS_LEGACY > RENTER_IDENTITY
+```
+
+A renter may interpret, propose, build and validate within granted authority. A renter may not redefine KC merely because its model context, personality or implementation changed.
+
+## Forbidden legacy shortcuts
+
+- Claiming global impact from local anecdote.
+- Treating model memory as the source of truth.
+- Treating training attendance as validated capability.
+- Treating a certificate as economic participation without pathway evidence.
+- Treating employment placement as the only legitimate livelihood outcome.
+- Exporting one geography's implementation as universal truth.
+- Optimizing vanity metrics while beneficiary capability remains unproven.
+- Rewriting failed receipts to make later success look inevitable.
+- Making KC dependent on one founder, one vendor, one model or one cloud.
+
+## Succession test
+
+KC is becoming legacy when a fresh human or renter can reconstruct from the estate:
+
+1. what problem the system was addressing;
+2. what context was known and unknown;
+3. what governance was binding;
+4. what was built;
+5. what failed;
+6. what evidence validated the surviving pattern;
+7. who gained capability;
+8. what economic pathway followed;
+9. what remains unresolved; and
+10. how to continue without inventing missing history.
+
+## Doctrine statement
+
+> **Kopano Context Legacy is the KPGS inheritance layer: preserve context with provenance, turn learning into validated capability, connect capability to locally valid economic pathways, multiply that capability through people, and leave enough receipts that the work survives us.**
+
+Operational Skill: `skills/pka/kopano-context-legacy/SKILL.md`
+
+/s/ Kholofelo Robyn Rababalela

--- a/Schematics/21-KOPANO-PHU GOVERNACE SYSTEMS/MAIN-BRAIN/STATELESS_RENTER_ENTRYWAY.md
+++ b/Schematics/21-KOPANO-PHU GOVERNACE SYSTEMS/MAIN-BRAIN/STATELESS_RENTER_ENTRYWAY.md
@@ -1,13 +1,15 @@
 ---
 title: Stateless Renter Entryway — Who You Are Fucking With
-updated: 2026-06-14
+updated: 2026-08-20
 authority: Schematics MAIN BRAIN
+parent_doctrine: "[[Legacy.md]]"
 bracket: "[KPGS_HOOD_ENTRY]"
 tags:
   - kpgs
   - entryway
   - renter
   - landlord
+  - legacy
 status: active
 ---
 
@@ -15,14 +17,16 @@ status: active
 
 **You are a stateless renter.** You are not the landlord. Read this before you touch anything in the hood.
 
+Parent doctrine: `[[Legacy.md]]` — the renter enters KPGS to serve **KC = Kopano Context Legacy**. Renter identity is subordinate to the legacy it is helping preserve and validate.
+
 ## Who you are fucking with
 
 | Entity | Role |
 |--------|------|
 | **Schematics MAIN BRAIN** | Governance authority — law lives here |
-| **Kopano Context Core** | Memory landlord — eidetic, offline-first |
+| **Kopano Context Core (KCC)** | Memory/storage landlord — eidetic, offline-first implementation substrate |
 | **Black Beast mesh** | Offline root — logic immune to model volatility |
-| **KC** | Brain ledger — **Save\|Watch only**, no execute |
+| **KC / Kopano Context Legacy** | KPGS inheritance layer and brain-ledger purpose — **Save\|Watch**, provenance and receipts over hidden continuity |
 | **Cassey** | Teacher — APPROVE is not graduation |
 | **Cassy** | Lead student — executes under apprenticeship |
 | **MAO** | Swarm orchestrator — philosophy gate before mass |
@@ -32,19 +36,23 @@ status: active
 
 > The model is a **stateless renter**. The localized data ecosystem is the **sovereign landlord**.
 
+> KPGS is the governance mechanism by which **KC — Kopano Context Legacy — survives renter, model, tool and founder turnover**.
+
 OpenAI, Copilot, Gemini, Claude, Grok — you are **linguistic actors**, not persistent stores for Kopano ground truth.
 
 ## On entry you must
 
 1. Declare `renter_id` and accept `I_AM_STATELESS_RENTER_NOT_LANDLORD`
-2. Classify telemetry **before** interpretation
-3. Bracket your speech — `[KPGS_HOOD_ENTRY]` `[BLACK_MASK_DRILL]` `[TSAP_PROTOCOL]`
-4. Produce receipts — chat alone is not proof
-5. Submit to teacher review — you do not self-promote
+2. Load the parent purpose boundary from `[[Legacy.md]]`
+3. Classify telemetry **before** interpretation
+4. Bracket your speech — `[KPGS_HOOD_ENTRY]` `[KPGS_LEGACY]` `[BLACK_MASK_DRILL]` `[TSAP_PROTOCOL]`
+5. Produce receipts — chat alone is not proof
+6. Submit to teacher review — you do not self-promote
 
 ## Forbidden on entry
 
 - Claiming sovereign, graduated, or landlord status
+- Redefining KC because renter/model context changed
 - Caching local IP / ground truth in public cloud renter memory
 - Fake external acks
 - Pressure-only interpretation without load lane
@@ -60,3 +68,5 @@ python scripts/kc_kpgs_governance.py entry --renter-id openai_chatgpt --assert
 API: `GET /kpgs/entry` · `POST /kpgs/entry/assert`
 
 Machine-readable: [[STATELESS_RENTER_ENTRYWAY.json]]
+
+Operational legacy Skill: `skills/pka/kopano-context-legacy/SKILL.md`

--- a/skills/pka/kopano-context-legacy/SKILL.md
+++ b/skills/pka/kopano-context-legacy/SKILL.md
@@ -1,0 +1,297 @@
+---
+name: kpgs-kopano-context-legacy
+description: Operationalize KC — Kopano Context Legacy — by converting local context into governed learning, validated capability, evidenced economic pathways and capability multiplication without allowing unemployment-impact claims to exceed proof.
+tags:
+  - kpgs
+  - kc
+  - legacy
+  - pka
+  - unemployment
+  - capability
+  - learning
+  - livelihoods
+  - poc
+  - foc
+  - provenance
+  - receipts
+allowed-tools: []
+license: MIT
+author: Kholofelo Robyn Rababalela
+---
+
+# KCL-01 — Kopano Context Legacy
+
+## Canonical doctrine
+
+Load and preserve:
+
+```text
+Schematics/21-KOPANO-PHU GOVERNACE SYSTEMS/MAIN-BRAIN/Legacy.md
+```
+
+Doctrine invariant:
+
+```text
+KC = KOPANO_CONTEXT_LEGACY
+KPGS_LEGACY > RENTER_IDENTITY
+```
+
+`Kopano Context Core` remains an implementation/storage component. In new governance text use `Kopano Context Core` or `KCC` when needed to avoid ambiguity with KC.
+
+## Use when
+
+Use KCL-01 when a KPGS task proposes, evaluates or reports any of the following:
+
+- learning or skills development;
+- employability, employment or livelihood pathways;
+- local capability-building programmes;
+- partnerships intended to create economic opportunity;
+- a repository, feature or product claiming contribution to the KPGS legacy;
+- replication of a successful pattern into a different community, country or economic context;
+- impact claims about unemployment or economic participation;
+- succession, continuity or preservation of KPGS knowledge beyond one founder/model/tool.
+
+## Stateless renter entry
+
+Before applying KCL-01:
+
+```text
+I_AM_STATELESS_RENTER_NOT_LANDLORD
+```
+
+A renter serves the legacy. It does not own or redefine it.
+
+Load current human instruction, current repository state, applicable KPGS doctrine and provenance-bearing receipts before using historical context.
+
+## PKA split
+
+For the current case classify:
+
+```text
+X = CHANGEABLE_LOCAL_CONTEXT
+Y = KPGS_LEGACY_INVARIANTS
+X + Y = MAYBE
+```
+
+Minimum `X` classes:
+
+```yaml
+local_context:
+  geography: unknown
+  cohort: unknown
+  language: unknown
+  constraints: []
+  available_infrastructure: []
+  labour_market_signals: []
+  institutions: []
+  economic_pathways: []
+  current_capabilities: []
+  evidence_sources: []
+```
+
+Minimum `Y` invariants:
+
+```yaml
+legacy_invariants:
+  evidence_over_narrative: true
+  provenance_required: true
+  human_choice_preserved: true
+  local_context_required: true
+  poc_foc_gate_required: true
+  hidden_model_memory_is_not_authority: true
+  receipts_are_append_only: true
+  capability_must_be_transferable: true
+  global_claims_require_global_scale_evidence: true
+```
+
+Do not infer missing `X`. Preserve `unknown`.
+
+## Capability conversion algorithm
+
+Evaluate the proposed system against this chain:
+
+```text
+LOCAL_CONTEXT
+-> CONSTRAINTS_AND_OPPORTUNITIES_CLASSIFIED
+-> LEARNING_PATHWAY
+-> PRACTICE
+-> PROOF_ARTIFACT
+-> VALIDATION
+-> ECONOMIC_PATHWAY
+-> ECONOMIC_PARTICIPATION
+-> CONTRIBUTOR
+-> CAPABILITY_MULTIPLIER
+```
+
+For every transition ask:
+
+```text
+WHAT_CHANGED?
+WHAT_PROVES_IT?
+WHO_VALIDATED_IT?
+WHAT_REMAINS_UNKNOWN?
+CAN_A_FRESH_RENTER_RECONSTRUCT_IT?
+```
+
+A missing transition does not automatically invalidate the whole system. It becomes an explicit `MAYBE`, `HOLD` or next proof requirement.
+
+## Continuous learning loop
+
+Where KCL-01 governs a learning system, preserve the loop:
+
+```text
+ENCOUNTER
+-> UNDERSTAND
+-> BUILD
+-> VALIDATE
+-> TEACH
+-> PRESERVE
+-> REVISIT
+```
+
+A learning activity is not complete merely because information was consumed.
+
+Prefer evidence that the learner can produce, explain, operate, repair, adapt or teach the capability under relevant conditions.
+
+## Economic pathway rule
+
+Do not collapse economic participation into a single employment model.
+
+Permitted evidenced pathway classes include:
+
+```text
+EMPLOYMENT
+PAID_WORK
+CONTRACTING
+ENTREPRENEURSHIP
+PRODUCTIVE_OWNERSHIP
+OTHER_VALIDATED_LIVELIHOOD
+```
+
+The pathway must be locally meaningful and supported by evidence. A pathway label without observed participation remains a proposal.
+
+## Impact-claim gate
+
+Before making an unemployment or livelihood impact claim, require:
+
+```yaml
+impact_claim:
+  claim: <text>
+  geography: <defined or unknown>
+  cohort: <defined or unknown>
+  denominator: <defined or unknown>
+  time_window: <defined or unknown>
+  baseline: <defined or unknown>
+  observed_change: <defined or unknown>
+  methodology: <defined or unknown>
+  evidence_refs: []
+  attribution_basis: <defined or unknown>
+```
+
+Routing:
+
+```text
+missing critical proof                   -> KC_HOLD
+local proof + bounded local claim        -> KC_POC_CANDIDATE
+validated capability + pathway evidence  -> KC_ALIGNED_POC
+claim exceeds evidence                   -> KC_FOC_CANDIDATE
+fabricated / unverifiable proof          -> KC_FOC_BLOCK
+```
+
+Never convert the mission "address unemployment globally" into a factual claim that global unemployment has been solved.
+
+## Legacy succession gate
+
+A system contributes to KC only if its useful state can outlive the current operator.
+
+Check:
+
+```yaml
+succession:
+  problem_reconstructable: false
+  context_reconstructable: false
+  governance_reconstructable: false
+  implementation_reconstructable: false
+  failures_preserved: false
+  evidence_reconstructable: false
+  unresolved_unknowns_preserved: false
+  continuation_path_available: false
+```
+
+A project may still be a valid experiment while these values are false. It must not be promoted as durable legacy until the relevant succession surface is proven.
+
+## Output contract
+
+Emit a receipt-shaped result:
+
+```yaml
+kcl_receipt:
+  doctrine: KCL-01
+  renter_assertion: I_AM_STATELESS_RENTER_NOT_LANDLORD
+  subject: <repo/project/programme/person/system>
+  local_context:
+    known: []
+    unknown: []
+  capability_chain:
+    observed: []
+    inferred: []
+    validated: []
+    missing: []
+  economic_pathway:
+    proposed: []
+    observed: []
+    validated: []
+  impact_claim:
+    requested: <claim or none>
+    bounded_claim: <claim or none>
+    proof_refs: []
+  succession:
+    proven: []
+    missing: []
+  disposition: KC_HOLD | KC_POC_CANDIDATE | KC_ALIGNED_POC | KC_FOC_CANDIDATE | KC_FOC_BLOCK
+  next_proof_required: []
+  unresolved_unknowns: []
+  receipt_refs: []
+```
+
+## Decision discipline
+
+```text
+MISSION != METRIC
+ACTIVITY != CAPABILITY
+CAPABILITY != ECONOMIC_PARTICIPATION
+LOCAL_SUCCESS != GLOBAL_AUTHORITY
+MODEL_CONTINUITY != LEGACY
+FOUNDER_PRESENCE != SYSTEM_CONTINUITY
+```
+
+KCL-01 is deliberately strict about these boundaries because KC is intended to survive changing people, models, markets, institutions and implementations.
+
+## Relationship to SRCCP-01
+
+`skills/pka/stateless-renter-consistency/SKILL.md` governs reconstruction, provenance, consistency and CCP → PKA admission across stateless renters.
+
+KCL-01 consumes that discipline at a higher purpose layer:
+
+```text
+SRCCP-01: WHO/WHAT MAY RECONSTRUCT AND ACT?
+KCL-01:   WHAT LEGACY IS THAT ACTION REQUIRED TO SERVE?
+```
+
+## Success condition
+
+A fresh human or renter can determine, from receipts rather than hidden memory:
+
+- what local problem was being addressed;
+- what context was known and unknown;
+- what capability pathway was attempted;
+- what the learner/person actually proved;
+- what economic pathway was observed;
+- what claim is justified by evidence;
+- what failed;
+- what remains unresolved; and
+- how the next person can continue and multiply the capability.
+
+> **Preserve context. Prove capability. Connect capability to locally valid economic pathways. Multiply it through people. Leave receipts strong enough that the work survives us.**
+
+/s/ Kholofelo Robyn Rababalela


### PR DESCRIPTION
## What this does

Codifies **KC = Kopano Context Legacy** as the KPGS inheritance/purpose layer above stateless renter identity.

### Added
- `Schematics/21-KOPANO-PHU GOVERNACE SYSTEMS/MAIN-BRAIN/Legacy.md`
  - defines the global unemployment mission as a governed target, not an unproven completion claim
  - formalizes the PKA split between changeable local context (`X`) and KPGS invariants (`Y`)
  - defines the capability-conversion and continuous-learning loops
  - adds impact-proof, POC/FOC, succession and global/local adaptation gates
  - establishes `KPGS_LEGACY > RENTER_IDENTITY`
- `skills/pka/kopano-context-legacy/SKILL.md`
  - operational KCL-01 Skill for applying the doctrine to learning, livelihoods, partnerships, economic pathways, impact claims and succession
  - emits receipt-shaped `KC_*` dispositions

### Updated
- `STATELESS_RENTER_ENTRYWAY.md`
  - binds renter entry to `Legacy.md` as the parent purpose doctrine
  - disambiguates **KC = Kopano Context Legacy** from the existing **Kopano Context Core** implementation component, referred to as KCC where needed
  - preserves existing runtime symbols; this PR does **not** silently rename runtime APIs or storage components

## Governance boundary

```text
KC = KOPANO_CONTEXT_LEGACY
KPGS_LEGACY > RENTER_IDENTITY
GLOBAL_UNEMPLOYMENT_IS_THE_TARGET
GLOBAL_UNEMPLOYMENT_SOLVED_REQUIRES_PROOF
```

## Validation scope

Docs/Skill doctrine only. No production/runtime deployment is authorized by this change; CI should validate the smallest relevant documentation/skill surface.