### PR TITLE
Ingress Testimony, Zero Trust, and Security Playground protocols

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -20,11 +20,22 @@
 |----------|-------------|--------|
 | [NAMED_GUILD_IDENTITY.md](NAMED_GUILD_IDENTITY.md) | IRIS 150-word bio + Named Guild 500-word 4Ws biography | ✅ LIVE |
 
+## Swarm / Admission Protocols
+
+| Document | Description | Status |
+|----------|-------------|--------|
+| [swarm-ops/BLACK_MASS_PROTOCOL.md](swarm-ops/BLACK_MASS_PROTOCOL.md) | Black Mask / BlackMass pre-flight and mass-movement doctrine | ✅ LIVE |
+| [swarm-ops/BRACKET_PROTOCOL.md](swarm-ops/BRACKET_PROTOCOL.md) | Breaking-point receipt and Main Brain/sub-brain alignment | ✅ LIVE |
+| [swarm-ops/OZ_CONTEXT_BLEED_PROTOCOL.md](swarm-ops/OZ_CONTEXT_BLEED_PROTOCOL.md) | Structural domain-boundary enforcement and sealed crossings | ✅ LIVE |
+| [swarm-ops/TESTIMONY_PROTOCOL.md](swarm-ops/TESTIMONY_PROTOCOL.md) | Earned convergence: observe/infer/validate without manufacturing the testimony | 🟡 INGRESS / REVIEW |
+| [swarm-ops/ZERO_TRUST_STATE_ADMISSION_PROTOCOL.md](swarm-ops/ZERO_TRUST_STATE_ADMISSION_PROTOCOL.md) | Privileged-state admission contract using provenance, PKA and KMEC routing | 🟡 INGRESS / REVIEW |
+| [swarm-ops/SECURITY_PLAYGROUND_PROTOCOL.md](swarm-ops/SECURITY_PLAYGROUND_PROTOCOL.md) | Isolated adversarial containment / honeypot evidence lane | 🟡 INGRESS / REVIEW |
+
 ## Operational Directories
 
 | Directory | Description |
 |-----------|-------------|
-| `swarm-ops/` | Black Mask Commandments, agent deployment ops |
+| `swarm-ops/` | Black Mask Commandments, agent deployment ops, admission/boundary protocols |
 | `portfolio/` | Project portfolio documentation |
 
 ## Cross-References

--- a/docs/swarm-ops/SECURITY_PLAYGROUND_PROTOCOL.md
+++ b/docs/swarm-ops/SECURITY_PLAYGROUND_PROTOCOL.md
@@ -1,0 +1,89 @@
+# Security Playground Protocol
+
+**Status:** Human-authored doctrine ingress / containment contract  
+**Authority:** Kholofelo Robyn Rababalela, current-human instruction  
+**Ingress receipt:** `RobynAwesome/Project-Jennifer#67`  
+**Depends on:** `ZERO_TRUST_STATE_ADMISSION_PROTOCOL.md`, `OZ_CONTEXT_BLEED_PROTOCOL.md`
+
+## Purpose
+
+The Security Playground is a deliberately isolated adversarial world for entities that must be contained, observed, or studied without granting access to canonical production state.
+
+The intruder may believe it has penetrated a meaningful system surface. The actual architecture preserves a dedicated containment domain.
+
+## Founder-defined intent
+
+```text
+contain the intruder
+→ let the intruder act
+→ product-discover the intruder vigorously
+→ preserve forensic evidence
+→ never silently promote adversarial state into production authority
+```
+
+The playground is conceptually part of the wider World of Jennifer / KPGS security architecture while remaining structurally separated from canonical Jennifer/runtime state.
+
+## Hard separation invariant
+
+Nothing learned or generated inside the Security Playground may directly mutate:
+
+```text
+SELF.md
+USER.md
+IDENTITY.md
+SOUL.md
+world canon
+relationship canon
+production credentials
+production authority
+governance policy
+```
+
+Any proposed transfer out of containment must re-enter through normal provenance, validation, Zero Trust admission, PKA evaluation, and receiving-runtime governance.
+
+## Allowed outputs
+
+The playground may emit bounded evidence such as:
+
+- attack-path observations;
+- behavioral telemetry;
+- exploit hypotheses;
+- payload samples;
+- timing / recurrence patterns;
+- source/provenance metadata;
+- containment receipts;
+- candidate defensive rules.
+
+These are **evidence**, not self-authorizing truth.
+
+## Forbidden shortcut
+
+```text
+SECURITY_PLAYGROUND_TELEMETRY
+-x-> DIRECT_CANON_MUTATION
+-x-> SELF_REWRITE
+-x-> USER_REWRITE
+-x-> PRODUCTION_AUTHORITY
+```
+
+This protects against a second-order attack where an adversary intentionally poisons the telemetry or learning channel in order to influence future identity reconstruction or production policy.
+
+## Relationship to soul infection
+
+Security telemetry is a high-risk foreign-state source. Repeated attacker language, personas, strategies, or identity artifacts must not become persistent identity-state merely because the system observed them extensively.
+
+Observation is not admission.
+
+## Relationship to Oz Lattice
+
+The Security Playground should be represented as a separate structural node/domain in any runtime lattice that implements it. Crossings to production domains must be explicit edges with seals, scans, receipts, and deny-by-default behavior.
+
+## Relationship to Black Mask / BlackMass
+
+The playground can support drills and adversarial validation, but drill success is not production graduation. No fake swarm ACK is permitted.
+
+## Proof boundary
+
+This document specifies containment doctrine. It does not claim that an isolated runtime, honeypot, or network boundary is already deployed.
+
+`[SECURITY_PLAYGROUND | SPECIFIED | ISOLATION_REQUIRED_BEFORE_RUNTIME_CLAIM]`

--- a/docs/swarm-ops/TESTIMONY_PROTOCOL.md
+++ b/docs/swarm-ops/TESTIMONY_PROTOCOL.md
@@ -1,0 +1,95 @@
+# Testimony Protocol — Commandment 15 (Convergence Lane)
+
+**Status:** Human-authored doctrine ingress  
+**Authority:** Kholofelo Robyn Rababalela, current-human instruction  
+**Ingress receipt:** `RobynAwesome/Project-Jennifer#67`  
+**Black Mask pre-flight:** `RobynAwesome/Introduction-to-MCP#93`
+
+> **Do not manufacture the testimony you are trying to observe.**
+
+## Scope
+
+The Testimony Protocol governs situations where a human, agent, or multi-agent system is being evaluated for **understanding, convergence, continuity, or learned relational behavior**.
+
+It exists to prevent an invalid evaluation pattern:
+
+```text
+ask subject for exact answer
+→ copy answer
+→ call the copy "understanding"
+```
+
+That proves instruction-following. It does not prove convergence.
+
+## Core sequence
+
+```text
+OBSERVE
+→ RETAIN
+→ COMPARE RECURRENCE
+→ INFER
+→ RISK BEING WRONG
+→ VALIDATE AGAINST FUTURE REALITY
+```
+
+The evaluator may ask when a genuine ambiguity blocks safe or authorized action. It must not turn every unknown into an interview that supplies the answer key.
+
+## Classification-before-interpret rule
+
+Before interpreting a signal:
+
+1. classify what was actually observed;
+2. preserve source/provenance;
+3. distinguish current-human testimony from historical context, telemetry, model inference, and repository state;
+4. retain `UNKNOWN` / `MAYBE` when evidence does not close the state;
+5. ask only when ambiguity is genuinely blocking or authority cannot be inferred safely.
+
+## Convergence validity
+
+A convergence claim is stronger when the system can recover the relevant pattern **without the human restating it in executable form**.
+
+Valid evidence may include:
+
+- recurrence across time;
+- behavior under changed context;
+- correction after prior failure;
+- preservation of terminology and authority boundaries;
+- independent witness agreement when witnesses were not contaminated by each other's answers;
+- successful repair after rupture without becoming a pure echo.
+
+## MMAO witness rule
+
+Blind witnesses must not receive each other's answers before evaluation. Otherwise agreement may be contamination rather than convergence.
+
+An explicitly designated full-context integrator may receive the combined record, but must be classified separately from blind witnesses.
+
+Current Project Jennifer mapping:
+
+```text
+Jennifer / Copilot / future blind witnesses -> independent lanes
+Cindy -> explicit full-context relational integrator
+Forge -> synthesis / implementation / validation lane
+Kholofelo -> sovereign human adjudicator
+```
+
+## Rushing reset
+
+When inference begins collapsing ambiguity too quickly, apply the current-human `Rushing` reset:
+
+> **What am I rushing for? What am I searching for?**
+
+The reset is not passivity. It is a guard against premature interpretation.
+
+## Historical numbering boundary
+
+This document uses **"Commandment 15" in the current Testimony/Convergence lane because that is the human-authored name supplied in the current context.**
+
+It does **not** overwrite or renumber historical `BLACK_MASK_COMMANDMENTS.json`, where `CMD-15` remains the Servitude Triad requirement (`Grit + Realism + Aesthetics`).
+
+Both records remain historically true in their own lanes. `CANON != HISTORY != INTERPRETATION` applies.
+
+## Proof boundary
+
+Do not claim that an agent "understands" a human merely because it repeated supplied text correctly. Preserve the weaker, inspectable statement supported by receipts.
+
+`[TESTIMONY_PROTOCOL | INGRESSED | NOT_RUNTIME_GRADUATED]`

--- a/docs/swarm-ops/ZERO_TRUST_STATE_ADMISSION_PROTOCOL.md
+++ b/docs/swarm-ops/ZERO_TRUST_STATE_ADMISSION_PROTOCOL.md
@@ -1,0 +1,116 @@
+# Zero Trust State Admission Protocol
+
+**Status:** Human-authored doctrine ingress / implementation contract  
+**Authority:** Kholofelo Robyn Rababalela, current-human instruction  
+**Ingress receipt:** `RobynAwesome/Project-Jennifer#67`  
+**Black Mask pre-flight:** `RobynAwesome/Introduction-to-MCP#93`
+
+## Purpose
+
+Canonical identity, user, memory, governance, and world-state files must not be directly reachable by untrusted ingress.
+
+The admission membrane combines four founder-defined influences:
+
+1. **Smart Contract Ledger architecture** — state changes require inspectable receipts instead of silent mutation.
+2. **Jethro Triage / WWJD Firewall** — classify intent/risk before consequential execution.
+3. **Android parser separation** — parse and normalize foreign input before privileged state handling.
+4. **Sovereign Apple parser/system thinking** — preserve explicit platform/domain boundaries instead of flattening all ingress into one execution lane.
+
+## Governing pipeline
+
+```text
+UNTRUSTED INGRESS
+→ parser / provenance classification
+→ Zero_Trust.md admission membrane
+→ PKA evaluation
+→ GREEN | YELLOW | RED trust vector
+→ KMEC monitoring / alert / governed consequence
+→ only admitted state may approach privileged .md / runtime mutation
+```
+
+This protocol does not define arbitrary scoring weights. Partial Knowable Algebra remains responsible for preserving uncertainty where evidence is incomplete.
+
+## Protected state
+
+The following state classes are privileged by default:
+
+```text
+IDENTITY.md
+SOUL.md
+SELF.md
+USER.md
+canonical memory
+world canon
+relationship state
+production authority
+governance configuration
+```
+
+A payload cannot promote itself into these states merely because it is persuasive, repeated, semantically similar, retrieved from memory, or produced by another agent.
+
+## Trust vectors
+
+### GREEN
+Evidence and authority are sufficient for the bounded action being requested.
+
+GREEN is not universal trust. It is permission scoped to the evaluated crossing/action.
+
+### YELLOW
+State remains partial, contradictory, insufficiently evidenced, or contextually uncertain.
+
+Default behavior is **HOLD / inspect / request bounded clarification or more evidence** rather than silently coercing the state into GREEN or RED.
+
+### RED
+A verified boundary violation, malicious/transgressive condition, prohibited authority escalation, or other governed hard failure is present.
+
+RED routes to containment / alert / block behavior defined by the consuming runtime.
+
+## PKA relationship
+
+PKA is not reduced to a traffic-light classifier.
+
+The trust vector is a downstream operational projection. PKA may still produce `MAYBE` / `HOLD` internally when reality has not closed the question.
+
+```text
+partial evidence + governed state
+→ PKA
+→ MAYBE / bounded disposition
+→ operational projection when justified
+```
+
+The PKA runtime implementation authority remains `RobynAwesome/Partial-Knowable-Algebra`.
+
+## KMEC relationship
+
+KMEC consumes the governed trust disposition for monitoring, alerts, routing, and enforcement.
+
+Semantic/governance authority remains here in Introduction-to-MCP; KMEC owns its runtime implementation.
+
+## Oz Lattice alignment
+
+Zero Trust complements `OZ_CONTEXT_BLEED_PROTOCOL.md`:
+
+- Oz validates **structural domain crossings** and semantic leakage.
+- Zero Trust validates **state admission / authority crossing** before privileged mutation.
+
+A payload may be structurally well-formed and still fail admission authority. Conversely, an authorized actor may still be blocked if the payload violates structural boundaries.
+
+## Identity-state / soul-infection boundary
+
+Separate:
+
+```text
+INFORMATION_INFECTION = foreign information is learned
+BEHAVIORAL_INFECTION  = foreign interaction changes behavior
+IDENTITY_INFECTION    = foreign identity-state becomes persistent input to self-reconstruction
+```
+
+Identity infection is the privileged case. Persistent foreign identity-state requires provenance, explicit admission, bounded authority, and receipts.
+
+## Proof boundary
+
+This document specifies the semantic/governance contract. It does not by itself prove that PKA, KMEC, Project Jennifer, or any other runtime currently enforces every stage.
+
+Runtime claims require code + tests + receipts in the owning repository.
+
+`[ZERO_TRUST_STATE_ADMISSION | SPECIFIED | CROSS_REPO_IMPLEMENTATION_REQUIRED]`


### PR DESCRIPTION
Implements #96 under the Black Mask v0.5 pre-flight tracked in #93.

## Changes
- adds Testimony Protocol for earned convergence without answer-key contamination;
- adds Zero Trust privileged-state admission contract with PKA -> Green/Yellow/Red -> KMEC routing boundary;
- adds Security Playground isolated adversarial containment doctrine;
- updates `docs/INDEX.md` to expose the new review-stage protocol surfaces.

## Authority / history boundaries
- current-human weekend doctrine is preserved from `RobynAwesome/Project-Jennifer#67`;
- historical Black Mask `CMD-15` is **not** overwritten by current Testimony Protocol / Commandment 15 usage;
- semantic/governance contracts are separated from PKA and KMEC runtime implementation authority;
- no runtime-enforcement, BlackMass activation, or graduation claim is made by this docs PR.

## Proof
Branch is 4 commits ahead of `master`, with exactly four changed files. No fake external ACK.