### PR TITLE
feat(kpgs): require earned trust + role-fit before MAO/MMAO

### DIFF
--- a/governance/kpgs-vnext/stateless-renter/FAILURE_MATRIX.md
+++ b/governance/kpgs-vnext/stateless-renter/FAILURE_MATRIX.md
@@ -6,8 +6,10 @@ Failures never widen renter authority or move canonical state into the renter pr
 
 | Failure code | Typical source | Recoverability | Required behavior |
 |---|---|---|---|
-| `input_invalid` | Payload violates declared input contract | `user_action` | Reject before durable side effects. |
+| `input_invalid` | Payload or orchestration classification violates declared input contract | `user_action` / `operator_action` | Reject before durable side effects. |
 | `policy_denied` | Tenant/task/operation/resource outside capability lease | `operator_action` | Do not invoke the workload handler. |
+| `trust_not_earned` | Missing, expired, self-issued, identity-mismatched, cycle-mismatched, or evidence-empty KPGS trust grant | `operator_action` | Deny MAO/MMAO entry before capability or handler execution. |
+| `role_not_fit` | Renter is trusted but the current decision domain, consequence class, or authority mode is outside the grant | `operator_action` | Preserve trust receipt, deny this role, and route to an appropriately fit validator/executor. |
 | `capability_expired` | Short-lived lease expired | `rehydrate` | Reject execution and obtain a fresh governed lease. |
 | `dependency_unavailable` | Required external service unavailable | `retry` | Preserve Hub-owned checkpoint and retry from canonical state. |
 | `timeout` | Bounded operation exceeds deadline | `retry` | Reuse the same idempotency key where a side effect may have committed. |
@@ -17,14 +19,18 @@ Failures never widen renter authority or move canonical state into the renter pr
 
 ## Recovery invariants
 
-1. Retry never widens the capability lease.
+1. Retry never widens the KPGS trust grant or capability lease.
 2. Replacement renters load checkpoints and idempotency records from the declared canonical store.
 3. Reusing an idempotency key returns the prior canonical result instead of repeating a durable side effect.
 4. Failure envelopes retain tenant, domain, session, task, renter, correlation, lease and governing-spec provenance.
-5. Cache/session-local state is disposable and is never the sole source required for recovery.
+5. MAO/MMAO failures preserve `authority_mode`; successful trust/fit admission also receipts `decision_domain`, `consequence_class`, and `trust_grant_id`.
+6. `trust_not_earned` and `role_not_fit` are distinct: untrusted is not the same state as trusted-but-wrong-role.
+7. Validation-only authority never silently promotes into execution authority after retry or rehydration.
+8. Cache/session-local state is disposable and is never the sole source required for recovery.
 
 ## Executable evidence
 
 - Runtime: `kopano-core/kopano/stateless_renter.py`
 - Conformance/recovery suite: `tests/test_stateless_renter_conformance.py`
 - Event contract: `renter-envelope.schema.json`
+- Trust/role-fit contract: `trust-grant.schema.json`

--- a/governance/kpgs-vnext/stateless-renter/PROTOCOL.md
+++ b/governance/kpgs-vnext/stateless-renter/PROTOCOL.md
@@ -2,23 +2,44 @@
 
 Issue: #34
 
+Runtime protocol version: `1.1`
+
 ## 1. Purpose
 
 A **Stateless Renter** is a disposable execution unit that temporarily leases authority and context from KPGS. It may compute, call tools, emit events and produce evidence, but it is never the landlord of canonical business/governance state.
 
 The renter contract exists so KPGS can evolve domain applications independently while preserving one reproducible governance boundary.
 
+The admission law for agentic orchestration is:
+
+```text
+MODELS COMPETE FOR CAPABILITY.
+AGENTS EARN TRUST.
+SEATS CARRY AUTHORITY.
+KPGS GOVERNS THE DIFFERENCE.
+```
+
+A model/provider/benchmark result is capability evidence only. It MUST NOT be treated as MAO/MMAO execution authority.
+
 ## 2. Normative lifecycle
 
 ```text
-discover -> lease -> hydrate -> execute -> emit -> checkpoint -> release
+discover -> prove -> trust -> lease -> hydrate -> execute -> emit -> checkpoint -> release
 ```
 
 ### discover
 The renter declares runtime identity, protocol version and supported capabilities. Discovery does not grant authority.
 
+### prove
+The renter produces receipts that KPGS can evaluate: bounded execution evidence, BlackMask/verification results, teacher/reviewer decisions, recovery behavior, and other domain-approved proof. A claim that the model is "frontier", "smart", "trusted", named, or highly ranked is not proof.
+
+### trust
+Before a stateless renter enters an `MAO` or `MMAO` cycle, KPGS MUST issue an evidence-backed trust grant. The trust grant is identity-bound, tenant/domain-bound, cycle-scoped, expiring, and receipt-bearing.
+
+No trust grant means no orchestration entry.
+
 ### lease
-The Sovereign Hub issues a short-lived capability lease scoped to tenant, domain, task, resources and permitted operations.
+Only after the trust gate passes for MAO/MMAO may the Sovereign Hub honor or issue a short-lived capability lease scoped to tenant, domain, task, resources and permitted operations.
 
 ### hydrate
 The renter receives only the governed context required for the task. Hydration data carries version and provenance metadata.
@@ -33,9 +54,58 @@ Progress, decisions, tool outcomes and failures are emitted as typed events with
 A renter may emit a checkpoint reference into canonical storage. A checkpoint is evidence/state owned by the Hub or declared canonical domain store; it is not renter-local authority.
 
 ### release
-The renter returns completion/failure evidence and releases/forgets its capability lease and task-local material.
+The renter returns completion/failure evidence and releases/forgets its capability lease, trust material and task-local material.
 
-## 3. Canonical identifiers
+## 3. KPGS trust admission gate
+
+The canonical orchestration admission predicate is:
+
+```text
+ENTER(cycle, renter) =
+  cycle in {MAO, MMAO}
+  AND trust_state == trusted
+  AND issuer == KPGS
+  AND renter_id matches
+  AND tenant/domain scope matches
+  AND cycle is explicitly allowed
+  AND trust grant is unexpired
+  AND evidence_refs is non-empty
+```
+
+If any predicate is false:
+
+```text
+event_kind = policy.denied
+failure.code = trust_not_earned
+handler_execution = false
+```
+
+Trust MUST be earned from receipts. It MUST NOT be inferred from:
+
+- model family or provider;
+- benchmark rank;
+- parameter count or context-window size;
+- naming/persona continuity;
+- prior conversation warmth;
+- discovery success;
+- local cached credentials;
+- a previous renter process merely claiming it was trusted.
+
+The governing promotion invariant remains:
+
+```text
+No promotion without proof. Drill is not graduation.
+```
+
+`Structure/07-Agents/PROMOTION_LAW.json` remains the canonical promotion-law anchor. A KPGS trust grant MAY reference promotion evidence, but trust admission and public graduation remain separate decisions.
+
+### Trust is scoped authority, not permanent identity
+
+A grant applies only to its declared renter, tenant/domain and allowed orchestration cycle(s). Expiry or scope mismatch MUST fail closed.
+
+A replacement runtime may inherit a governed seat/context only when KPGS rehydrates valid trust evidence or issues a fresh grant. Model replacement alone MUST NOT transfer authority.
+
+## 4. Canonical identifiers
 
 Every governed execution MUST carry:
 
@@ -50,7 +120,12 @@ Every governed execution MUST carry:
 
 Where a message can cause a durable side effect, it MUST also carry `idempotency_key`.
 
-## 4. Capability lease
+Where execution occurs inside MAO/MMAO, the event SHOULD also carry:
+
+- `orchestration_cycle`
+- `trust_grant_id`
+
+## 5. Capability lease
 
 A capability lease MUST be:
 
@@ -62,9 +137,18 @@ A capability lease MUST be:
 - rejected after expiry;
 - unusable outside the declared scope.
 
+A capability lease does not substitute for a KPGS trust grant. For MAO/MMAO, both gates apply:
+
+```text
+KPGS_TRUST_PASS
+AND
+CAPABILITY_LEASE_PASS
+-> MAY_EXECUTE
+```
+
 A renter MUST NOT derive additional privilege from local configuration, cached credentials or undocumented environment variables.
 
-## 5. Hydration contract
+## 6. Hydration contract
 
 Hydration MUST be deterministic enough that a replacement renter can reconstruct the same governed task context from canonical sources.
 
@@ -76,11 +160,13 @@ Hydration SHOULD include:
 - required skill versions;
 - current checkpoint reference if resuming;
 - environment/runtime contract;
-- evidence correlation metadata.
+- evidence correlation metadata;
+- orchestration cycle when applicable;
+- current KPGS trust-grant reference when applicable.
 
 Hydration MUST NOT silently import unrelated tenant/user history.
 
-## 6. Event envelope
+## 7. Event envelope
 
 Renter events use the machine-readable envelope in `renter-envelope.schema.json`.
 
@@ -97,7 +183,13 @@ Canonical event kinds:
 - `capability.expired`
 - `evidence.emitted`
 
-## 7. State rules
+Canonical trust admission failure:
+
+- `trust_not_earned`
+
+The grant format is defined by `trust-grant.schema.json`.
+
+## 8. State rules
 
 Allowed renter-local state:
 
@@ -112,9 +204,10 @@ Forbidden renter-local canonical state:
 - long-lived credentials;
 - sole audit history;
 - sole workflow progress record;
-- hidden tenant profile required to resume execution.
+- hidden tenant profile required to resume execution;
+- self-issued or locally persisted trust authority.
 
-## 8. Replay and idempotency
+## 9. Replay and idempotency
 
 Retries and replay are normal operating conditions.
 
@@ -125,25 +218,30 @@ A side-effecting operation MUST either:
 
 Duplicate messages MUST NOT duplicate durable side effects.
 
-## 9. Rehydration test
+Trust replay is also bounded: a previously observed trust grant may be reused only while its identity, tenant/domain, cycle and expiry predicates remain valid.
+
+## 10. Rehydration test
 
 A renter implementation is conformant only if this test passes:
 
 1. start a governed task;
-2. emit progress/checkpoint evidence;
-3. destroy the renter process;
-4. create a replacement renter;
-5. hydrate from canonical sources;
-6. resume or safely restart according to the spec;
-7. complete without duplicated durable side effects;
-8. produce a continuous evidence chain.
+2. if MAO/MMAO, prove KPGS trust admission before execution;
+3. emit progress/checkpoint evidence;
+4. destroy the renter process;
+5. create a replacement renter;
+6. hydrate from canonical sources;
+7. revalidate trust and capability scope;
+8. resume or safely restart according to the spec;
+9. complete without duplicated durable side effects;
+10. produce a continuous evidence chain.
 
-## 10. Failure semantics
+## 11. Failure semantics
 
 Failures MUST be classified at least as:
 
 - `input_invalid`
 - `policy_denied`
+- `trust_not_earned`
 - `capability_expired`
 - `dependency_unavailable`
 - `timeout`
@@ -153,12 +251,14 @@ Failures MUST be classified at least as:
 
 A failure MUST include a machine code and a plain-language recoverability hint. Sensitive internals MUST NOT be exposed to end users.
 
-## 11. Conformance
+## 12. Conformance
 
 A conformant renter MUST demonstrate:
 
 - disposable/re-hydratable execution;
 - no ambient long-lived credentials;
+- KPGS trust-gate enforcement before MAO/MMAO execution;
+- evidence-backed, identity/scope/expiry-bound trust;
 - capability-scope enforcement;
 - replay-safe side effects;
 - typed event/evidence emission;

--- a/governance/kpgs-vnext/stateless-renter/PROTOCOL.md
+++ b/governance/kpgs-vnext/stateless-renter/PROTOCOL.md
@@ -2,7 +2,7 @@
 
 Issue: #34
 
-Runtime protocol version: `1.1`
+Runtime protocol version: `1.2`
 
 ## 1. Purpose
 
@@ -21,10 +21,18 @@ KPGS GOVERNS THE DIFFERENCE.
 
 A model/provider/benchmark result is capability evidence only. It MUST NOT be treated as MAO/MMAO execution authority.
 
+A second law governs role fitness:
+
+```text
+CAPABILITY != ROLE_FIT != AUTHORITY
+```
+
+An agent may be trusted and still be the wrong agent for a decision domain or consequence class.
+
 ## 2. Normative lifecycle
 
 ```text
-discover -> prove -> trust -> lease -> hydrate -> execute -> emit -> checkpoint -> release
+discover -> prove -> trust -> fit -> lease -> hydrate -> execute -> emit -> checkpoint -> release
 ```
 
 ### discover
@@ -38,8 +46,17 @@ Before a stateless renter enters an `MAO` or `MMAO` cycle, KPGS MUST issue an ev
 
 No trust grant means no orchestration entry.
 
+### fit
+A trusted renter MUST also be fit for the current:
+
+- `decision_domain`;
+- `consequence_class`;
+- `authority_mode` (`validation` or `execution`).
+
+Trust does not erase specialization. A code-focused renter may be trusted for software delivery while remaining ineligible for human-welfare or forensic-sociology execution. A validation-focused renter may contribute as a peer inference surface without receiving mutation authority.
+
 ### lease
-Only after the trust gate passes for MAO/MMAO may the Sovereign Hub honor or issue a short-lived capability lease scoped to tenant, domain, task, resources and permitted operations.
+Only after the trust and role-fit gates pass for MAO/MMAO may the Sovereign Hub honor or issue a short-lived capability lease scoped to tenant, domain, task, resources and permitted operations.
 
 ### hydrate
 The renter receives only the governed context required for the task. Hydration data carries version and provenance metadata.
@@ -56,12 +73,12 @@ A renter may emit a checkpoint reference into canonical storage. A checkpoint is
 ### release
 The renter returns completion/failure evidence and releases/forgets its capability lease, trust material and task-local material.
 
-## 3. KPGS trust admission gate
+## 3. KPGS trust + role-fit admission gate
 
 The canonical orchestration admission predicate is:
 
 ```text
-ENTER(cycle, renter) =
+ENTER(cycle, renter, task) =
   cycle in {MAO, MMAO}
   AND trust_state == trusted
   AND issuer == KPGS
@@ -70,15 +87,34 @@ ENTER(cycle, renter) =
   AND cycle is explicitly allowed
   AND trust grant is unexpired
   AND evidence_refs is non-empty
+  AND task.decision_domain in allowed_decision_domains
+  AND task.consequence_class in allowed_consequence_classes
+  AND task.authority_mode in allowed_authority_modes
 ```
 
-If any predicate is false:
+If trust predicates fail:
 
 ```text
 event_kind = policy.denied
 failure.code = trust_not_earned
 handler_execution = false
 ```
+
+If trust passes but role-fit predicates fail:
+
+```text
+event_kind = policy.denied
+failure.code = role_not_fit
+handler_execution = false
+```
+
+This distinction is deliberate:
+
+```text
+UNTRUSTED != TRUSTED_BUT_WRONG_ROLE
+```
+
+KPGS MUST preserve that difference in receipts.
 
 Trust MUST be earned from receipts. It MUST NOT be inferred from:
 
@@ -101,11 +137,51 @@ No promotion without proof. Drill is not graduation.
 
 ### Trust is scoped authority, not permanent identity
 
-A grant applies only to its declared renter, tenant/domain and allowed orchestration cycle(s). Expiry or scope mismatch MUST fail closed.
+A grant applies only to its declared renter, tenant/domain, allowed orchestration cycle(s), decision domains, consequence classes and authority modes. Expiry or scope mismatch MUST fail closed.
 
 A replacement runtime may inherit a governed seat/context only when KPGS rehydrates valid trust evidence or issues a fresh grant. Model replacement alone MUST NOT transfer authority.
 
-## 4. Canonical identifiers
+## 4. Validation plane vs execution plane
+
+MMAO uses two different geometries.
+
+### Validation plane — peer standing
+
+When `authority_mode == validation`:
+
+- participating agents are independent inference surfaces;
+- no participant wins merely because it speaks last;
+- convergence is evidence, not authority;
+- divergence MUST remain visible until governed resolution;
+- validation output MUST NOT mutate canonical state merely because a validator produced it;
+- peer standing in validation does not imply equal execution permissions.
+
+Canonical invariant:
+
+```text
+PEER_VALIDATION_STANDING != EXECUTION_AUTHORITY
+```
+
+### Execution plane — hierarchical authority
+
+When `authority_mode == execution`:
+
+- KPGS applies trust, role-fit and capability gates;
+- authority may be hierarchical and delegated;
+- seats may govern workers/spawns;
+- consequential mutation requires the execution-capable grant plus the capability lease.
+
+Therefore:
+
+```text
+EQUAL_IN_VALIDATION
+AND
+BOUNDED_HIERARCHY_IN_EXECUTION
+```
+
+are compatible, not contradictory.
+
+## 5. Canonical identifiers
 
 Every governed execution MUST carry:
 
@@ -120,12 +196,15 @@ Every governed execution MUST carry:
 
 Where a message can cause a durable side effect, it MUST also carry `idempotency_key`.
 
-Where execution occurs inside MAO/MMAO, the event SHOULD also carry:
+Where work occurs inside MAO/MMAO, the event MUST classify the work with:
 
-- `orchestration_cycle`
-- `trust_grant_id`
+- `orchestration_cycle`;
+- `authority_mode`;
+- `decision_domain` when a trust grant is evaluated;
+- `consequence_class` when a trust grant is evaluated;
+- `trust_grant_id` when trust/fit admission succeeds.
 
-## 5. Capability lease
+## 6. Capability lease
 
 A capability lease MUST be:
 
@@ -137,10 +216,12 @@ A capability lease MUST be:
 - rejected after expiry;
 - unusable outside the declared scope.
 
-A capability lease does not substitute for a KPGS trust grant. For MAO/MMAO, both gates apply:
+A capability lease does not substitute for a KPGS trust grant. For MAO/MMAO execution:
 
 ```text
 KPGS_TRUST_PASS
+AND
+ROLE_FIT_PASS
 AND
 CAPABILITY_LEASE_PASS
 -> MAY_EXECUTE
@@ -148,7 +229,7 @@ CAPABILITY_LEASE_PASS
 
 A renter MUST NOT derive additional privilege from local configuration, cached credentials or undocumented environment variables.
 
-## 6. Hydration contract
+## 7. Hydration contract
 
 Hydration MUST be deterministic enough that a replacement renter can reconstruct the same governed task context from canonical sources.
 
@@ -162,11 +243,13 @@ Hydration SHOULD include:
 - environment/runtime contract;
 - evidence correlation metadata;
 - orchestration cycle when applicable;
+- authority mode when applicable;
+- decision domain and consequence class when applicable;
 - current KPGS trust-grant reference when applicable.
 
 Hydration MUST NOT silently import unrelated tenant/user history.
 
-## 7. Event envelope
+## 8. Event envelope
 
 Renter events use the machine-readable envelope in `renter-envelope.schema.json`.
 
@@ -183,13 +266,14 @@ Canonical event kinds:
 - `capability.expired`
 - `evidence.emitted`
 
-Canonical trust admission failure:
+Canonical orchestration-admission failures:
 
-- `trust_not_earned`
+- `trust_not_earned` — the renter has not established valid KPGS trust;
+- `role_not_fit` — the renter is trusted but not fit for this decision domain, consequence class or authority mode.
 
 The grant format is defined by `trust-grant.schema.json`.
 
-## 8. State rules
+## 9. State rules
 
 Allowed renter-local state:
 
@@ -205,9 +289,10 @@ Forbidden renter-local canonical state:
 - sole audit history;
 - sole workflow progress record;
 - hidden tenant profile required to resume execution;
-- self-issued or locally persisted trust authority.
+- self-issued or locally persisted trust authority;
+- locally self-assigned role/consequence authority.
 
-## 9. Replay and idempotency
+## 10. Replay and idempotency
 
 Retries and replay are normal operating conditions.
 
@@ -218,30 +303,33 @@ A side-effecting operation MUST either:
 
 Duplicate messages MUST NOT duplicate durable side effects.
 
-Trust replay is also bounded: a previously observed trust grant may be reused only while its identity, tenant/domain, cycle and expiry predicates remain valid.
+Trust replay is also bounded: a previously observed trust grant may be reused only while its identity, tenant/domain, cycle, decision-domain, consequence-class, authority-mode and expiry predicates remain valid.
 
-## 10. Rehydration test
+## 11. Rehydration test
 
 A renter implementation is conformant only if this test passes:
 
 1. start a governed task;
-2. if MAO/MMAO, prove KPGS trust admission before execution;
-3. emit progress/checkpoint evidence;
-4. destroy the renter process;
-5. create a replacement renter;
-6. hydrate from canonical sources;
-7. revalidate trust and capability scope;
-8. resume or safely restart according to the spec;
-9. complete without duplicated durable side effects;
-10. produce a continuous evidence chain.
+2. if MAO/MMAO, prove KPGS trust admission before work;
+3. classify `decision_domain`, `consequence_class`, and `authority_mode`;
+4. prove role-fit for the current task;
+5. emit progress/checkpoint evidence;
+6. destroy the renter process;
+7. create a replacement renter;
+8. hydrate from canonical sources;
+9. revalidate trust, role-fit and capability scope;
+10. resume or safely restart according to the spec;
+11. complete without duplicated durable side effects;
+12. produce a continuous evidence chain.
 
-## 11. Failure semantics
+## 12. Failure semantics
 
 Failures MUST be classified at least as:
 
 - `input_invalid`
 - `policy_denied`
 - `trust_not_earned`
+- `role_not_fit`
 - `capability_expired`
 - `dependency_unavailable`
 - `timeout`
@@ -251,14 +339,16 @@ Failures MUST be classified at least as:
 
 A failure MUST include a machine code and a plain-language recoverability hint. Sensitive internals MUST NOT be exposed to end users.
 
-## 12. Conformance
+## 13. Conformance
 
 A conformant renter MUST demonstrate:
 
 - disposable/re-hydratable execution;
 - no ambient long-lived credentials;
-- KPGS trust-gate enforcement before MAO/MMAO execution;
+- KPGS trust-gate enforcement before MAO/MMAO work;
 - evidence-backed, identity/scope/expiry-bound trust;
+- decision-domain/consequence-class/authority-mode fit enforcement;
+- validation/execution authority separation;
 - capability-scope enforcement;
 - replay-safe side effects;
 - typed event/evidence emission;

--- a/governance/kpgs-vnext/stateless-renter/renter-envelope.schema.json
+++ b/governance/kpgs-vnext/stateless-renter/renter-envelope.schema.json
@@ -55,6 +55,18 @@
       "type": "string",
       "enum": ["mao", "mmao"]
     },
+    "decision_domain": {
+      "type": "string",
+      "minLength": 1
+    },
+    "consequence_class": {
+      "type": "string",
+      "minLength": 1
+    },
+    "authority_mode": {
+      "type": "string",
+      "enum": ["validation", "execution"]
+    },
     "trust_grant_id": {
       "type": "string",
       "minLength": 1,
@@ -106,6 +118,7 @@
             "input_invalid",
             "policy_denied",
             "trust_not_earned",
+            "role_not_fit",
             "capability_expired",
             "dependency_unavailable",
             "timeout",
@@ -135,14 +148,19 @@
         "required": ["orchestration_cycle"]
       },
       "then": {
+        "required": ["authority_mode"],
         "anyOf": [
-          { "required": ["trust_grant_id"] },
+          {
+            "required": ["trust_grant_id", "decision_domain", "consequence_class"]
+          },
           {
             "required": ["failure"],
             "properties": {
               "failure": {
                 "properties": {
-                  "code": { "const": "trust_not_earned" }
+                  "code": {
+                    "enum": ["trust_not_earned", "role_not_fit"]
+                  }
                 }
               }
             }

--- a/governance/kpgs-vnext/stateless-renter/renter-envelope.schema.json
+++ b/governance/kpgs-vnext/stateless-renter/renter-envelope.schema.json
@@ -51,6 +51,15 @@
     "correlation_id": { "type": "string", "minLength": 1 },
     "lease_id": { "type": "string", "minLength": 1 },
     "issued_at": { "type": "string", "format": "date-time" },
+    "orchestration_cycle": {
+      "type": "string",
+      "enum": ["mao", "mmao"]
+    },
+    "trust_grant_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 300
+    },
     "idempotency_key": {
       "type": "string",
       "minLength": 1,
@@ -96,6 +105,7 @@
           "enum": [
             "input_invalid",
             "policy_denied",
+            "trust_not_earned",
             "capability_expired",
             "dependency_unavailable",
             "timeout",
@@ -116,6 +126,29 @@
     {
       "if": { "properties": { "event_kind": { "const": "task.failed" } } },
       "then": { "required": ["failure"] }
+    },
+    {
+      "if": {
+        "properties": {
+          "orchestration_cycle": { "enum": ["mao", "mmao"] }
+        },
+        "required": ["orchestration_cycle"]
+      },
+      "then": {
+        "anyOf": [
+          { "required": ["trust_grant_id"] },
+          {
+            "required": ["failure"],
+            "properties": {
+              "failure": {
+                "properties": {
+                  "code": { "const": "trust_not_earned" }
+                }
+              }
+            }
+          }
+        ]
+      }
     }
   ]
 }

--- a/governance/kpgs-vnext/stateless-renter/trust-grant.schema.json
+++ b/governance/kpgs-vnext/stateless-renter/trust-grant.schema.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kopanolabs.com/schemas/kpgs/stateless-renter/trust-grant.schema.json",
+  "title": "KPGS Stateless Renter Trust Grant",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "grant_id",
+    "renter_id",
+    "tenant_id",
+    "domain_id",
+    "allowed_cycles",
+    "evidence_refs",
+    "expires_at",
+    "issuer",
+    "trust_state"
+  ],
+  "properties": {
+    "grant_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 300
+    },
+    "renter_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "tenant_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "domain_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "allowed_cycles": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "enum": ["mao", "mmao"]
+      }
+    },
+    "evidence_refs": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "expires_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "issuer": {
+      "const": "kpgs"
+    },
+    "trust_state": {
+      "const": "trusted"
+    }
+  }
+}

--- a/governance/kpgs-vnext/stateless-renter/trust-grant.schema.json
+++ b/governance/kpgs-vnext/stateless-renter/trust-grant.schema.json
@@ -10,6 +10,9 @@
     "tenant_id",
     "domain_id",
     "allowed_cycles",
+    "allowed_decision_domains",
+    "allowed_consequence_classes",
+    "allowed_authority_modes",
     "evidence_refs",
     "expires_at",
     "issuer",
@@ -40,6 +43,33 @@
       "items": {
         "type": "string",
         "enum": ["mao", "mmao"]
+      }
+    },
+    "allowed_decision_domains": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "allowed_consequence_classes": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "allowed_authority_modes": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "enum": ["validation", "execution"]
       }
     },
     "evidence_refs": {

--- a/kopano-core/kopano/stateless_renter.py
+++ b/kopano-core/kopano/stateless_renter.py
@@ -5,7 +5,9 @@ idempotency records are delegated to a caller-supplied canonical store so replac
 this process does not transfer or lose authority.
 
 MAO/MMAO admission is fail-closed: a stateless renter must present an earned,
-evidence-backed KPGS trust grant before an orchestration cycle may execute.
+evidence-backed KPGS trust grant before an orchestration cycle may execute. Trust
+alone is not enough: the renter must also be fit for the decision domain,
+consequence class, and authority mode of the current task.
 """
 
 from __future__ import annotations
@@ -15,13 +17,15 @@ from datetime import datetime, timezone
 from typing import Any, Callable, Mapping, Protocol
 from uuid import uuid4
 
-PROTOCOL_VERSION = "1.1"
+PROTOCOL_VERSION = "1.2"
 ORCHESTRATION_CYCLES = frozenset({"mao", "mmao"})
+AUTHORITY_MODES = frozenset({"validation", "execution"})
 TRUST_STATE = "trusted"
 FAILURE_CODES = {
     "input_invalid",
     "policy_denied",
     "trust_not_earned",
+    "role_not_fit",
     "capability_expired",
     "dependency_unavailable",
     "timeout",
@@ -42,15 +46,19 @@ class TaskContext:
     governing_spec_ref: str
     skill_versions: Mapping[str, str] = field(default_factory=dict)
     orchestration_cycle: str | None = None
+    decision_domain: str | None = None
+    consequence_class: str | None = None
+    authority_mode: str = "execution"
 
 
 @dataclass(frozen=True)
 class KPGSTrustGrant:
-    """Evidence-backed admission grant issued after KPGS trust is earned.
+    """Evidence-backed, role-fit admission grant issued after KPGS trust is earned.
 
-    Trust is bound to a renter identity, tenant/domain boundary and explicit
-    orchestration cycles. A model name, benchmark score, provider reputation or
-    successful discovery handshake is never sufficient admission evidence.
+    Trust is bound to a renter identity, tenant/domain boundary, explicit
+    orchestration cycles, decision domains, consequence classes and authority
+    modes. A model name, benchmark score, provider reputation or successful
+    discovery handshake is never sufficient admission evidence.
     """
 
     grant_id: str
@@ -58,6 +66,9 @@ class KPGSTrustGrant:
     tenant_id: str
     domain_id: str
     allowed_cycles: frozenset[str]
+    allowed_decision_domains: frozenset[str]
+    allowed_consequence_classes: frozenset[str]
+    allowed_authority_modes: frozenset[str]
     evidence_refs: tuple[str, ...]
     expires_at: datetime
     issuer: str = "kpgs"
@@ -70,25 +81,54 @@ class KPGSTrustGrant:
         renter_id: str,
         cycle: str,
         now: datetime,
-    ) -> str | None:
+    ) -> tuple[str, str] | None:
         if self.expires_at.tzinfo is None:
             raise ValueError("KPGSTrustGrant.expires_at must be timezone-aware")
         if now >= self.expires_at:
-            return "KPGS trust grant has expired"
+            return ("trust_not_earned", "KPGS trust grant has expired")
         if self.trust_state != TRUST_STATE:
-            return f"KPGS trust_state must be {TRUST_STATE!r}"
+            return ("trust_not_earned", f"KPGS trust_state must be {TRUST_STATE!r}")
         if not self.grant_id:
-            return "KPGS trust grant_id is required"
+            return ("trust_not_earned", "KPGS trust grant_id is required")
         if self.issuer.lower() != "kpgs":
-            return "KPGS trust grant must be issued by KPGS"
+            return ("trust_not_earned", "KPGS trust grant must be issued by KPGS")
         if self.renter_id != renter_id:
-            return "KPGS trust grant is bound to a different renter"
+            return ("trust_not_earned", "KPGS trust grant is bound to a different renter")
         if (self.tenant_id, self.domain_id) != (context.tenant_id, context.domain_id):
-            return "KPGS trust grant is bound to a different tenant/domain"
+            return ("trust_not_earned", "KPGS trust grant is bound to a different tenant/domain")
         if cycle not in self.allowed_cycles:
-            return f"KPGS trust grant does not authorize {cycle.upper()} entry"
+            return ("trust_not_earned", f"KPGS trust grant does not authorize {cycle.upper()} entry")
         if not self.evidence_refs or any(not ref.strip() for ref in self.evidence_refs):
-            return "KPGS trust requires at least one non-empty proof receipt"
+            return ("trust_not_earned", "KPGS trust requires at least one non-empty proof receipt")
+
+        decision_domain = (context.decision_domain or "").strip()
+        consequence_class = (context.consequence_class or "").strip()
+        authority_mode = (context.authority_mode or "").strip().lower()
+
+        if not decision_domain:
+            return ("role_not_fit", "MAO/MMAO entry requires an explicit decision_domain")
+        if not consequence_class:
+            return ("role_not_fit", "MAO/MMAO entry requires an explicit consequence_class")
+        if authority_mode not in AUTHORITY_MODES:
+            return (
+                "role_not_fit",
+                f"authority_mode must be one of {sorted(AUTHORITY_MODES)}",
+            )
+        if decision_domain not in self.allowed_decision_domains:
+            return (
+                "role_not_fit",
+                f"renter is trusted but not fit for decision_domain {decision_domain!r}",
+            )
+        if consequence_class not in self.allowed_consequence_classes:
+            return (
+                "role_not_fit",
+                f"renter is trusted but not fit for consequence_class {consequence_class!r}",
+            )
+        if authority_mode not in self.allowed_authority_modes:
+            return (
+                "role_not_fit",
+                f"renter is trusted but not authorized for {authority_mode!r} authority mode",
+            )
         return None
 
 
@@ -200,7 +240,7 @@ class StatelessRenter:
             "protocol_version": self.protocol_version,
             "accepting_work": self._accepting_work,
             "state_authority": "external-canonical-store",
-            "orchestration_entry_policy": "kpgs-earned-trust-required-for-mao-mmao",
+            "orchestration_entry_policy": "kpgs-trust-plus-domain-consequence-fit-required",
         }
 
     def begin_eviction(self) -> None:
@@ -227,7 +267,9 @@ class StatelessRenter:
         renter keeps no checkpoint or deduplication ledger of its own.
 
         If ``context.orchestration_cycle`` is MAO or MMAO, an earned KPGS trust
-        grant is required before capability-scope evaluation or handler execution.
+        grant plus role-fit for the current decision domain, consequence class and
+        authority mode is required before capability-scope evaluation or handler
+        execution.
         """
         event_time = now or datetime.now(timezone.utc)
         if event_time.tzinfo is None:
@@ -241,7 +283,6 @@ class StatelessRenter:
                 lease=lease,
                 payload={"operation": operation, "resource": resource},
                 now=event_time,
-                orchestration_cycle=cycle,
                 failure={
                     "code": "input_invalid",
                     "recoverability": "operator_action",
@@ -278,6 +319,7 @@ class StatelessRenter:
                 now=event_time,
             )
             if trust_failure:
+                failure_code, message = trust_failure
                 return self._event(
                     event_kind="policy.denied",
                     context=context,
@@ -287,9 +329,9 @@ class StatelessRenter:
                     orchestration_cycle=cycle,
                     trust_grant_id=trust_grant.grant_id or None,
                     failure={
-                        "code": "trust_not_earned",
+                        "code": failure_code,
                         "recoverability": "operator_action",
-                        "message": trust_failure,
+                        "message": message,
                     },
                 )
             trust_grant_id = trust_grant.grant_id
@@ -466,6 +508,12 @@ class StatelessRenter:
         }
         if orchestration_cycle:
             envelope["orchestration_cycle"] = orchestration_cycle
+        if context.decision_domain:
+            envelope["decision_domain"] = context.decision_domain
+        if context.consequence_class:
+            envelope["consequence_class"] = context.consequence_class
+        if context.orchestration_cycle:
+            envelope["authority_mode"] = context.authority_mode
         if trust_grant_id:
             envelope["trust_grant_id"] = trust_grant_id
         if idempotency_key:

--- a/kopano-core/kopano/stateless_renter.py
+++ b/kopano-core/kopano/stateless_renter.py
@@ -3,6 +3,9 @@
 The renter intentionally owns no canonical task database. Durable checkpoints and
 idempotency records are delegated to a caller-supplied canonical store so replacing
 this process does not transfer or lose authority.
+
+MAO/MMAO admission is fail-closed: a stateless renter must present an earned,
+evidence-backed KPGS trust grant before an orchestration cycle may execute.
 """
 
 from __future__ import annotations
@@ -12,10 +15,13 @@ from datetime import datetime, timezone
 from typing import Any, Callable, Mapping, Protocol
 from uuid import uuid4
 
-PROTOCOL_VERSION = "1.0"
+PROTOCOL_VERSION = "1.1"
+ORCHESTRATION_CYCLES = frozenset({"mao", "mmao"})
+TRUST_STATE = "trusted"
 FAILURE_CODES = {
     "input_invalid",
     "policy_denied",
+    "trust_not_earned",
     "capability_expired",
     "dependency_unavailable",
     "timeout",
@@ -35,6 +41,55 @@ class TaskContext:
     correlation_id: str
     governing_spec_ref: str
     skill_versions: Mapping[str, str] = field(default_factory=dict)
+    orchestration_cycle: str | None = None
+
+
+@dataclass(frozen=True)
+class KPGSTrustGrant:
+    """Evidence-backed admission grant issued after KPGS trust is earned.
+
+    Trust is bound to a renter identity, tenant/domain boundary and explicit
+    orchestration cycles. A model name, benchmark score, provider reputation or
+    successful discovery handshake is never sufficient admission evidence.
+    """
+
+    grant_id: str
+    renter_id: str
+    tenant_id: str
+    domain_id: str
+    allowed_cycles: frozenset[str]
+    evidence_refs: tuple[str, ...]
+    expires_at: datetime
+    issuer: str = "kpgs"
+    trust_state: str = TRUST_STATE
+
+    def authorization_failure(
+        self,
+        context: TaskContext,
+        *,
+        renter_id: str,
+        cycle: str,
+        now: datetime,
+    ) -> str | None:
+        if self.expires_at.tzinfo is None:
+            raise ValueError("KPGSTrustGrant.expires_at must be timezone-aware")
+        if now >= self.expires_at:
+            return "KPGS trust grant has expired"
+        if self.trust_state != TRUST_STATE:
+            return f"KPGS trust_state must be {TRUST_STATE!r}"
+        if not self.grant_id:
+            return "KPGS trust grant_id is required"
+        if self.issuer.lower() != "kpgs":
+            return "KPGS trust grant must be issued by KPGS"
+        if self.renter_id != renter_id:
+            return "KPGS trust grant is bound to a different renter"
+        if (self.tenant_id, self.domain_id) != (context.tenant_id, context.domain_id):
+            return "KPGS trust grant is bound to a different tenant/domain"
+        if cycle not in self.allowed_cycles:
+            return f"KPGS trust grant does not authorize {cycle.upper()} entry"
+        if not self.evidence_refs or any(not ref.strip() for ref in self.evidence_refs):
+            return "KPGS trust requires at least one non-empty proof receipt"
+        return None
 
 
 @dataclass(frozen=True)
@@ -145,6 +200,7 @@ class StatelessRenter:
             "protocol_version": self.protocol_version,
             "accepting_work": self._accepting_work,
             "state_authority": "external-canonical-store",
+            "orchestration_entry_policy": "kpgs-earned-trust-required-for-mao-mmao",
         }
 
     def begin_eviction(self) -> None:
@@ -163,15 +219,80 @@ class StatelessRenter:
         idempotency_key: str | None,
         side_effecting: bool = True,
         now: datetime | None = None,
+        trust_grant: KPGSTrustGrant | None = None,
     ) -> dict[str, Any]:
         """Execute one governed step and return a typed protocol event envelope.
 
         The caller supplies all task authority and durable state dependencies. The
         renter keeps no checkpoint or deduplication ledger of its own.
+
+        If ``context.orchestration_cycle`` is MAO or MMAO, an earned KPGS trust
+        grant is required before capability-scope evaluation or handler execution.
         """
         event_time = now or datetime.now(timezone.utc)
         if event_time.tzinfo is None:
             raise ValueError("now must be timezone-aware")
+
+        cycle = (context.orchestration_cycle or "").strip().lower()
+        if context.orchestration_cycle and cycle not in ORCHESTRATION_CYCLES:
+            return self._event(
+                event_kind="policy.denied",
+                context=context,
+                lease=lease,
+                payload={"operation": operation, "resource": resource},
+                now=event_time,
+                orchestration_cycle=cycle,
+                failure={
+                    "code": "input_invalid",
+                    "recoverability": "operator_action",
+                    "message": (
+                        f"unsupported orchestration_cycle {context.orchestration_cycle!r}; "
+                        f"expected one of {sorted(ORCHESTRATION_CYCLES)}"
+                    ),
+                },
+            )
+
+        trust_grant_id: str | None = None
+        if cycle in ORCHESTRATION_CYCLES:
+            if trust_grant is None:
+                return self._event(
+                    event_kind="policy.denied",
+                    context=context,
+                    lease=lease,
+                    payload={"operation": operation, "resource": resource},
+                    now=event_time,
+                    orchestration_cycle=cycle,
+                    failure={
+                        "code": "trust_not_earned",
+                        "recoverability": "operator_action",
+                        "message": (
+                            f"{cycle.upper()} entry denied: stateless renter must earn KPGS trust "
+                            "and present an evidence-backed trust grant"
+                        ),
+                    },
+                )
+            trust_failure = trust_grant.authorization_failure(
+                context,
+                renter_id=self.renter_id,
+                cycle=cycle,
+                now=event_time,
+            )
+            if trust_failure:
+                return self._event(
+                    event_kind="policy.denied",
+                    context=context,
+                    lease=lease,
+                    payload={"operation": operation, "resource": resource},
+                    now=event_time,
+                    orchestration_cycle=cycle,
+                    trust_grant_id=trust_grant.grant_id or None,
+                    failure={
+                        "code": "trust_not_earned",
+                        "recoverability": "operator_action",
+                        "message": trust_failure,
+                    },
+                )
+            trust_grant_id = trust_grant.grant_id
 
         if not self._accepting_work:
             return self._event(
@@ -180,6 +301,8 @@ class StatelessRenter:
                 lease=lease,
                 payload={"operation": operation, "resource": resource},
                 now=event_time,
+                orchestration_cycle=cycle or None,
+                trust_grant_id=trust_grant_id,
                 failure={
                     "code": "cancelled",
                     "recoverability": "rehydrate",
@@ -203,6 +326,8 @@ class StatelessRenter:
                 lease=lease,
                 payload={"operation": operation, "resource": resource},
                 now=event_time,
+                orchestration_cycle=cycle or None,
+                trust_grant_id=trust_grant_id,
                 failure={
                     "code": failure_code,
                     "recoverability": recoverability,
@@ -217,6 +342,8 @@ class StatelessRenter:
                 lease=lease,
                 payload={"operation": operation, "resource": resource},
                 now=event_time,
+                orchestration_cycle=cycle or None,
+                trust_grant_id=trust_grant_id,
                 failure={
                     "code": "policy_denied",
                     "recoverability": "operator_action",
@@ -236,6 +363,8 @@ class StatelessRenter:
                     idempotency_key=idempotency_key,
                     checkpoint_ref=existing.checkpoint_ref,
                     evidence=existing.evidence,
+                    orchestration_cycle=cycle or None,
+                    trust_grant_id=trust_grant_id,
                 )
 
         checkpoint = self.store.load_checkpoint(context)
@@ -249,6 +378,8 @@ class StatelessRenter:
                 payload={"operation": operation, "resource": resource},
                 now=event_time,
                 idempotency_key=idempotency_key,
+                orchestration_cycle=cycle or None,
+                trust_grant_id=trust_grant_id,
                 failure={
                     "code": exc.code,
                     "recoverability": exc.recoverability,
@@ -263,6 +394,8 @@ class StatelessRenter:
                 payload={"operation": operation, "resource": resource},
                 now=event_time,
                 idempotency_key=idempotency_key,
+                orchestration_cycle=cycle or None,
+                trust_grant_id=trust_grant_id,
                 failure={
                     "code": "execution_failed",
                     "recoverability": "retry",
@@ -295,6 +428,8 @@ class StatelessRenter:
             idempotency_key=idempotency_key,
             checkpoint_ref=checkpoint_ref,
             evidence=outcome.evidence,
+            orchestration_cycle=cycle or None,
+            trust_grant_id=trust_grant_id,
         )
 
     def _event(
@@ -309,6 +444,8 @@ class StatelessRenter:
         checkpoint_ref: str | None = None,
         evidence: tuple[Mapping[str, str], ...] = (),
         failure: Mapping[str, str] | None = None,
+        orchestration_cycle: str | None = None,
+        trust_grant_id: str | None = None,
     ) -> dict[str, Any]:
         envelope: dict[str, Any] = {
             "protocol_version": self.protocol_version,
@@ -327,6 +464,10 @@ class StatelessRenter:
             "payload": dict(payload),
             "evidence": [dict(item) for item in evidence],
         }
+        if orchestration_cycle:
+            envelope["orchestration_cycle"] = orchestration_cycle
+        if trust_grant_id:
+            envelope["trust_grant_id"] = trust_grant_id
         if idempotency_key:
             envelope["idempotency_key"] = idempotency_key
         if checkpoint_ref:

--- a/skills/pka/stateless-renter-consistency/SKILL.md
+++ b/skills/pka/stateless-renter-consistency/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: kpgs-stateless-renter-consistency
-description: Preserve KPGS persistence, consistency, context provenance and proof-gated trust across stateless AI renters; parse CCP Accepted receipts into explicit PKA admission requests without treating conceptual acceptance, model capability or discovery as execution authority.
+description: Preserve KPGS persistence, consistency, context provenance, proof-gated trust and role-fit across stateless AI renters; parse CCP Accepted receipts into explicit PKA admission requests without treating conceptual acceptance, model capability, validation standing or discovery as execution authority.
 tags:
   - kpgs
   - pka
@@ -12,6 +12,8 @@ tags:
   - receipts
   - provenance
   - trust
+  - role-fit
+  - peer-validation
   - mao
   - mmao
 allowed-tools: []
@@ -45,6 +47,8 @@ SEMANTIC_SIMILARITY != CURRENT_AUTHORITY
 CCP_ACCEPTED != PKA_ADMITTED
 PKA_PROPOSE != DOWNSTREAM_EXECUTION_AUTHORITY
 MODEL_CAPABILITY != KPGS_TRUST
+CAPABILITY != ROLE_FIT != AUTHORITY
+PEER_VALIDATION_STANDING != EXECUTION_AUTHORITY
 DISCOVERY_SUCCESS != MAO_MMAO_ADMISSION
 CI_TRIGGER != DEFECT_CAUSALITY
 ```
@@ -74,6 +78,9 @@ task:
   ref: <commit>
   current_instruction: <instruction>
   orchestration_cycle: null | mao | mmao
+  decision_domain: null | <bounded-domain>
+  consequence_class: null | <bounded-consequence>
+  authority_mode: validation | execution
 context:
   current_human: []
   repository: []
@@ -89,6 +96,9 @@ proof_state:
 trust:
   state: untrusted
   grant_id: null
+  allowed_decision_domains: []
+  allowed_consequence_classes: []
+  allowed_authority_modes: []
   evidence_refs: []
   expires_at: null
 receipts:
@@ -123,7 +133,7 @@ SEATS CARRY AUTHORITY
 KPGS GOVERNS THE DIFFERENCE
 ```
 
-Admission is fail-closed:
+Trust admission is fail-closed:
 
 ```text
 cycle in {mao, mmao}
@@ -134,7 +144,7 @@ AND trust_grant tenant/domain == current tenant/domain
 AND cycle in trust_grant.allowed_cycles
 AND trust_grant.expires_at > now
 AND trust_grant.evidence_refs is non-empty
--> ELIGIBLE_FOR_ORCHESTRATION_ENTRY
+-> TRUST_PASS
 ```
 
 Otherwise:
@@ -183,10 +193,102 @@ self-declared trust
 
 A replacement model/runtime does not inherit authority merely because it inherits a name. The governed seat/context may persist; the runtime must rehydrate valid trust evidence or receive a fresh grant.
 
+## Role-fit membrane
+
+Passing trust is necessary but not sufficient.
+
+Before MAO/MMAO work proceeds, classify:
+
+```text
+D = decision_domain
+C = consequence_class
+M = authority_mode
+```
+
+Then evaluate:
+
+```text
+TRUST_PASS
+AND D in trust_grant.allowed_decision_domains
+AND C in trust_grant.allowed_consequence_classes
+AND M in trust_grant.allowed_authority_modes
+-> ROLE_FIT_PASS
+```
+
+If trust passes but fit fails:
+
+```text
+POLICY_DENIED
+failure.code = role_not_fit
+handler_execution = false
+```
+
+This preserves specialization. A renter can be excellent at repository mutation and still be the wrong authority for forensic sociology, intern welfare, identity decisions or other human-consequence lanes.
+
+The governing authority equation is:
+
+```text
+AUTHORITY = KPGS_TRUST ∩ ROLE_FIT ∩ CAPABILITY_LEASE
+```
+
+Do not collapse these into one score.
+
+## Validation plane vs execution plane
+
+MMAO uses two geometries.
+
+### Validation plane
+
+When `authority_mode == validation`:
+
+```text
+peer inference surface A ─┐
+peer inference surface B ─┼─> evidence -> convergence | divergence
+peer inference surface C ─┘
+```
+
+Rules:
+
+- validators have peer standing for the current validation question;
+- no validator wins because it speaks last;
+- convergence is evidence, not automatic authority;
+- divergence remains visible until governed resolution;
+- validation-only trust MUST NOT authorize consequential mutation;
+- a validation result may feed the next governed gate.
+
+### Execution plane
+
+When `authority_mode == execution`:
+
+```text
+human/root authority
+-> trusted seat
+-> bounded delegated authority
+-> worker/spawn
+```
+
+Rules:
+
+- hierarchy is permitted;
+- the renter must have execution-mode role fit;
+- consequential mutation still requires capability-scope admission;
+- validation standing never silently promotes into execution authority.
+
+Therefore:
+
+```text
+EQUAL_IN_VALIDATION
+AND
+BOUNDED_HIERARCHY_IN_EXECUTION
+```
+
+are compatible.
+
 Canonical runtime law:
 
 - `governance/kpgs-vnext/stateless-renter/PROTOCOL.md`
 - `governance/kpgs-vnext/stateless-renter/trust-grant.schema.json`
+- `governance/kpgs-vnext/stateless-renter/renter-envelope.schema.json`
 - `Structure/07-Agents/PROMOTION_LAW.json`
 
 ## CCP → PKA parser
@@ -321,8 +423,8 @@ For each repository:
 
 ## Success condition
 
-A fresh renter can determine from evidence: current authority, current vs historical context, exact evaluated commit/runtime, CCP decision, whether PKA actually ran, the resulting receipt, downstream eligibility, orchestration-cycle eligibility, KPGS trust-grant provenance and unresolved unknowns.
+A fresh renter can determine from evidence: current authority, current vs historical context, exact evaluated commit/runtime, CCP decision, whether PKA actually ran, the resulting receipt, downstream eligibility, orchestration-cycle eligibility, KPGS trust-grant provenance, role-fit boundaries, validation-vs-execution mode and unresolved unknowns.
 
-> **Persist receipts, not renter identity. Preserve provenance, not hidden continuity. Capability does not equal authority. CCP may accept a concept; PKA may propose admission; KPGS trust gates MAO/MMAO entry; the consumer runtime owns later consequential execution.**
+> **Persist receipts, not renter identity. Preserve provenance, not hidden continuity. Capability does not equal authority. Trust does not erase specialization. Peer validation does not imply execution authority. CCP may accept a concept; PKA may propose admission; KPGS trust and role-fit gate MAO/MMAO entry; the consumer runtime owns later consequential execution.**
 
 /s/ Kholofelo Robyn Rababalela

--- a/skills/pka/stateless-renter-consistency/SKILL.md
+++ b/skills/pka/stateless-renter-consistency/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: kpgs-stateless-renter-consistency
-description: Preserve KPGS persistence, consistency and context provenance across stateless AI renters, and parse CCP Accepted receipts into explicit PKA admission requests without treating conceptual acceptance as execution authority.
+description: Preserve KPGS persistence, consistency, context provenance and proof-gated trust across stateless AI renters; parse CCP Accepted receipts into explicit PKA admission requests without treating conceptual acceptance, model capability or discovery as execution authority.
 tags:
   - kpgs
   - pka
@@ -11,6 +11,9 @@ tags:
   - context-awareness
   - receipts
   - provenance
+  - trust
+  - mao
+  - mmao
 allowed-tools: []
 license: MIT
 author: Kholofelo Robyn Rababalela
@@ -41,6 +44,8 @@ MODEL_MEMORY != PERSISTENCE
 SEMANTIC_SIMILARITY != CURRENT_AUTHORITY
 CCP_ACCEPTED != PKA_ADMITTED
 PKA_PROPOSE != DOWNSTREAM_EXECUTION_AUTHORITY
+MODEL_CAPABILITY != KPGS_TRUST
+DISCOVERY_SUCCESS != MAO_MMAO_ADMISSION
 CI_TRIGGER != DEFECT_CAUSALITY
 ```
 
@@ -68,6 +73,7 @@ task:
   repository: <owner/repo>
   ref: <commit>
   current_instruction: <instruction>
+  orchestration_cycle: null | mao | mmao
 context:
   current_human: []
   repository: []
@@ -80,6 +86,11 @@ proof_state:
   inferred: []
   validated: []
   runtime_proven: []
+trust:
+  state: untrusted
+  grant_id: null
+  evidence_refs: []
+  expires_at: null
 receipts:
   inputs: []
   outputs: []
@@ -98,6 +109,85 @@ new evidence or governance              -> new action_id + new receipt
 ```
 
 Never rewrite an old receipt to make it appear the system knew later evidence earlier.
+
+## KPGS trust admission for MAO / MMAO
+
+Stateless renters do **not** enter an MAO or MMAO cycle merely because they can reason, call tools, route tasks, use a frontier model, carry a persona, or have previously participated in the ecosystem.
+
+The renter must first **earn KPGS trust**.
+
+```text
+MODELS COMPETE FOR CAPABILITY
+AGENTS EARN TRUST
+SEATS CARRY AUTHORITY
+KPGS GOVERNS THE DIFFERENCE
+```
+
+Admission is fail-closed:
+
+```text
+cycle in {mao, mmao}
+AND trust_state == trusted
+AND trust_grant.issuer == kpgs
+AND trust_grant.renter_id == renter_id
+AND trust_grant tenant/domain == current tenant/domain
+AND cycle in trust_grant.allowed_cycles
+AND trust_grant.expires_at > now
+AND trust_grant.evidence_refs is non-empty
+-> ELIGIBLE_FOR_ORCHESTRATION_ENTRY
+```
+
+Otherwise:
+
+```text
+POLICY_DENIED
+failure.code = trust_not_earned
+handler_execution = false
+```
+
+### What may earn trust
+
+KPGS trust is receipt-driven. Valid evidence can include the governed proof lane already present in the repository, for example:
+
+- BlackMask `SHIP` evidence;
+- teacher/reviewer approval;
+- deterministic execution receipts;
+- verified recovery after failure;
+- capability-scope compliance;
+- correct escalation/HOLD behavior;
+- domain-specific production evidence;
+- other proof explicitly admitted by current KPGS governance.
+
+The governing law remains:
+
+```text
+No promotion without proof. Drill is not graduation.
+```
+
+Trust admission is not public graduation. A renter may be trusted for a bounded MAO/MMAO lane without being globally promoted or permanently authoritative.
+
+### What never earns trust by itself
+
+```text
+benchmark rank
+provider reputation
+parameter count
+context-window size
+model release recency
+persona/name
+prior chat continuity
+discovery handshake
+cached credentials
+self-declared trust
+```
+
+A replacement model/runtime does not inherit authority merely because it inherits a name. The governed seat/context may persist; the runtime must rehydrate valid trust evidence or receive a fresh grant.
+
+Canonical runtime law:
+
+- `governance/kpgs-vnext/stateless-renter/PROTOCOL.md`
+- `governance/kpgs-vnext/stateless-renter/trust-grant.schema.json`
+- `Structure/07-Agents/PROMOTION_LAW.json`
 
 ## CCP → PKA parser
 
@@ -231,8 +321,8 @@ For each repository:
 
 ## Success condition
 
-A fresh renter can determine from evidence: current authority, current vs historical context, exact evaluated commit/runtime, CCP decision, whether PKA actually ran, the resulting receipt, downstream eligibility and unresolved unknowns.
+A fresh renter can determine from evidence: current authority, current vs historical context, exact evaluated commit/runtime, CCP decision, whether PKA actually ran, the resulting receipt, downstream eligibility, orchestration-cycle eligibility, KPGS trust-grant provenance and unresolved unknowns.
 
-> **Persist receipts, not renter identity. Preserve provenance, not hidden continuity. CCP may accept a concept; PKA may propose admission; the consumer runtime owns later consequential execution.**
+> **Persist receipts, not renter identity. Preserve provenance, not hidden continuity. Capability does not equal authority. CCP may accept a concept; PKA may propose admission; KPGS trust gates MAO/MMAO entry; the consumer runtime owns later consequential execution.**
 
 /s/ Kholofelo Robyn Rababalela

--- a/skills/pka/stateless-renter-consistency/awesomeskills.json
+++ b/skills/pka/stateless-renter-consistency/awesomeskills.json
@@ -1,7 +1,7 @@
 {
   "name": "Stateless Renter Consistency + CCP to PKA Admission",
   "slug": "kpgs-stateless-renter-consistency",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": "Kholofelo Robyn Rababalela",
   "license": "MIT",
   "source_repository": "RobynAwesome/Introduction-to-MCP",
@@ -18,9 +18,12 @@
     "consistency",
     "context-awareness",
     "receipts",
-    "provenance"
+    "provenance",
+    "trust",
+    "mao",
+    "mmao"
   ],
-  "summary": "Makes persistence receipt-based, context provenance explicit, and CCP Accepted a deterministic input to PKA evaluation rather than an execution shortcut.",
+  "summary": "Makes persistence receipt-based, context provenance explicit, CCP Accepted a deterministic input to PKA evaluation rather than an execution shortcut, and requires evidence-backed KPGS trust before stateless renters enter MAO or MMAO cycles.",
   "registry_intent": "AwesomeSkills.dev publication",
   "signature": "/s/ Kholofelo Robyn Rababalela"
 }

--- a/skills/pka/stateless-renter-consistency/awesomeskills.json
+++ b/skills/pka/stateless-renter-consistency/awesomeskills.json
@@ -1,7 +1,7 @@
 {
   "name": "Stateless Renter Consistency + CCP to PKA Admission",
   "slug": "kpgs-stateless-renter-consistency",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": "Kholofelo Robyn Rababalela",
   "license": "MIT",
   "source_repository": "RobynAwesome/Introduction-to-MCP",
@@ -20,10 +20,12 @@
     "receipts",
     "provenance",
     "trust",
+    "role-fit",
+    "peer-validation",
     "mao",
     "mmao"
   ],
-  "summary": "Makes persistence receipt-based, context provenance explicit, CCP Accepted a deterministic input to PKA evaluation rather than an execution shortcut, and requires evidence-backed KPGS trust before stateless renters enter MAO or MMAO cycles.",
+  "summary": "Makes persistence receipt-based, context provenance explicit, CCP Accepted a deterministic input to PKA evaluation rather than an execution shortcut, and requires evidence-backed KPGS trust plus decision-domain, consequence-class and authority-mode fit before stateless renters enter MAO or MMAO work.",
   "registry_intent": "AwesomeSkills.dev publication",
   "signature": "/s/ Kholofelo Robyn Rababalela"
 }

--- a/tests/test_stateless_renter_conformance.py
+++ b/tests/test_stateless_renter_conformance.py
@@ -8,6 +8,7 @@ import pytest
 from kopano.stateless_renter import (
     CapabilityLease,
     IdempotencyRecord,
+    KPGSTrustGrant,
     RenterFailure,
     StatelessRenter,
     StepOutcome,
@@ -46,7 +47,7 @@ class MemoryHubStore:
         return self.effects[key]
 
 
-def make_context(domain: str) -> TaskContext:
+def make_context(domain: str, *, orchestration_cycle: str | None = None) -> TaskContext:
     return TaskContext(
         tenant_id="tenant-kopano",
         domain_id=domain,
@@ -55,6 +56,7 @@ def make_context(domain: str) -> TaskContext:
         correlation_id=f"corr-{domain}",
         governing_spec_ref="governance/kpgs-vnext/stateless-renter/PROTOCOL.md",
         skill_versions={"kpgs-audit-verify-govern": "0.1.0"},
+        orchestration_cycle=orchestration_cycle,
     )
 
 
@@ -67,6 +69,27 @@ def make_lease(context: TaskContext, operation: str, resource: str) -> Capabilit
         allowed_operations=frozenset({operation}),
         allowed_resources=frozenset({resource}),
         expires_at=datetime.now(timezone.utc) + timedelta(minutes=5),
+    )
+
+
+def make_trust_grant(
+    context: TaskContext,
+    *,
+    renter_id: str,
+    cycle: str,
+    expires_in: timedelta = timedelta(minutes=5),
+) -> KPGSTrustGrant:
+    return KPGSTrustGrant(
+        grant_id=f"trust-{renter_id}-{cycle}",
+        renter_id=renter_id,
+        tenant_id=context.tenant_id,
+        domain_id=context.domain_id,
+        allowed_cycles=frozenset({cycle}),
+        evidence_refs=(
+            f"hub://evidence/{renter_id}/blackmask-ship",
+            f"hub://evidence/{renter_id}/teacher-review",
+        ),
+        expires_at=datetime.now(timezone.utc) + expires_in,
     )
 
 
@@ -259,3 +282,100 @@ def test_failure_classification_and_graceful_eviction_are_deterministic():
     )
     assert denied["failure"]["code"] == "cancelled"
     assert denied["failure"]["recoverability"] == "rehydrate"
+
+
+@pytest.mark.parametrize("cycle", ["mao", "mmao"])
+def test_orchestration_cycle_denies_untrusted_stateless_renter_before_handler(cycle: str):
+    hub = MemoryHubStore()
+    context = make_context("orchestration", orchestration_cycle=cycle)
+    lease = make_lease(context, "work.execute", "work:item")
+    called = False
+
+    def should_not_run(_checkpoint: Mapping[str, Any] | None, _payload: Mapping[str, Any]) -> StepOutcome:
+        nonlocal called
+        called = True
+        return StepOutcome(payload={"should": "not run"}, completed=True)
+
+    event = StatelessRenter("renter-candidate", hub).execute(
+        context=context,
+        lease=lease,
+        operation="work.execute",
+        resource="work:item",
+        payload={},
+        handler=should_not_run,
+        idempotency_key=f"{cycle}-candidate",
+    )
+
+    assert event["event_kind"] == "policy.denied"
+    assert event["failure"]["code"] == "trust_not_earned"
+    assert event["orchestration_cycle"] == cycle
+    assert called is False
+
+
+def test_earned_kpgs_trust_allows_mmao_entry_and_is_receipted():
+    hub = MemoryHubStore()
+    context = make_context("orchestration", orchestration_cycle="mmao")
+    lease = make_lease(context, "work.execute", "work:item")
+    renter_id = "renter-proven"
+    trust = make_trust_grant(context, renter_id=renter_id, cycle="mmao")
+
+    event = StatelessRenter(renter_id, hub).execute(
+        context=context,
+        lease=lease,
+        operation="work.execute",
+        resource="work:item",
+        payload={},
+        handler=lambda _checkpoint, _payload: StepOutcome(payload={"ok": True}, completed=True),
+        idempotency_key="mmao-proven",
+        trust_grant=trust,
+    )
+
+    assert event["event_kind"] == "task.completed"
+    assert event["orchestration_cycle"] == "mmao"
+    assert event["trust_grant_id"] == trust.grant_id
+
+
+@pytest.mark.parametrize(
+    "grant_mutation",
+    ["wrong_renter", "wrong_cycle", "expired", "missing_evidence"],
+)
+def test_kpgs_trust_is_identity_scoped_cycle_scoped_fresh_and_evidence_backed(grant_mutation: str):
+    hub = MemoryHubStore()
+    context = make_context("orchestration", orchestration_cycle="mao")
+    lease = make_lease(context, "work.execute", "work:item")
+    renter_id = "renter-scoped"
+    base = make_trust_grant(context, renter_id=renter_id, cycle="mao")
+
+    values = {
+        "grant_id": base.grant_id,
+        "renter_id": base.renter_id,
+        "tenant_id": base.tenant_id,
+        "domain_id": base.domain_id,
+        "allowed_cycles": base.allowed_cycles,
+        "evidence_refs": base.evidence_refs,
+        "expires_at": base.expires_at,
+        "issuer": base.issuer,
+        "trust_state": base.trust_state,
+    }
+    if grant_mutation == "wrong_renter":
+        values["renter_id"] = "someone-else"
+    elif grant_mutation == "wrong_cycle":
+        values["allowed_cycles"] = frozenset({"mmao"})
+    elif grant_mutation == "expired":
+        values["expires_at"] = datetime.now(timezone.utc) - timedelta(seconds=1)
+    elif grant_mutation == "missing_evidence":
+        values["evidence_refs"] = ()
+
+    event = StatelessRenter(renter_id, hub).execute(
+        context=context,
+        lease=lease,
+        operation="work.execute",
+        resource="work:item",
+        payload={},
+        handler=lambda _checkpoint, _payload: StepOutcome(payload={"should": "not run"}, completed=True),
+        idempotency_key=f"mao-{grant_mutation}",
+        trust_grant=KPGSTrustGrant(**values),
+    )
+
+    assert event["event_kind"] == "policy.denied"
+    assert event["failure"]["code"] == "trust_not_earned"

--- a/tests/test_stateless_renter_conformance.py
+++ b/tests/test_stateless_renter_conformance.py
@@ -47,7 +47,17 @@ class MemoryHubStore:
         return self.effects[key]
 
 
-def make_context(domain: str, *, orchestration_cycle: str | None = None) -> TaskContext:
+def make_context(
+    domain: str,
+    *,
+    orchestration_cycle: str | None = None,
+    decision_domain: str | None = None,
+    consequence_class: str | None = None,
+    authority_mode: str = "execution",
+) -> TaskContext:
+    if orchestration_cycle:
+        decision_domain = decision_domain or "software_delivery"
+        consequence_class = consequence_class or "technical_change"
     return TaskContext(
         tenant_id="tenant-kopano",
         domain_id=domain,
@@ -57,6 +67,9 @@ def make_context(domain: str, *, orchestration_cycle: str | None = None) -> Task
         governing_spec_ref="governance/kpgs-vnext/stateless-renter/PROTOCOL.md",
         skill_versions={"kpgs-audit-verify-govern": "0.1.0"},
         orchestration_cycle=orchestration_cycle,
+        decision_domain=decision_domain,
+        consequence_class=consequence_class,
+        authority_mode=authority_mode,
     )
 
 
@@ -78,6 +91,9 @@ def make_trust_grant(
     renter_id: str,
     cycle: str,
     expires_in: timedelta = timedelta(minutes=5),
+    allowed_decision_domains: frozenset[str] | None = None,
+    allowed_consequence_classes: frozenset[str] | None = None,
+    allowed_authority_modes: frozenset[str] | None = None,
 ) -> KPGSTrustGrant:
     return KPGSTrustGrant(
         grant_id=f"trust-{renter_id}-{cycle}",
@@ -85,6 +101,12 @@ def make_trust_grant(
         tenant_id=context.tenant_id,
         domain_id=context.domain_id,
         allowed_cycles=frozenset({cycle}),
+        allowed_decision_domains=allowed_decision_domains
+        or frozenset({context.decision_domain or "software_delivery"}),
+        allowed_consequence_classes=allowed_consequence_classes
+        or frozenset({context.consequence_class or "technical_change"}),
+        allowed_authority_modes=allowed_authority_modes
+        or frozenset({context.authority_mode}),
         evidence_refs=(
             f"hub://evidence/{renter_id}/blackmask-ship",
             f"hub://evidence/{renter_id}/teacher-review",
@@ -312,7 +334,7 @@ def test_orchestration_cycle_denies_untrusted_stateless_renter_before_handler(cy
     assert called is False
 
 
-def test_earned_kpgs_trust_allows_mmao_entry_and_is_receipted():
+def test_earned_kpgs_trust_allows_mmao_entry_and_receipts_role_fit():
     hub = MemoryHubStore()
     context = make_context("orchestration", orchestration_cycle="mmao")
     lease = make_lease(context, "work.execute", "work:item")
@@ -332,6 +354,9 @@ def test_earned_kpgs_trust_allows_mmao_entry_and_is_receipted():
 
     assert event["event_kind"] == "task.completed"
     assert event["orchestration_cycle"] == "mmao"
+    assert event["decision_domain"] == "software_delivery"
+    assert event["consequence_class"] == "technical_change"
+    assert event["authority_mode"] == "execution"
     assert event["trust_grant_id"] == trust.grant_id
 
 
@@ -352,6 +377,9 @@ def test_kpgs_trust_is_identity_scoped_cycle_scoped_fresh_and_evidence_backed(gr
         "tenant_id": base.tenant_id,
         "domain_id": base.domain_id,
         "allowed_cycles": base.allowed_cycles,
+        "allowed_decision_domains": base.allowed_decision_domains,
+        "allowed_consequence_classes": base.allowed_consequence_classes,
+        "allowed_authority_modes": base.allowed_authority_modes,
         "evidence_refs": base.evidence_refs,
         "expires_at": base.expires_at,
         "issuer": base.issuer,
@@ -379,3 +407,125 @@ def test_kpgs_trust_is_identity_scoped_cycle_scoped_fresh_and_evidence_backed(gr
 
     assert event["event_kind"] == "policy.denied"
     assert event["failure"]["code"] == "trust_not_earned"
+
+
+@pytest.mark.parametrize(
+    ("context_kwargs", "grant_kwargs"),
+    [
+        (
+            {"decision_domain": "forensic_sociology"},
+            {"allowed_decision_domains": frozenset({"software_delivery"})},
+        ),
+        (
+            {"consequence_class": "human_welfare"},
+            {"allowed_consequence_classes": frozenset({"technical_change"})},
+        ),
+    ],
+)
+def test_trusted_renter_is_denied_when_role_fit_does_not_match_consequence(
+    context_kwargs: dict[str, str],
+    grant_kwargs: dict[str, frozenset[str]],
+):
+    hub = MemoryHubStore()
+    context = make_context(
+        "orchestration",
+        orchestration_cycle="mmao",
+        **context_kwargs,
+    )
+    lease = make_lease(context, "work.execute", "work:item")
+    renter_id = "renter-trusted-wrong-role"
+    trust = make_trust_grant(
+        context,
+        renter_id=renter_id,
+        cycle="mmao",
+        **grant_kwargs,
+    )
+    called = False
+
+    def should_not_run(_checkpoint: Mapping[str, Any] | None, _payload: Mapping[str, Any]) -> StepOutcome:
+        nonlocal called
+        called = True
+        return StepOutcome(payload={"should": "not run"}, completed=True)
+
+    event = StatelessRenter(renter_id, hub).execute(
+        context=context,
+        lease=lease,
+        operation="work.execute",
+        resource="work:item",
+        payload={},
+        handler=should_not_run,
+        idempotency_key="wrong-role",
+        trust_grant=trust,
+    )
+
+    assert event["event_kind"] == "policy.denied"
+    assert event["failure"]["code"] == "role_not_fit"
+    assert called is False
+
+
+def test_validation_authority_is_peer_surface_not_execution_authority():
+    hub = MemoryHubStore()
+    renter_id = "renter-validator"
+
+    validation_context = make_context(
+        "orchestration",
+        orchestration_cycle="mmao",
+        decision_domain="forensic_sociology",
+        consequence_class="human_welfare",
+        authority_mode="validation",
+    )
+    validation_lease = make_lease(validation_context, "review.validate", "case:42")
+    validation_trust = make_trust_grant(
+        validation_context,
+        renter_id=renter_id,
+        cycle="mmao",
+        allowed_decision_domains=frozenset({"forensic_sociology"}),
+        allowed_consequence_classes=frozenset({"human_welfare"}),
+        allowed_authority_modes=frozenset({"validation"}),
+    )
+
+    validated = StatelessRenter(renter_id, hub).execute(
+        context=validation_context,
+        lease=validation_lease,
+        operation="review.validate",
+        resource="case:42",
+        payload={},
+        handler=lambda _checkpoint, _payload: StepOutcome(
+            payload={"disposition": "independent_validation"},
+            completed=True,
+        ),
+        idempotency_key="validate-case-42",
+        trust_grant=validation_trust,
+    )
+    assert validated["event_kind"] == "task.completed"
+    assert validated["authority_mode"] == "validation"
+
+    execution_context = make_context(
+        "orchestration",
+        orchestration_cycle="mmao",
+        decision_domain="forensic_sociology",
+        consequence_class="human_welfare",
+        authority_mode="execution",
+    )
+    execution_lease = make_lease(execution_context, "case.mutate", "case:42")
+    executed = False
+
+    def should_not_execute(_checkpoint: Mapping[str, Any] | None, _payload: Mapping[str, Any]) -> StepOutcome:
+        nonlocal executed
+        executed = True
+        return StepOutcome(payload={"mutated": True}, completed=True)
+
+    denied = StatelessRenter(renter_id, hub).execute(
+        context=execution_context,
+        lease=execution_lease,
+        operation="case.mutate",
+        resource="case:42",
+        payload={},
+        handler=should_not_execute,
+        idempotency_key="mutate-case-42",
+        trust_grant=validation_trust,
+    )
+
+    assert denied["event_kind"] == "policy.denied"
+    assert denied["failure"]["code"] == "role_not_fit"
+    assert executed is False


### PR DESCRIPTION
## What changed
- bumps the canonical stateless renter runtime protocol to `1.2`
- adds `KPGSTrustGrant` as an evidence-backed, identity-bound, tenant/domain-bound, cycle-scoped, expiring admission grant
- adds explicit role-fit boundaries: `decision_domain`, `consequence_class`, and `authority_mode`
- fails closed with `trust_not_earned` when trust is absent/invalid
- fails closed with `role_not_fit` when a trusted renter is the wrong authority for the current domain, consequence, or mode
- receipts `orchestration_cycle`, `decision_domain`, `consequence_class`, `authority_mode`, and `trust_grant_id`
- extends the machine-readable trust grant + renter event schemas
- evolves SRCCP-01 / AwesomeSkills to make `CAPABILITY != ROLE_FIT != AUTHORITY` and `PEER_VALIDATION_STANDING != EXECUTION_AUTHORITY` canonical
- preserves the existing promotion law: `No promotion without proof. Drill is not graduation.`

## Admission law
```text
MODELS COMPETE FOR CAPABILITY
AGENTS EARN TRUST
SEATS CARRY AUTHORITY
KPGS GOVERNS THE DIFFERENCE
```

```text
AUTHORITY = KPGS_TRUST ∩ ROLE_FIT ∩ CAPABILITY_LEASE
```

## Validation vs execution
```text
EQUAL_IN_VALIDATION
AND
BOUNDED_HIERARCHY_IN_EXECUTION
```

Validation-mode agents are peer inference surfaces: no last-speaker-wins rule, convergence is evidence rather than authority, and divergence remains visible. A validation-only grant cannot silently mutate canonical state or upgrade itself into execution authority.

## Conformance coverage
- MAO and MMAO deny untrusted renters before handler execution
- valid MMAO trust admission is receipted
- trust is renter-bound, cycle-bound, expiring, and evidence-backed
- a trusted renter is still denied for the wrong decision domain
- a trusted renter is still denied for the wrong consequence class
- validation-only authority cannot be reused as execution authority
- legacy non-orchestrated renter behavior remains covered

## Scope
This PR establishes the canonical KPGS renter trust + role-fit membrane. It does not treat benchmark rank, provider reputation, model/persona continuity, discovery success, or peer validation standing as execution authority.