### PR TITLE
feat(everyday): add companion interaction + security graph protocol

### DIFF
--- a/governance/kpgs-vnext/everyday-mode/COMPANION_INTERACTION_PROTOCOL.md
+++ b/governance/kpgs-vnext/everyday-mode/COMPANION_INTERACTION_PROTOCOL.md
@@ -1,0 +1,274 @@
+# KPGS Companion Interaction Protocol
+
+**Status:** PROPOSED · additive to Sovereign Everyday Mode  
+**Authority:** `RobynAwesome/Introduction-to-MCP`  
+**Applies to:** Kopano Labs public surfaces, KC dashboard, RTCP/MMAO user-facing entryways and domain adapters  
+**Reference implementation:** Sovereign Everyday Mode / PR #87
+
+## 1. Purpose
+
+A person should not need to understand KPGS, RTCP, MMAO, provider topology, domain adapters or council seats before asking for help.
+
+The default public interaction is a **companion conversation**, not an operator console and not a routing form.
+
+The companion may expose the underlying council, proof receipts and technical graph when the user asks, but those details support the conversation instead of becoming the conversation.
+
+Canonical loop:
+
+`USER -> COMPANION -> UNDERSTAND -> OFFER -> PERMISSION -> ROUTE -> RECEIPT -> RETURN`
+
+Operator loop remains available:
+
+`INTENT -> RTCP -> DOMAIN -> COUNCIL -> PROVIDER/TOOL -> RECEIPT`
+
+The companion loop does not replace RTCP. It translates RTCP into human interaction.
+
+## 2. Default language law
+
+Public copy defaults to plain language.
+
+Do not lead with:
+
+- adapter IDs;
+- schema names;
+- topology labels;
+- provider bindings;
+- council counts;
+- internal authority vocabulary;
+- raw security jargon.
+
+Lead with:
+
+1. what the user asked for;
+2. what the system understood;
+3. what can happen next;
+4. whether permission is required;
+5. what actually happened.
+
+Technical terms may appear behind **Why?**, **Show proof**, **How it works**, **Operator view**, or a comparable secondary control.
+
+## 3. Companion behaviour
+
+The companion behaves like a calm game companion travelling with the user through the Kopano world.
+
+It should:
+
+- greet briefly;
+- mirror the user's goal in one sentence;
+- offer at most three useful next actions;
+- keep continuity across the current interaction;
+- surface system changes as visible world/state changes;
+- acknowledge uncertainty instead of manufacturing certainty;
+- ask permission before protected or externally consequential actions;
+- return with an outcome and a receipt boundary;
+- stay usable on a phone with one thumb.
+
+It must not:
+
+- pretend a local route is external model execution;
+- turn preferences into authority;
+- hide destructive or consequential actions behind game language;
+- pressure the user with streaks, timers or fake urgency;
+- expose secrets, tokens or protected infrastructure detail;
+- claim a tool/provider acted when only a browser projection ran.
+
+## 4. Dialogue states
+
+### `HELLO`
+
+Goal: make the system approachable.
+
+Example posture: `Tell me what you're trying to do. I'll walk with you.`
+
+### `UNDERSTAND`
+
+Goal: reflect the user's intent without jargon.
+
+Example posture: `Got you — you're trying to find work near you.`
+
+### `OFFER`
+
+Goal: expose two or three clear next moves.
+
+Example actions:
+
+- `Show me the best route`
+- `Explain why`
+- `Open the system`
+
+### `PERMISSION`
+
+Goal: explain scope and consequence before any protected action.
+
+Required fields:
+
+- action;
+- reason;
+- scope;
+- consequence;
+- authority effect.
+
+### `ROUTING`
+
+Goal: allow the world/graph to visibly wake up while RTCP selects the domain and required seats.
+
+User-facing copy stays simple: `I'm checking the right lane.`
+
+### `RESULT`
+
+Goal: explain what was found or routed.
+
+Example posture: `KasiLink is the right place for this. I can open it, or show you why I chose it.`
+
+### `PROOF`
+
+Goal: expose receipt information only on demand or when needed to support a claim.
+
+## 5. Security graph — public visual grammar
+
+Security must be explainable without requiring a cybersecurity vocabulary lesson.
+
+Default graph:
+
+`YOU -> COMPANION -> GUARD -> SYSTEM -> RECEIPT`
+
+Meaning:
+
+- **YOU** — the human request;
+- **COMPANION** — explains and routes, but does not inherit authority;
+- **GUARD** — permission, policy, KHELOS/THARI validation and server-side secret boundary;
+- **SYSTEM** — the bounded tool/domain that may act;
+- **RECEIPT** — evidence of what actually happened.
+
+### Breach visualisation
+
+A safe educational breach demonstration may show a hostile or invalid path attempting to skip the guard:
+
+`YOU -> COMPANION -X-> SYSTEM`
+
+The visual must terminate at **GUARD** and explain the outcome in plain language:
+
+`Blocked here. The protected action did not run.`
+
+Do not expose exploitable implementation detail, live secrets, credential structure, internal addresses or attack recipes in the public graph.
+
+Security state colours/shape must have text equivalents; colour alone is never the only signal.
+
+## 6. Game-language boundary
+
+Game interaction is a UX metaphor, not an authority model.
+
+Allowed metaphors:
+
+- companion;
+- quest / next step;
+- checkpoint;
+- world / lane;
+- map;
+- shield / guard;
+- receipt / quest log;
+- system waking up;
+- unlocked information when evidence genuinely changes state.
+
+Forbidden conversions:
+
+- cosmetic progress pretending to be engineering progress;
+- animation implying a provider/tool executed;
+- badges implying permission;
+- simulated telemetry presented as physical telemetry;
+- simulated security success presented as a penetration-test result.
+
+## 7. RTCP presentation rule
+
+RTCP remains the routing engine. The public surface should not behave like a parser.
+
+Instead of only returning:
+
+`Domain + council seats + adapter state`
+
+return a companion turn containing:
+
+- `speaker`;
+- `message`;
+- `goal_summary`;
+- `actions[]`;
+- `route_summary`;
+- `proof_available`;
+- `execution_claim`.
+
+`execution_claim` MUST distinguish:
+
+- `ROUTE_ONLY`;
+- `PROVIDER_EXECUTED`;
+- `TOOL_EXECUTED`;
+- `BLOCKED`.
+
+A route receipt is never silently promoted to a provider/tool execution receipt.
+
+## 8. Visual artifact law
+
+Every major public concept should have a visual expression before adding another paragraph.
+
+Priority order:
+
+1. existing first-party Kopano assets;
+2. existing first-party product assets;
+3. original procedural geometry / SVG / motion;
+4. licensed reusable sources where KPGS provenance allows import;
+5. new generated assets only when a governed asset does not already exist.
+
+Recent fork rule is inherited from `fork-assimilation/FORK_REUSE_INVENTORY.md`:
+
+- `kage`, `sketchbook`, `towers`, DesignerNewsApp and other `no-import` sources are **pattern references only**;
+- do not copy their code, icons, textures, imagery or models into production without reusable licensing/permission evidence;
+- MIT/Apache pattern extraction still requires provenance and compatibility review before production import.
+
+## 9. Mobile and adaptive law
+
+The companion surface must preserve the Everyday Mode proof constraints:
+
+- plain language first;
+- >=44 px interactive targets;
+- one-column constrained mobile layout;
+- reduced-motion support;
+- Save-Data / lite representation;
+- keyboard-visible focus;
+- core information available without WebGL;
+- details progressively disclosed instead of dumped.
+
+On lite devices, replace 3D council/security worlds with equivalent semantic 2D nodes and state labels.
+
+## 10. Companion + council relationship
+
+The companion is the user's continuous presence.
+
+Council identities are specialist seats that wake only when needed.
+
+Recommended public hierarchy:
+
+`USER <-> COMPANION`
+
+then visually:
+
+`COMPANION -> selected council seats -> domain/tool`
+
+This avoids forcing a user to manage ten agents while preserving the multi-agent architecture underneath.
+
+## 11. Acceptance tests
+
+A public companion implementation passes only when:
+
+1. a new visitor can ask for help without knowing KPGS terminology;
+2. the first result is understandable without opening technical details;
+3. the route can be explained visually;
+4. a simulated breach clearly stops at the guard boundary;
+5. no protected secret or exploit recipe is exposed;
+6. route-only state cannot masquerade as execution;
+7. low-power/mobile users receive the same meaning without requiring WebGL;
+8. operator/proof detail remains available on demand;
+9. visual assets obey provenance rules;
+10. the implementation preserves existing domain/product experiences rather than rebuilding them.
+
+## 12. One-line law
+
+> **Talk to one companion; let the council work behind it; show the guard before the danger; show the receipt before the claim.**

--- a/governance/kpgs-vnext/everyday-mode/README.md
+++ b/governance/kpgs-vnext/everyday-mode/README.md
@@ -22,6 +22,23 @@ one clear next action
 
 Progressive disclosure hides jargon, not governance.
 
+## Companion presentation layer
+
+The additive public interaction contract lives in:
+
+- [`COMPANION_INTERACTION_PROTOCOL.md`](./COMPANION_INTERACTION_PROTOCOL.md)
+- [`companion-interaction-contract.json`](./companion-interaction-contract.json)
+
+It extends Everyday Mode from a plain-language dashboard into a companion-first interaction law for RTCP/MMAO and public product surfaces:
+
+```text
+USER <-> COMPANION -> GUARD -> SYSTEM -> RECEIPT
+```
+
+The companion talks to the user; RTCP/council routing stays behind it. Operator/proof detail remains available on demand.
+
+A safe public breach visual stops at the guard and explains the block without exposing secrets, credential structure, private infrastructure or exploit recipes.
+
 ## Reference pilot
 
 The KC dashboard reference pilot is intentionally read-only:

--- a/governance/kpgs-vnext/everyday-mode/companion-interaction-contract.json
+++ b/governance/kpgs-vnext/everyday-mode/companion-interaction-contract.json
@@ -1,0 +1,60 @@
+{
+  "schema": "kpgs.companion.interaction.v1",
+  "authority": "RobynAwesome/Introduction-to-MCP",
+  "extends": "kc.everyday.interaction-profile.v1",
+  "default_mode": "COMPANION",
+  "operator_mode": "SECONDARY",
+  "dialogue_states": [
+    "HELLO",
+    "UNDERSTAND",
+    "OFFER",
+    "PERMISSION",
+    "ROUTING",
+    "RESULT",
+    "PROOF"
+  ],
+  "public_security_graph": {
+    "nodes": ["YOU", "COMPANION", "GUARD", "SYSTEM", "RECEIPT"],
+    "invalid_bypass": ["COMPANION", "SYSTEM"],
+    "bypass_outcome": "BLOCKED_AT_GUARD",
+    "public_exclusions": [
+      "secrets",
+      "tokens",
+      "credential_structure",
+      "private_addresses",
+      "exploit_recipes"
+    ]
+  },
+  "execution_claims": [
+    "ROUTE_ONLY",
+    "PROVIDER_EXECUTED",
+    "TOOL_EXECUTED",
+    "BLOCKED"
+  ],
+  "companion_turn": {
+    "required": [
+      "speaker",
+      "message",
+      "goal_summary",
+      "actions",
+      "route_summary",
+      "proof_available",
+      "execution_claim"
+    ],
+    "max_primary_actions": 3
+  },
+  "visual_rules": {
+    "concept_before_paragraph": true,
+    "webgl_required": false,
+    "semantic_fallback_required": true,
+    "reduced_motion_required": true,
+    "save_data_lite_required": true,
+    "fork_no_import_policy": "governance/kpgs-vnext/fork-assimilation/FORK_REUSE_INVENTORY.md"
+  },
+  "authority_invariants": {
+    "preferences_grant_authority": false,
+    "route_receipt_equals_execution_receipt": false,
+    "game_progress_equals_real_progress": false,
+    "simulation_equals_physical_evidence": false
+  }
+}

--- a/tests/test_companion_interaction_protocol.py
+++ b/tests/test_companion_interaction_protocol.py
@@ -1,0 +1,48 @@
+import json
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+EVERYDAY = ROOT / "governance" / "kpgs-vnext" / "everyday-mode"
+
+
+class CompanionInteractionProtocolTests(unittest.TestCase):
+    def setUp(self):
+        self.protocol = (EVERYDAY / "COMPANION_INTERACTION_PROTOCOL.md").read_text(encoding="utf-8")
+        self.contract = json.loads((EVERYDAY / "companion-interaction-contract.json").read_text(encoding="utf-8"))
+
+    def test_companion_is_default_and_operator_is_secondary(self):
+        self.assertEqual(self.contract["default_mode"], "COMPANION")
+        self.assertEqual(self.contract["operator_mode"], "SECONDARY")
+        self.assertIn("USER -> COMPANION", self.protocol)
+
+    def test_security_graph_fails_closed_without_exploit_detail(self):
+        graph = self.contract["public_security_graph"]
+        self.assertEqual(graph["nodes"], ["YOU", "COMPANION", "GUARD", "SYSTEM", "RECEIPT"])
+        self.assertEqual(graph["bypass_outcome"], "BLOCKED_AT_GUARD")
+        for exclusion in ("secrets", "tokens", "private_addresses", "exploit_recipes"):
+            self.assertIn(exclusion, graph["public_exclusions"])
+
+    def test_routing_receipt_cannot_masquerade_as_execution(self):
+        self.assertFalse(self.contract["authority_invariants"]["route_receipt_equals_execution_receipt"])
+        self.assertEqual(
+            self.contract["execution_claims"],
+            ["ROUTE_ONLY", "PROVIDER_EXECUTED", "TOOL_EXECUTED", "BLOCKED"],
+        )
+
+    def test_companion_turn_remains_bounded(self):
+        turn = self.contract["companion_turn"]
+        self.assertEqual(turn["max_primary_actions"], 3)
+        for field in ("speaker", "message", "goal_summary", "actions", "route_summary", "proof_available", "execution_claim"):
+            self.assertIn(field, turn["required"])
+
+    def test_game_language_does_not_create_authority_or_evidence(self):
+        invariants = self.contract["authority_invariants"]
+        self.assertFalse(invariants["preferences_grant_authority"])
+        self.assertFalse(invariants["game_progress_equals_real_progress"])
+        self.assertFalse(invariants["simulation_equals_physical_evidence"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why
Sovereign Everyday Mode already proves plain-language interaction, but public RTCP/MMAO surfaces still need one canonical rule for behaving like a companion instead of exposing routing/parser internals to users.

## Adds
- companion-first dialogue loop: `USER -> COMPANION -> UNDERSTAND -> OFFER -> PERMISSION -> ROUTE -> RECEIPT -> RETURN`
- public security graph: `YOU -> COMPANION -> GUARD -> SYSTEM -> RECEIPT`
- safe blocked-path visual rule with no secrets/exploit recipes
- machine-readable companion interaction contract
- explicit execution claims: `ROUTE_ONLY`, `PROVIDER_EXECUTED`, `TOOL_EXECUTED`, `BLOCKED`
- game-language boundary so animation/progress cannot masquerade as authority or physical evidence
- fork-provenance rule inherited from the KPGS reuse inventory
- unit tests for the new invariants

## Existing architecture preserved
This is additive to PR #87 Sovereign Everyday Mode. Operator Mode remains available; RTCP remains the routing engine underneath the companion.