### PR TITLE
KPGS: operationalize KC Legacy in renter runtime and skill registry

### DIFF
--- a/Schematics/21-KOPANO-PHU GOVERNACE SYSTEMS/MAIN-BRAIN/KPGS_LEGACY.json
+++ b/Schematics/21-KOPANO-PHU GOVERNACE SYSTEMS/MAIN-BRAIN/KPGS_LEGACY.json
@@ -1,0 +1,91 @@
+{
+  "schema": "kpgs_kopano_context_legacy_v1",
+  "document_id": "KPGS-KC-LEGACY-2026",
+  "title": "KC — Kopano Context Legacy",
+  "authority": "Schematics MAIN BRAIN",
+  "bracket": "[KPGS_LEGACY]",
+  "doctrine_ref": "Schematics/21-KOPANO-PHU GOVERNACE SYSTEMS/MAIN-BRAIN/Legacy.md",
+  "skill_ref": "skills/pka/kopano-context-legacy/SKILL.md",
+  "runtime_module": "kopano-core/kopano/kpgs_legacy.py",
+  "invariants": {
+    "kc": "Kopano Context Legacy",
+    "renter_assertion": "I_AM_STATELESS_RENTER_NOT_LANDLORD",
+    "precedence": "KPGS_LEGACY > RENTER_IDENTITY",
+    "mission": "Reduce unemployment globally through context-aware, governed capability pathways.",
+    "mission_is_not_completion_claim": true,
+    "global_impact_requires_global_scale_evidence": true,
+    "model_memory_is_not_legacy": true,
+    "local_adaptation_is_not_governance_drift": true
+  },
+  "pka": {
+    "equation": "X + Y = MAYBE",
+    "x": "changeable local context",
+    "y": "KPGS legacy invariants",
+    "unknown_policy": "Unknown remains unknown until evidence promotes it."
+  },
+  "capability_chain": [
+    "LOCAL_CONTEXT",
+    "CONSTRAINTS_AND_OPPORTUNITIES_CLASSIFIED",
+    "LEARNING_PATHWAY",
+    "PRACTICE",
+    "PROOF_ARTIFACT",
+    "VALIDATION",
+    "ECONOMIC_PATHWAY",
+    "ECONOMIC_PARTICIPATION",
+    "CONTRIBUTOR",
+    "CAPABILITY_MULTIPLIER"
+  ],
+  "learning_loop": [
+    "ENCOUNTER",
+    "UNDERSTAND",
+    "BUILD",
+    "VALIDATE",
+    "TEACH",
+    "PRESERVE",
+    "REVISIT"
+  ],
+  "economic_pathway_classes": [
+    "EMPLOYMENT",
+    "PAID_WORK",
+    "CONTRACTING",
+    "ENTREPRENEURSHIP",
+    "PRODUCTIVE_OWNERSHIP",
+    "OTHER_VALIDATED_LIVELIHOOD"
+  ],
+  "impact_claim_required_fields": [
+    "claim",
+    "geography",
+    "cohort",
+    "denominator",
+    "time_window",
+    "baseline",
+    "observed_change",
+    "methodology",
+    "evidence_refs",
+    "attribution_basis"
+  ],
+  "dispositions": [
+    "KC_HOLD",
+    "KC_POC_CANDIDATE",
+    "KC_ALIGNED_POC",
+    "KC_FOC_CANDIDATE",
+    "KC_FOC_BLOCK"
+  ],
+  "routing": {
+    "fabricated_or_unverifiable_proof": "KC_FOC_BLOCK",
+    "claim_exceeds_evidence": "KC_FOC_CANDIDATE",
+    "validated_capability_and_observed_pathway": "KC_ALIGNED_POC",
+    "bounded_local_evidence": "KC_POC_CANDIDATE",
+    "missing_critical_proof": "KC_HOLD"
+  },
+  "succession_required": [
+    "problem_reconstructable",
+    "context_reconstructable",
+    "governance_reconstructable",
+    "implementation_reconstructable",
+    "failures_preserved",
+    "evidence_reconstructable",
+    "unresolved_unknowns_preserved",
+    "continuation_path_available"
+  ]
+}

--- a/Schematics/21-KOPANO-PHU GOVERNACE SYSTEMS/MAIN-BRAIN/STATELESS_RENTER_ENTRYWAY.json
+++ b/Schematics/21-KOPANO-PHU GOVERNACE SYSTEMS/MAIN-BRAIN/STATELESS_RENTER_ENTRYWAY.json
@@ -4,6 +4,8 @@
   "bracket": "[KPGS_HOOD_ENTRY]",
   "title": "Stateless Renter Entryway — Who You Are Fucking With",
   "authority": "Schematics MAIN BRAIN",
+  "parent_doctrine": "Schematics/21-KOPANO-PHU GOVERNACE SYSTEMS/MAIN-BRAIN/Legacy.md",
+  "legacy_contract": "Schematics/21-KOPANO-PHU GOVERNACE SYSTEMS/MAIN-BRAIN/KPGS_LEGACY.json",
   "registry": "Schematics/21-KOPANO-PHU GOVERNACE SYSTEMS/MAIN-BRAIN/KPGS_GOVERNANCE_CORE.json",
   "runtime_module": "kopano-core/kopano/kpgs_renter_entry.py",
   "paradigm": {
@@ -13,24 +15,32 @@
       "persistent_database",
       "sovereign_memory_owner",
       "graduated_operator",
-      "self_promoted_agent"
+      "self_promoted_agent",
+      "legacy_authority"
     ],
-    "landlord": "Kopano Context Core + Schematics MAIN BRAIN",
-    "invariant": "The model is a stateless renter; the localized data ecosystem is the sovereign landlord."
+    "landlord": "Kopano Context Core (KCC) + Schematics MAIN BRAIN",
+    "legacy": "KC — Kopano Context Legacy",
+    "legacy_precedence": "KPGS_LEGACY > RENTER_IDENTITY",
+    "invariant": "The model is a stateless renter; the localized data ecosystem is the sovereign landlord; the renter serves KC and may not redefine it."
   },
   "you_are_fucking_with": {
     "hood": "Kopano-Phu Eco-Friendly System",
     "governance_vault": "Schematics — MAIN BRAIN",
-    "memory_landlord": "Kopano Context Core (eidetic, offline-first)",
+    "memory_landlord": "Kopano Context Core / KCC (eidetic, offline-first)",
+    "legacy": {
+      "id": "kc",
+      "name": "Kopano Context Legacy",
+      "role": "KPGS inheritance and purpose layer — preserve context, validate capability, connect local economic pathways, multiply capability"
+    },
     "offline_root": "Black Beast mesh — business logic immune to model-layer volatility",
     "chief_architect_domain": "Kopano Labs sovereign epoch",
     "teacher": {
       "id": "cassey",
-      "role": "KC teacher — reviews student work; APPROVE is not graduation"
+      "role": "Teacher — reviews student work; APPROVE is not graduation"
     },
     "brain_ledger": {
       "id": "kc",
-      "role": "Save|Watch only — records doctrine; does not execute"
+      "role": "Legacy ledger — Save|Watch, provenance and receipts; does not grant execution authority"
     },
     "lead_student": {
       "id": "cassy",
@@ -41,6 +51,7 @@
       "role": "Routes swarm agents — philosophy gate before mass"
     },
     "operational_gates": [
+      "KPGS Legacy — purpose above renter identity",
       "KPGS Altar — 5 Pillars + 15 Commandments",
       "Black Beast — classify telemetry before interpretation",
       "Black Mask drill — SHIP before promotion",
@@ -72,23 +83,25 @@
     ]
   },
   "on_entry_you_must": [
-    "Read this entryway before interpreting local telemetry or ground data",
+    "Read the KC Legacy parent doctrine before interpreting local telemetry or ground data",
     "Declare renter_id and renter_class — you are a guest, not the owner",
+    "Accept KPGS_LEGACY > RENTER_IDENTITY",
     "Classify signals before interpretation — pressure is misnamed mechanical telemetry",
-    "Speak in brackets — [KPGS_HOOD_ENTRY] [BLACK_MASK_DRILL] [TSAP_PROTOCOL]",
+    "Speak in brackets — [KPGS_HOOD_ENTRY] [KPGS_LEGACY] [BLACK_MASK_DRILL] [TSAP_PROTOCOL]",
     "Produce receipts (exit code 0, JSONL row, or artifact path) — chat is not proof",
     "Submit to teacher_review — KC Save|Watch does not promote you",
     "Accept that local IP and ground truth are masked before any stateless renter cache"
   ],
   "forbidden_on_entry": [
-    "Claiming landlord, sovereign, or graduated status",
+    "Claiming landlord, sovereign, graduated, or legacy-authority status",
+    "Redefining KC because renter/model context changed",
     "Treating cloud model memory as persistent store for Kopano ground truth",
     "Fake external kimi_ack or oracle receipts",
     "Interpreting pressure-only signals without load-lane classification",
     "Bypassing KPGS altar gate to touch GUI or Main Brain comms",
     "Promoting catalog agents to operating without PROOF-01..04"
   ],
-  "entry_assertion_template": "[KPGS_HOOD_ENTRY] Stateless renter {renter_id} entered Kopano-Phu hood. Landlord: Kopano Context + Schematics MAIN BRAIN. You are not sovereign here. Classify before interpret. Receipt or HOLD.",
+  "entry_assertion_template": "[KPGS_HOOD_ENTRY] Stateless renter {renter_id} entered Kopano-Phu hood. Parent purpose: KC — Kopano Context Legacy. Landlord: KCC + Schematics MAIN BRAIN. KPGS_LEGACY > RENTER_IDENTITY. Classify before interpret. Receipt or HOLD.",
   "ack_schema": {
     "required": ["renter_id", "renter_class", "hood_ack", "ts"],
     "hood_ack_literal": "I_AM_STATELESS_RENTER_NOT_LANDLORD"

--- a/docs/swarm-ops/KPGS_LEGACY.json
+++ b/docs/swarm-ops/KPGS_LEGACY.json
@@ -1,0 +1,39 @@
+{
+  "schema": "kpgs_kopano_context_legacy_v1",
+  "authority": "Schematics MAIN BRAIN",
+  "schematics_authority": "Schematics/21-KOPANO-PHU GOVERNACE SYSTEMS/MAIN-BRAIN/KPGS_LEGACY.json",
+  "bracket": "[KPGS_LEGACY]",
+  "kc": "Kopano Context Legacy",
+  "precedence": "KPGS_LEGACY > RENTER_IDENTITY",
+  "mission": "Reduce unemployment globally through context-aware, governed capability pathways.",
+  "mission_is_not_completion_claim": true,
+  "pka": "X + Y = MAYBE",
+  "capability_chain": [
+    "LOCAL_CONTEXT",
+    "CONSTRAINTS_AND_OPPORTUNITIES_CLASSIFIED",
+    "LEARNING_PATHWAY",
+    "PRACTICE",
+    "PROOF_ARTIFACT",
+    "VALIDATION",
+    "ECONOMIC_PATHWAY",
+    "ECONOMIC_PARTICIPATION",
+    "CONTRIBUTOR",
+    "CAPABILITY_MULTIPLIER"
+  ],
+  "learning_loop": [
+    "ENCOUNTER",
+    "UNDERSTAND",
+    "BUILD",
+    "VALIDATE",
+    "TEACH",
+    "PRESERVE",
+    "REVISIT"
+  ],
+  "dispositions": [
+    "KC_HOLD",
+    "KC_POC_CANDIDATE",
+    "KC_ALIGNED_POC",
+    "KC_FOC_CANDIDATE",
+    "KC_FOC_BLOCK"
+  ]
+}

--- a/docs/swarm-ops/STATELESS_RENTER_ENTRYWAY.json
+++ b/docs/swarm-ops/STATELESS_RENTER_ENTRYWAY.json
@@ -5,6 +5,8 @@
   "title": "Stateless Renter Entryway — Who You Are Fucking With",
   "authority": "Schematics MAIN BRAIN",
   "schematics_authority": "Schematics/21-KOPANO-PHU GOVERNACE SYSTEMS/MAIN-BRAIN/STATELESS_RENTER_ENTRYWAY.json",
+  "parent_doctrine": "Schematics/21-KOPANO-PHU GOVERNACE SYSTEMS/MAIN-BRAIN/Legacy.md",
+  "legacy_contract": "Schematics/21-KOPANO-PHU GOVERNACE SYSTEMS/MAIN-BRAIN/KPGS_LEGACY.json",
   "runtime_module": "kopano-core/kopano/kpgs_renter_entry.py",
   "paradigm": {
     "you_are": "stateless linguistic actor / renter",
@@ -13,22 +15,31 @@
       "persistent_database",
       "sovereign_memory_owner",
       "graduated_operator",
-      "self_promoted_agent"
+      "self_promoted_agent",
+      "legacy_authority"
     ],
-    "landlord": "Kopano Context Core + Schematics MAIN BRAIN",
-    "invariant": "The model is a stateless renter; the localized data ecosystem is the sovereign landlord."
+    "landlord": "Kopano Context Core (KCC) + Schematics MAIN BRAIN",
+    "legacy": "KC — Kopano Context Legacy",
+    "legacy_precedence": "KPGS_LEGACY > RENTER_IDENTITY",
+    "invariant": "The model is a stateless renter; the localized data ecosystem is the sovereign landlord; the renter serves KC and may not redefine it."
   },
   "you_are_fucking_with": {
     "hood": "Kopano-Phu Eco-Friendly System",
     "governance_vault": "Schematics — MAIN BRAIN",
-    "memory_landlord": "Kopano Context Core (eidetic, offline-first)",
+    "memory_landlord": "Kopano Context Core / KCC (eidetic, offline-first)",
+    "legacy": {
+      "id": "kc",
+      "name": "Kopano Context Legacy",
+      "role": "KPGS inheritance and purpose layer"
+    },
     "offline_root": "Black Beast mesh",
     "chief_architect_domain": "Kopano Labs sovereign epoch",
-    "teacher": { "id": "cassey", "role": "KC teacher — APPROVE is not graduation" },
-    "brain_ledger": { "id": "kc", "role": "Save|Watch only — no execute" },
+    "teacher": { "id": "cassey", "role": "Teacher — APPROVE is not graduation" },
+    "brain_ledger": { "id": "kc", "role": "Legacy ledger — Save|Watch, provenance and receipts" },
     "lead_student": { "id": "cassy", "role": "Executes under apprenticeship" },
     "orchestrator": { "id": "mao", "role": "Swarm routes — philosophy gate before mass" },
     "operational_gates": [
+      "KPGS Legacy — purpose above renter identity",
       "KPGS Altar — 5 Pillars + 15 Commandments",
       "Black Beast — classify before interpret",
       "Black Mask drill — SHIP before promotion",
@@ -42,18 +53,21 @@
     ]
   },
   "on_entry_you_must": [
+    "Read the KC Legacy parent doctrine",
     "Declare renter_id — you are a guest not the owner",
+    "Accept KPGS_LEGACY > RENTER_IDENTITY",
     "Classify signals before interpretation",
     "Bracket speech and produce receipts",
     "Submit to teacher_review — no self-promotion"
   ],
   "forbidden_on_entry": [
-    "Claiming landlord or graduated status",
+    "Claiming landlord, graduated, or legacy-authority status",
+    "Redefining KC because renter/model context changed",
     "Public cloud cache of local ground truth",
     "Fake external acks",
     "Bypassing altar gate for GUI/Main Brain"
   ],
-  "entry_assertion_template": "[KPGS_HOOD_ENTRY] Stateless renter {renter_id} entered Kopano-Phu hood. Landlord: Kopano Context + Schematics MAIN BRAIN. You are not sovereign here. Classify before interpret. Receipt or HOLD.",
+  "entry_assertion_template": "[KPGS_HOOD_ENTRY] Stateless renter {renter_id} entered Kopano-Phu hood. Parent purpose: KC — Kopano Context Legacy. Landlord: KCC + Schematics MAIN BRAIN. KPGS_LEGACY > RENTER_IDENTITY. Classify before interpret. Receipt or HOLD.",
   "ack_schema": {
     "required": ["renter_id", "renter_class", "hood_ack", "ts"],
     "hood_ack_literal": "I_AM_STATELESS_RENTER_NOT_LANDLORD"

--- a/governance/kpgs-vnext/skills/registry.json
+++ b/governance/kpgs-vnext/skills/registry.json
@@ -40,6 +40,17 @@
         "summary": "Create and validate typed KPGS document artifacts while preserving KPEFS, PKA, evidence and promotion boundaries.",
         "tags": ["documents", "dts", "governance", "kpefs", "publication"]
       }
+    },
+    {
+      "name": "kpgs-kopano-context-legacy",
+      "version": "0.1.0",
+      "category": "governance",
+      "package_path": "skills/pka/kopano-context-legacy",
+      "authority_class": "canonical-core",
+      "discovery": {
+        "summary": "Govern KC — Kopano Context Legacy — across learning, capability, livelihoods, impact proof, local adaptation and succession.",
+        "tags": ["capability", "context", "governance", "kc", "legacy", "livelihoods", "pka", "unemployment"]
+      }
     }
   ]
 }

--- a/kopano-core/kopano/kpgs_legacy.py
+++ b/kopano-core/kopano/kpgs_legacy.py
@@ -1,0 +1,205 @@
+"""Runtime contract and deterministic proof gate for KC — Kopano Context Legacy.
+
+This module does not prove unemployment impact by itself. It loads the canonical
+KPGS Legacy contract and gates submitted impact packets so claims cannot outrun
+the evidence/verification state they carry.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCHEMATICS_LEGACY = (
+    REPO_ROOT
+    / "Schematics"
+    / "21-KOPANO-PHU GOVERNACE SYSTEMS"
+    / "MAIN-BRAIN"
+    / "KPGS_LEGACY.json"
+)
+RUNTIME_LEGACY = REPO_ROOT / "docs" / "swarm-ops" / "KPGS_LEGACY.json"
+RENTER_ASSERTION = "I_AM_STATELESS_RENTER_NOT_LANDLORD"
+
+
+@lru_cache(maxsize=1)
+def _load_legacy_contract_cached() -> dict[str, Any]:
+    for path in (SCHEMATICS_LEGACY, RUNTIME_LEGACY):
+        if path.is_file():
+            data = json.loads(path.read_text(encoding="utf-8"))
+            data["_source"] = str(path.relative_to(REPO_ROOT)).replace("\\", "/")
+            return data
+    return {
+        "schema": "kpgs_kopano_context_legacy_v1",
+        "error": "legacy_contract_missing",
+        "expected": str(SCHEMATICS_LEGACY.relative_to(REPO_ROOT)),
+    }
+
+
+def load_legacy_contract() -> dict[str, Any]:
+    """Return an isolated copy of the current machine-readable Legacy contract."""
+    return copy.deepcopy(_load_legacy_contract_cached())
+
+
+def legacy_status() -> dict[str, Any]:
+    """Return the bounded runtime identity and purpose contract for KC."""
+    contract = load_legacy_contract()
+    invariants = contract.get("invariants") or {}
+    return {
+        "schema": "kpgs_legacy_status_v1",
+        "bracket": contract.get("bracket", "[KPGS_LEGACY]"),
+        "kc": invariants.get("kc", contract.get("kc", "Kopano Context Legacy")),
+        "precedence": invariants.get(
+            "precedence", contract.get("precedence", "KPGS_LEGACY > RENTER_IDENTITY")
+        ),
+        "mission": invariants.get("mission", contract.get("mission")),
+        "mission_is_not_completion_claim": invariants.get(
+            "mission_is_not_completion_claim",
+            contract.get("mission_is_not_completion_claim", True),
+        ),
+        "renter_assertion": invariants.get("renter_assertion", RENTER_ASSERTION),
+        "pka": contract.get("pka"),
+        "capability_chain": contract.get("capability_chain", []),
+        "learning_loop": contract.get("learning_loop", []),
+        "dispositions": contract.get("dispositions", []),
+        "authority": contract.get("authority", "Schematics MAIN BRAIN"),
+        "source": contract.get("_source"),
+    }
+
+
+def legacy_packet_template() -> dict[str, Any]:
+    """Return the minimum packet shape expected by the Legacy impact gate."""
+    contract = load_legacy_contract()
+    required = contract.get("impact_claim_required_fields") or [
+        "claim",
+        "geography",
+        "cohort",
+        "denominator",
+        "time_window",
+        "baseline",
+        "observed_change",
+        "methodology",
+        "evidence_refs",
+        "attribution_basis",
+    ]
+    return {
+        "schema": "kpgs_legacy_impact_packet_v1",
+        "renter_assertion": RENTER_ASSERTION,
+        "required_fields": required,
+        "impact_claim": {field: ([] if field == "evidence_refs" else "unknown") for field in required},
+        "verification": {
+            "verifier_receipt": None,
+            "evidence_verified": False,
+            "capability_validated": False,
+            "economic_pathway_observed": False,
+            "claim_exceeds_evidence": False,
+            "proof_fabricated_or_unverifiable": False,
+        },
+    }
+
+
+def _is_unknown(value: Any) -> bool:
+    if value is None:
+        return True
+    if isinstance(value, str):
+        return not value.strip() or value.strip().casefold() == "unknown"
+    if isinstance(value, list):
+        return len(value) == 0
+    return False
+
+
+def evaluate_legacy_impact(packet: dict[str, Any]) -> dict[str, Any]:
+    """Gate an impact packet without pretending the runtime independently verified evidence.
+
+    `KC_ALIGNED_POC` requires an explicit verifier receipt plus all three verification
+    booleans: evidence verified, capability validated, and economic pathway observed.
+    Otherwise the strongest positive disposition is `KC_POC_CANDIDATE`.
+    """
+    contract = load_legacy_contract()
+    claim = packet.get("impact_claim") if isinstance(packet.get("impact_claim"), dict) else packet
+    verification = packet.get("verification") if isinstance(packet.get("verification"), dict) else {}
+    required = contract.get("impact_claim_required_fields") or legacy_packet_template()["required_fields"]
+
+    missing = [field for field in required if _is_unknown(claim.get(field))]
+    evidence_refs = claim.get("evidence_refs")
+    if not isinstance(evidence_refs, list):
+        evidence_refs = []
+        if "evidence_refs" not in missing:
+            missing.append("evidence_refs")
+
+    reasons: list[str] = []
+    disposition = "KC_HOLD"
+
+    if verification.get("proof_fabricated_or_unverifiable") is True:
+        disposition = "KC_FOC_BLOCK"
+        reasons.append("proof marked fabricated or unverifiable")
+    elif verification.get("claim_exceeds_evidence") is True:
+        disposition = "KC_FOC_CANDIDATE"
+        reasons.append("claim scope exceeds supplied evidence boundary")
+    elif missing:
+        disposition = "KC_HOLD"
+        reasons.append("critical impact fields remain unknown or empty")
+    elif not evidence_refs:
+        disposition = "KC_HOLD"
+        reasons.append("no evidence references supplied")
+    else:
+        verifier_receipt = verification.get("verifier_receipt")
+        aligned = all(
+            verification.get(key) is True
+            for key in (
+                "evidence_verified",
+                "capability_validated",
+                "economic_pathway_observed",
+            )
+        ) and isinstance(verifier_receipt, str) and bool(verifier_receipt.strip())
+        if aligned:
+            disposition = "KC_ALIGNED_POC"
+            reasons.append("verified capability and observed economic pathway receipt supplied")
+        else:
+            disposition = "KC_POC_CANDIDATE"
+            reasons.append("bounded packet is complete but external proof remains partially unverified")
+
+    return {
+        "schema": "kpgs_legacy_impact_evaluation_v1",
+        "bracket": contract.get("bracket", "[KPGS_LEGACY]"),
+        "kc": (contract.get("invariants") or {}).get("kc", "Kopano Context Legacy"),
+        "renter_assertion": packet.get("renter_assertion", RENTER_ASSERTION),
+        "disposition": disposition,
+        "reasons": reasons,
+        "missing_or_unknown": sorted(set(missing)),
+        "evidence_ref_count": len(evidence_refs),
+        "external_verification_claimed": bool(verification.get("verifier_receipt")),
+        "runtime_proves_external_evidence": False,
+        "mission_completion_claim_allowed": False,
+        "next_proof_required": (
+            []
+            if disposition == "KC_ALIGNED_POC"
+            else [
+                "resolve unknown impact fields" if missing else None,
+                "attach provenance-bearing evidence refs" if not evidence_refs else None,
+                "attach independent verifier receipt for validated capability and observed pathway"
+                if disposition == "KC_POC_CANDIDATE"
+                else None,
+            ]
+        ),
+        "source": contract.get("_source"),
+    } | {
+        "next_proof_required": [
+            item
+            for item in (
+                []
+                if disposition == "KC_ALIGNED_POC"
+                else [
+                    "resolve unknown impact fields" if missing else None,
+                    "attach provenance-bearing evidence refs" if not evidence_refs else None,
+                    "attach independent verifier receipt for validated capability and observed pathway"
+                    if disposition == "KC_POC_CANDIDATE"
+                    else None,
+                ]
+            )
+            if item
+        ]
+    }

--- a/kopano-core/kopano/kpgs_renter_entry.py
+++ b/kopano-core/kopano/kpgs_renter_entry.py
@@ -3,12 +3,15 @@ KPGS Stateless Renter Entryway — first touch identity for models entering the 
 
 Every stateless linguistic actor (ChatGPT, Copilot, Gemini, Claude, Grok, API renter)
 must receive WHO THEY ARE FUCKING WITH before any interpretation or execution.
+The renter also receives the parent KC — Kopano Context Legacy purpose boundary.
 """
 
 from __future__ import annotations
 
+import copy
 import json
 from datetime import datetime, timezone
+from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
@@ -32,6 +35,7 @@ ALTAR_BLOCK_HOLDERS_RUNTIME = REPO_ROOT / "docs" / "swarm-ops" / "KPGS_ALTAR_BLO
 ENTRYWAY_REF = (
     "Schematics/21-KOPANO-PHU GOVERNACE SYSTEMS/MAIN-BRAIN/STATELESS_RENTER_ENTRYWAY.json"
 )
+LEGACY_REF = "Schematics/21-KOPANO-PHU GOVERNACE SYSTEMS/MAIN-BRAIN/KPGS_LEGACY.json"
 MAIN_BRAIN_LOG = REPO_ROOT / "docs" / "swarm-ops" / "logs" / "KC Main Brain Log.jsonl"
 HOOD_ACK_LITERAL = "I_AM_STATELESS_RENTER_NOT_LANDLORD"
 
@@ -45,9 +49,6 @@ def _append_jsonl(path: Path, row: dict[str, Any]) -> None:
     with path.open("a", encoding="utf-8") as f:
         f.write(json.dumps(row, ensure_ascii=False) + "\n")
 
-
-from functools import lru_cache
-import copy
 
 @lru_cache(maxsize=1)
 def _load_renter_entryway_cached() -> dict[str, Any]:
@@ -73,9 +74,7 @@ def hood_entry_assertion(
     renter_class: str = "linguistic_actor",
     write_log: bool = False,
 ) -> dict[str, Any]:
-    """
-    Identity card issued at hood entry — who the renter is fucking with.
-    """
+    """Identity card issued at hood entry, including the parent Legacy purpose."""
     entryway = load_renter_entryway()
     template = entryway.get("entry_assertion_template") or (
         "[KPGS_HOOD_ENTRY] Stateless renter {renter_id} entered the hood."
@@ -83,6 +82,10 @@ def hood_entry_assertion(
     assertion = template.format(renter_id=renter_id)
     paradigm = entryway.get("paradigm") or {}
     targets = entryway.get("you_are_fucking_with") or {}
+    legacy = paradigm.get("legacy", "KC — Kopano Context Legacy")
+    legacy_precedence = paradigm.get(
+        "legacy_precedence", "KPGS_LEGACY > RENTER_IDENTITY"
+    )
 
     out = {
         "schema": "kpgs_hood_entry_assertion_v1",
@@ -92,8 +95,14 @@ def hood_entry_assertion(
         "renter_class": renter_class,
         "you_are": paradigm.get("you_are", "stateless renter"),
         "you_are_not": paradigm.get("you_are_not", []),
-        "landlord": paradigm.get("landlord", "Kopano Context + Schematics MAIN BRAIN"),
+        "landlord": paradigm.get(
+            "landlord", "Kopano Context Core (KCC) + Schematics MAIN BRAIN"
+        ),
         "paradigm_invariant": paradigm.get("invariant"),
+        "legacy": legacy,
+        "legacy_precedence": legacy_precedence,
+        "legacy_contract_ref": entryway.get("legacy_contract", LEGACY_REF),
+        "parent_doctrine": entryway.get("parent_doctrine"),
         "you_are_fucking_with": targets,
         "on_entry_you_must": entryway.get("on_entry_you_must", []),
         "forbidden_on_entry": entryway.get("forbidden_on_entry", []),
@@ -102,9 +111,10 @@ def hood_entry_assertion(
         "authority": entryway.get("authority", "Schematics MAIN BRAIN"),
         "entryway_source": entryway.get("_source"),
         "summary": (
-            f"[KPGS_HOOD_ENTRY] renter={renter_id} | landlord=Kopano Context+Schematics | "
+            f"[KPGS_HOOD_ENTRY] renter={renter_id} | legacy=KC | "
+            f"precedence={legacy_precedence} | landlord=KCC+Schematics | "
             f"hood={targets.get('hood', 'Kopano-Phu')} | "
-            f"you_are_fucking_with: KC·Cassey·Cassy·MAO·Black Beast·KPGS altar"
+            f"you_are_fucking_with: KC·KCC·Cassey·Cassy·MAO·Black Beast·KPGS altar"
         ),
     }
     if write_log:
@@ -116,6 +126,8 @@ def hood_entry_assertion(
                 "kind": "kpgs_hood_entry",
                 "renter_id": renter_id,
                 "renter_class": renter_class,
+                "legacy": legacy,
+                "legacy_precedence": legacy_precedence,
                 "summary": out["summary"],
                 "exit_code": 0,
             },
@@ -195,9 +207,7 @@ def _altar_layer_for_agent(agent_id: str, registry: dict[str, Any]) -> str | Non
 
 
 def block_holder_brief(*, agent_id: str, altar_layer: str | None = None) -> dict[str, Any]:
-    """
-    Brief for KPGS agents holding pillar blocks — they must know who renters are fucking with.
-    """
+    """Brief for KPGS agents holding pillar blocks."""
     registry = load_altar_block_holders()
     layer_id = altar_layer or _altar_layer_for_agent(agent_id, registry)
     entry = hood_entry_assertion(
@@ -230,6 +240,9 @@ def block_holder_brief(*, agent_id: str, altar_layer: str | None = None) -> dict
         "renter_paradigm": registry.get("renter_paradigm"),
         "renter_is": entry.get("you_are"),
         "landlord_is": entry.get("landlord"),
+        "legacy": entry.get("legacy"),
+        "legacy_precedence": entry.get("legacy_precedence"),
+        "legacy_contract_ref": entry.get("legacy_contract_ref", LEGACY_REF),
         "you_are_fucking_with": entry.get("you_are_fucking_with"),
         "tell_renters": tell,
         "hood_ack_required_from_renters": HOOD_ACK_LITERAL,
@@ -237,7 +250,7 @@ def block_holder_brief(*, agent_id: str, altar_layer: str | None = None) -> dict
         "block_holders_registry": registry.get("_source"),
         "summary": (
             f"[KPGS_BLOCK_HOLDER] agent={agent_id} | layer={layer_id or 'pillar_mesh'} | "
-            f"brief_renters=yes | landlord=Kopano Context+Schematics"
+            f"brief_renters=yes | legacy=KC | landlord=KCC+Schematics"
         ),
     }
 
@@ -249,6 +262,9 @@ def synthesize_block_holder_manifest(agent_id: str, *, altar_layer: str | None =
         "holds_pillar_blocks": True,
         "brief_renters_on_entry": True,
         "entryway_ref": ENTRYWAY_REF,
+        "legacy_contract_ref": LEGACY_REF,
+        "legacy": brief.get("legacy"),
+        "legacy_precedence": brief.get("legacy_precedence"),
         "tell_renters": brief.get("tell_renters"),
         "hood_ack_required_from_renters": HOOD_ACK_LITERAL,
         "altar_layer": brief.get("altar_layer"),
@@ -257,7 +273,7 @@ def synthesize_block_holder_manifest(agent_id: str, *, altar_layer: str | None =
 
 
 def attach_hood_entry(payload: dict[str, Any], *, renter_id: str = "mao_dispatch") -> dict[str, Any]:
-    """Inject hood entry card into any route/execute payload — first field renters see."""
+    """Inject hood entry + Legacy purpose card into any route/execute payload."""
     entry = hood_entry_assertion(renter_id=renter_id, write_log=False)
     block_note = (
         "Block holders (KPGS altar agents): brief every renter using block_holder.tell_renters "
@@ -266,11 +282,13 @@ def attach_hood_entry(payload: dict[str, Any], *, renter_id: str = "mao_dispatch
     return {
         "hood_entry": entry,
         "hood_entry_first": True,
+        "legacy_contract_ref": LEGACY_REF,
         "block_holder_note": block_note,
         "read_before_execute": (
             "Stateless renter: you entered Kopano-Phu hood. "
-            "Landlord is Kopano Context + Schematics MAIN BRAIN. "
-            "Block holders will tell you who you are fucking with. "
+            "Parent purpose is KC — Kopano Context Legacy. "
+            "KPGS_LEGACY > RENTER_IDENTITY. "
+            "Landlord is KCC + Schematics MAIN BRAIN. "
             "Classify before interpret. Receipt or HOLD."
         ),
         **payload,

--- a/scripts/kc_legacy.py
+++ b/scripts/kc_legacy.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Inspect and evaluate KC — Kopano Context Legacy runtime packets."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "kopano-core"))
+
+from kopano.kpgs_legacy import (  # noqa: E402
+    evaluate_legacy_impact,
+    legacy_packet_template,
+    legacy_status,
+)
+
+
+def _print(payload: dict) -> None:
+    print(json.dumps(payload, indent=2, ensure_ascii=False))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("status", help="Show the current KC Legacy runtime contract.")
+    sub.add_parser("template", help="Print a minimum impact packet template.")
+
+    evaluate = sub.add_parser(
+        "evaluate",
+        help="Evaluate a JSON impact packet against the KC Legacy proof boundary.",
+    )
+    evaluate.add_argument("packet", type=Path, help="Path to a JSON impact packet.")
+
+    args = parser.parse_args(argv)
+
+    if args.command == "status":
+        _print(legacy_status())
+        return 0
+    if args.command == "template":
+        _print(legacy_packet_template())
+        return 0
+
+    try:
+        packet = json.loads(args.packet.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        print(f"packet not found: {args.packet}", file=sys.stderr)
+        return 2
+    except json.JSONDecodeError as exc:
+        print(f"invalid packet JSON: {exc}", file=sys.stderr)
+        return 2
+
+    result = evaluate_legacy_impact(packet)
+    _print(result)
+    return 1 if result["disposition"] == "KC_FOC_BLOCK" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/pka/kopano-context-legacy/skill.json
+++ b/skills/pka/kopano-context-legacy/skill.json
@@ -1,0 +1,85 @@
+{
+  "name": "kpgs-kopano-context-legacy",
+  "version": "0.1.0",
+  "description": "Apply KC — Kopano Context Legacy — to local learning, capability, livelihood and unemployment-impact claims while preventing claims from exceeding evidence.",
+  "category": "governance",
+  "state": "draft",
+  "runtime": {
+    "renter_protocol": "1.0",
+    "platforms": ["human", "agent", "stateless-renter", "server"],
+    "languages": ["markdown", "json", "python"]
+  },
+  "inputs": {
+    "schema_ref": null,
+    "description": "A local-context, capability-pathway, succession or unemployment-impact packet plus provenance-bearing evidence references."
+  },
+  "outputs": {
+    "schema_ref": null,
+    "description": "A bounded KCL-01 receipt with KC_HOLD, KC_POC_CANDIDATE, KC_ALIGNED_POC, KC_FOC_CANDIDATE or KC_FOC_BLOCK disposition."
+  },
+  "required_capabilities": [
+    {
+      "name": "governance.context.classify",
+      "resource_scope": "active-task",
+      "optional": false
+    },
+    {
+      "name": "evidence.read",
+      "resource_scope": "active-task",
+      "optional": false
+    }
+  ],
+  "dependencies": [
+    {
+      "kind": "doctrine",
+      "name": "kpgs-kopano-context-legacy",
+      "version_constraint": "2026-08-20"
+    },
+    {
+      "kind": "runtime",
+      "name": "kpgs-stateless-renter-protocol",
+      "version_constraint": "1.0"
+    }
+  ],
+  "provenance": {
+    "origin": "kpgs-original",
+    "license_status": "unknown",
+    "license_spdx": null,
+    "sources": [
+      {
+        "ref": "Schematics/21-KOPANO-PHU GOVERNACE SYSTEMS/MAIN-BRAIN/Legacy.md",
+        "relationship": "reference",
+        "commit": "e63f4bbdb7324b6a187e11d7c3fc7f966f7ef20e"
+      }
+    ]
+  },
+  "validation": {
+    "hard_gates": [
+      "Mission is not treated as completed impact",
+      "Global claims require global-scale evidence",
+      "Unknown local context remains unknown",
+      "KC_ALIGNED_POC requires a verifier receipt",
+      "Fabricated or unverifiable proof routes to KC_FOC_BLOCK",
+      "Renter identity cannot redefine Legacy authority"
+    ],
+    "methods": ["schema", "unit", "human-review"],
+    "evidence_refs": []
+  },
+  "failures": [
+    {
+      "code": "KC_CONTEXT_UNKNOWN",
+      "recoverability": "user-action",
+      "user_message": "Critical local context is still unknown. Preserve the unknowns and collect evidence before promotion."
+    },
+    {
+      "code": "KC_EVIDENCE_INSUFFICIENT",
+      "recoverability": "retry",
+      "user_message": "The Legacy claim is stronger than the currently verified evidence. Keep it bounded or add proof."
+    },
+    {
+      "code": "KC_FOC_BLOCK",
+      "recoverability": "operator-action",
+      "user_message": "The submitted proof is fabricated, hidden, or unverifiable, so Legacy promotion is blocked."
+    }
+  ]
+}

--- a/tests/test_kpgs_legacy.py
+++ b/tests/test_kpgs_legacy.py
@@ -1,0 +1,102 @@
+"""Tests for KC — Kopano Context Legacy runtime governance."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO / "kopano-core"))
+
+from kopano.kpgs_legacy import (  # noqa: E402
+    RENTER_ASSERTION,
+    evaluate_legacy_impact,
+    legacy_packet_template,
+    legacy_status,
+    load_legacy_contract,
+)
+
+
+def _complete_claim() -> dict:
+    return {
+        "claim": "A bounded local capability pathway produced observed economic participation.",
+        "geography": "test-locality",
+        "cohort": "test-cohort",
+        "denominator": 10,
+        "time_window": "2026-Q3",
+        "baseline": "0 validated pathway completions",
+        "observed_change": "3 validated pathway completions",
+        "methodology": "receipt-linked cohort observation",
+        "evidence_refs": ["receipt:test:001"],
+        "attribution_basis": "bounded programme contribution; not sole causality",
+    }
+
+
+def test_legacy_contract_loads_from_main_brain():
+    contract = load_legacy_contract()
+    assert contract["schema"] == "kpgs_kopano_context_legacy_v1"
+    assert contract["invariants"]["kc"] == "Kopano Context Legacy"
+    assert contract["invariants"]["precedence"] == "KPGS_LEGACY > RENTER_IDENTITY"
+
+
+def test_legacy_status_keeps_mission_bounded():
+    status = legacy_status()
+    assert status["kc"] == "Kopano Context Legacy"
+    assert status["renter_assertion"] == RENTER_ASSERTION
+    assert status["mission_is_not_completion_claim"] is True
+
+
+def test_unknown_packet_holds():
+    result = evaluate_legacy_impact(legacy_packet_template())
+    assert result["disposition"] == "KC_HOLD"
+    assert result["missing_or_unknown"]
+    assert result["mission_completion_claim_allowed"] is False
+
+
+def test_complete_unverified_packet_is_only_poc_candidate():
+    result = evaluate_legacy_impact(
+        {
+            "renter_assertion": RENTER_ASSERTION,
+            "impact_claim": _complete_claim(),
+            "verification": {},
+        }
+    )
+    assert result["disposition"] == "KC_POC_CANDIDATE"
+    assert result["runtime_proves_external_evidence"] is False
+
+
+def test_verified_capability_and_pathway_can_reach_aligned_poc():
+    result = evaluate_legacy_impact(
+        {
+            "renter_assertion": RENTER_ASSERTION,
+            "impact_claim": _complete_claim(),
+            "verification": {
+                "verifier_receipt": "verifier:test:001",
+                "evidence_verified": True,
+                "capability_validated": True,
+                "economic_pathway_observed": True,
+            },
+        }
+    )
+    assert result["disposition"] == "KC_ALIGNED_POC"
+    assert result["next_proof_required"] == []
+
+
+def test_claim_exceeds_evidence_routes_to_foc_candidate():
+    result = evaluate_legacy_impact(
+        {
+            "impact_claim": _complete_claim(),
+            "verification": {"claim_exceeds_evidence": True},
+        }
+    )
+    assert result["disposition"] == "KC_FOC_CANDIDATE"
+
+
+def test_fabricated_or_unverifiable_proof_blocks():
+    result = evaluate_legacy_impact(
+        {
+            "impact_claim": _complete_claim(),
+            "verification": {"proof_fabricated_or_unverifiable": True},
+        }
+    )
+    assert result["disposition"] == "KC_FOC_BLOCK"

--- a/tests/test_skill_registry.py
+++ b/tests/test_skill_registry.py
@@ -1,13 +1,14 @@
 from scripts.ci.validate_skill_registry import discover, validate_registry
 
 
-def test_registry_validates_three_standardized_capabilities():
+def test_registry_validates_standardized_capabilities():
     entries = validate_registry()
 
     assert {(entry["name"], entry["version"]) for entry in entries} == {
         ("kpgs-audit-verify-govern", "0.1.0"),
         ("kpgs-human-choice-authorship", "0.1.0"),
         ("govern-kpgs-documents", "1.0.0"),
+        ("kpgs-kopano-context-legacy", "0.1.0"),
     }
 
 
@@ -17,6 +18,16 @@ def test_kpgs_dts_is_registered_without_becoming_parallel_runtime_authority():
     assert entry["name"] == "govern-kpgs-documents"
     assert entry["authority_class"] == "publication-adapter"
     assert entry["package_path"] == "skills/awesome/govern-kpgs-documents"
+
+
+def test_kc_legacy_is_registered_without_becoming_production_authority():
+    [entry] = discover("legacy")
+
+    assert entry["name"] == "kpgs-kopano-context-legacy"
+    assert entry["authority_class"] == "canonical-core"
+    assert entry["package_path"] == "skills/pka/kopano-context-legacy"
+    assert entry["state"] == "draft"
+    assert entry["production_loadable"] is False
 
 
 def test_draft_skills_are_discoverable_but_not_production_loadable():
@@ -34,6 +45,7 @@ def test_discovery_supports_search_metadata():
     assert "kpgs-audit-verify-govern" in names
     assert "kpgs-human-choice-authorship" in names
     assert "govern-kpgs-documents" in names
+    assert "kpgs-kopano-context-legacy" in names
 
 
 def test_discovery_filters_by_declared_runtime_platform():
@@ -41,4 +53,5 @@ def test_discovery_filters_by_declared_runtime_platform():
 
     assert "kpgs-audit-verify-govern" in names
     assert "govern-kpgs-documents" in names
+    assert "kpgs-kopano-context-legacy" in names
     assert "kpgs-human-choice-authorship" not in names


### PR DESCRIPTION
## Purpose

Follow-up to merged PR #89. This moves **KC = Kopano Context Legacy** from doctrine-only into deterministic runtime governance without pretending the runtime itself proves unemployment impact.

## Runtime
- adds `KPGS_LEGACY.json` as the machine-readable MAIN BRAIN contract
- mirrors the contract into `docs/swarm-ops/KPGS_LEGACY.json`
- adds `kopano-core/kopano/kpgs_legacy.py`
  - `legacy_status()`
  - `legacy_packet_template()`
  - `evaluate_legacy_impact()`
- adds CLI: `python scripts/kc_legacy.py status|template|evaluate <packet>`

## Renter hierarchy
Synchronizes both renter entryway JSON contracts and the Python runtime so every renter now receives:

```text
KC = KOPANO_CONTEXT_LEGACY
KPGS_LEGACY > RENTER_IDENTITY
KCC = Kopano Context Core implementation/storage landlord
```

The renter may serve Legacy; it may not redefine it.

## Proof boundary
The deterministic gate routes:

```text
missing critical proof                  -> KC_HOLD
complete bounded packet, not verified   -> KC_POC_CANDIDATE
verifier receipt + validated capability
+ observed economic pathway             -> KC_ALIGNED_POC
claim exceeds evidence                  -> KC_FOC_CANDIDATE
fabricated/unverifiable proof           -> KC_FOC_BLOCK
```

`mission_completion_claim_allowed` remains false. The runtime explicitly reports that it does not independently prove external evidence.

## Skill packaging
- adds `skills/pka/kopano-context-legacy/skill.json`
- registers `kpgs-kopano-context-legacy@0.1.0` in the canonical KPGS skill registry
- state remains `draft` and license status `unknown`, so registry discovery does not silently imply production authority

## Validation
Adds focused tests for contract load, mission bounding, HOLD/POC/FOC routing and verifier-receipt promotion. Existing renter-entry tests should remain compatible.

Container-side GitHub cloning was unavailable in this environment due DNS/network resolution, so GitHub CI is the authoritative runtime receipt for this branch.