### PR TITLE
estate: admit live Starfall and KasiLink provider witnesses

### DIFF
--- a/governance/kpgs-vnext/estate-registry/REGISTRY.md
+++ b/governance/kpgs-vnext/estate-registry/REGISTRY.md
@@ -1,6 +1,7 @@
 # KPGS Sovereign DNS Estate Registry
 
 Issue: #35
+Operational witness lane: #102
 
 ## Purpose
 
@@ -18,6 +19,29 @@ The Estate Registry is the canonical inventory of KPGS-governed DNS properties. 
 
 A property MUST NOT move from `declared_pending_witness` to `witnessed` solely because its DNS name appears in documentation. Witnessing requires evidence from an explicitly authorized source such as registrar/DNS, deployment, repository or domain-control verification.
 
+## Connected-provider witness law
+
+A connected provider/account surface may support a `witnessed` admission when it directly exposes the domain binding, project/deployment identity, repository linkage or equivalent control evidence. The witness must be receipted; a public HTTP response by itself is not domain-control proof.
+
+Canonical machine receipt contract: `live-provider-witness.schema.json`.
+
+A witness receipt has **witness-only** authority:
+
+```text
+connected provider observation
+  -> evidence receipt
+  -> witnessed registry state
+  != registered
+  != staging
+  != production promotion
+```
+
+The receipt must preserve exact provider/project/deployment/repository identifiers and any material contradiction or unknown. Missing adapter, renter, capability, policy, health, evaluation or rollback evidence stays missing; it must not be inferred merely because a provider reports `READY`.
+
+When two public hostnames are attached to different provider projects, the registry should preserve the split explicitly rather than collapse it into a fictional single deployment target. A shared Git commit does not make two provider project identities the same deployment.
+
+Provider mutation and witness admission are separate authorities. If the current tool surface cannot perform a domain cutover, the correct state is `HOLD`; do not guess DNS records or narrate a cutover that did not occur.
+
 ## Canonical linkage
 
 Each production record should answer:
@@ -32,3 +56,5 @@ Each production record should answer:
 4. Frontend technology is descriptive metadata, not a governance requirement.
 5. The .NET reference adapter is a control-plane boundary; it does not require rewriting an existing frontend.
 6. A property can remain partially registered while unknown fields are explicitly represented as `null`; unknown truth must not be fabricated.
+7. Connected-account evidence may admit `witnessed`, but provider availability/READY state never self-promotes the property to `registered`, `staging` or `production`.
+8. A rollback target reference is not a rollback-drill receipt and does not grant rollback execution authority.

--- a/governance/kpgs-vnext/estate-registry/estate.json
+++ b/governance/kpgs-vnext/estate-registry/estate.json
@@ -1,20 +1,77 @@
 {
   "schema_version": "1.0",
   "estate_id": "kopano-sovereign-estate",
-  "generated_at": "2026-08-17T06:40:00Z",
+  "generated_at": "2026-08-24T00:24:25Z",
   "properties": [
     {
       "domain": "KasiLink.com",
-      "status": "declared_pending_witness",
-      "ownership_evidence": [],
-      "repositories": [],
-      "deployment": { "provider": null, "environment": null, "target": null },
+      "status": "witnessed",
+      "ownership_evidence": [
+        {
+          "kind": "domain-control",
+          "ref": "vercel://team_w8Z8foT3ccswOxMiB4LypZ59/project/prj_07Q4oRr2okeBiPO12YotAzHZM10b/domain/kasilink.com",
+          "verified_at": "2026-08-24T00:24:25Z"
+        },
+        {
+          "kind": "domain-control",
+          "ref": "vercel://team_w8Z8foT3ccswOxMiB4LypZ59/project/prj_A1AvVl5WYRyTergoEcMsvEmMM3uX/domain/www.kasilink.com",
+          "verified_at": "2026-08-24T00:24:25Z"
+        },
+        {
+          "kind": "deployment",
+          "ref": "vercel://team_w8Z8foT3ccswOxMiB4LypZ59/deployment/dpl_9PMFHyTv9jP78sASJaZD5hGX47yr",
+          "verified_at": "2026-08-24T00:24:25Z"
+        },
+        {
+          "kind": "deployment",
+          "ref": "vercel://team_w8Z8foT3ccswOxMiB4LypZ59/deployment/dpl_AA9iSMwcpHPGvqtRc5mEFjMpywha",
+          "verified_at": "2026-08-24T00:24:25Z"
+        },
+        {
+          "kind": "repository",
+          "ref": "github://RobynAwesome/KasiLink/commit/1080fb18096cb2b5c9f8a9ea0d12b442b80329f4",
+          "verified_at": "2026-08-24T00:24:25Z"
+        }
+      ],
+      "repositories": [
+        {
+          "repository": "RobynAwesome/KasiLink",
+          "role": "application",
+          "ref": "commit://1080fb18096cb2b5c9f8a9ea0d12b442b80329f4"
+        }
+      ],
+      "deployment": {
+        "provider": "Vercel",
+        "environment": "production-split",
+        "target": null,
+        "environments": [
+          {
+            "name": "production-apex",
+            "provider": "Vercel",
+            "target": "vercel://team_w8Z8foT3ccswOxMiB4LypZ59/project/prj_07Q4oRr2okeBiPO12YotAzHZM10b/deployment/dpl_9PMFHyTv9jP78sASJaZD5hGX47yr"
+          },
+          {
+            "name": "production-www",
+            "provider": "Vercel",
+            "target": "vercel://team_w8Z8foT3ccswOxMiB4LypZ59/project/prj_A1AvVl5WYRyTergoEcMsvEmMM3uX/deployment/dpl_AA9iSMwcpHPGvqtRc5mEFjMpywha"
+          }
+        ]
+      },
       "adapter": { "required": true, "implementation": null, "version": null },
       "renter_compatibility": { "status": "unknown", "protocol_version": null },
       "governance": { "policy_ref": null, "risk_class": null },
-      "release": { "live_ref": null, "evidence_ref": null },
+      "release": {
+        "live_ref": null,
+        "evidence_ref": "repo://governance/kpgs-vnext/estate-registry/evidence/live-provider-witness-2026-08-24.json#KasiLink.com"
+      },
       "rollback": { "target_ref": null, "procedure_ref": null },
-      "notes": ["Declared as an initial KPGS DNS estate member. Await authoritative witness evidence before promotion."]
+      "notes": [
+        "Witnessed through connected Vercel and GitHub account surfaces on 2026-08-24; public HTTP alone was not used as ownership proof.",
+        "Apex kasilink.com and www.kasilink.com remain split across two Vercel project identities even though both current deployments resolve to commit 1080fb18096cb2b5c9f8a9ea0d12b442b80329f4.",
+        "Connected Vercel runtime aggregation reports MongoDB Atlas authentication failures on both project identities; migration remains HOLD.",
+        "No provider-domain mutation action is exposed by the currently connected Vercel surface, so no cutover was performed.",
+        "Adapter, renter compatibility, capability map, governance classification, evaluation and rollback-drill evidence remain explicitly unknown/incomplete."
+      ]
     },
     {
       "domain": "FivesArena.com",
@@ -31,16 +88,54 @@
     },
     {
       "domain": "starfallsalvage.kopanolabs.com",
-      "status": "declared_pending_witness",
-      "ownership_evidence": [],
-      "repositories": [],
-      "deployment": { "provider": null, "environment": null, "target": null },
+      "status": "witnessed",
+      "ownership_evidence": [
+        {
+          "kind": "domain-control",
+          "ref": "vercel://team_w8Z8foT3ccswOxMiB4LypZ59/project/prj_rik2lQSlmHm7CIUhEGZMprZ5CFcN/domain/starfallsalvage.kopanolabs.com",
+          "verified_at": "2026-08-24T00:24:25Z"
+        },
+        {
+          "kind": "deployment",
+          "ref": "vercel://team_w8Z8foT3ccswOxMiB4LypZ59/deployment/dpl_8Myns9BqgPovBtTaC1ZsrjtNwCuP",
+          "verified_at": "2026-08-24T00:24:25Z"
+        },
+        {
+          "kind": "repository",
+          "ref": "github://RobynAwesome/starfall-salvage/commit/fea307d09a8552cec72e0a6bcb5440cd173bef41",
+          "verified_at": "2026-08-24T00:24:25Z"
+        }
+      ],
+      "repositories": [
+        {
+          "repository": "RobynAwesome/starfall-salvage",
+          "role": "application",
+          "ref": "commit://fea307d09a8552cec72e0a6bcb5440cd173bef41"
+        }
+      ],
+      "deployment": {
+        "provider": "Vercel",
+        "environment": "production",
+        "target": "vercel://team_w8Z8foT3ccswOxMiB4LypZ59/project/prj_rik2lQSlmHm7CIUhEGZMprZ5CFcN/deployment/dpl_8Myns9BqgPovBtTaC1ZsrjtNwCuP"
+      },
       "adapter": { "required": true, "implementation": null, "version": null },
       "renter_compatibility": { "status": "unknown", "protocol_version": null },
       "governance": { "policy_ref": null, "risk_class": null },
-      "release": { "live_ref": null, "evidence_ref": null },
-      "rollback": { "target_ref": null, "procedure_ref": null },
-      "notes": ["Declared as an initial KPGS DNS estate member. Await authoritative witness evidence before promotion."]
+      "release": {
+        "live_ref": "vercel://team_w8Z8foT3ccswOxMiB4LypZ59/deployment/dpl_8Myns9BqgPovBtTaC1ZsrjtNwCuP",
+        "evidence_ref": "repo://governance/kpgs-vnext/estate-registry/evidence/live-provider-witness-2026-08-24.json#starfallsalvage.kopanolabs.com"
+      },
+      "rollback": {
+        "target_ref": "vercel://team_w8Z8foT3ccswOxMiB4LypZ59/deployment/dpl_9X3gbZpWuRWK5N3XC7Unvtd1doDR",
+        "procedure_ref": "repo://governance/kpgs-vnext/estate-registry/evidence/LIVE_PROVIDER_WITNESS_2026-08-24.md#starfall-rollback-procedure"
+      },
+      "notes": [
+        "Witnessed through connected Vercel and GitHub account surfaces on 2026-08-24; public HTTP alone was not used as ownership proof.",
+        "Connected GitHub currently resolves stable repository id 1229480004 as RobynAwesome/starfall-salvage while Vercel deployment metadata retains the historical Kopano-Labs organization label; stable repo id + exact commit anchor the identity seam.",
+        "Connected Vercel runtime-error aggregation returned no error groups in the selected seven-day window.",
+        "Rollback target records a real prior READY production deployment candidate but no rollback drill or automatic rollback authority is claimed.",
+        "Adapter, renter compatibility, capability map, governance classification, health/evidence endpoint and exact-commit KPGS evaluation remain explicitly unknown/incomplete, so migration remains HOLD."
+      ]
     },
     {
       "domain": "crisisconnect.kopanolabs.com",

--- a/governance/kpgs-vnext/estate-registry/evidence/LIVE_PROVIDER_WITNESS_2026-08-24.md
+++ b/governance/kpgs-vnext/estate-registry/evidence/LIVE_PROVIDER_WITNESS_2026-08-24.md
@@ -1,0 +1,105 @@
+# Live Provider Witness — 2026-08-24
+
+Issue: #102  
+Machine receipt: `live-provider-witness-2026-08-24.json`  
+Authority effect: **witness-only**  
+Provider mutation performed: **no**
+
+`I_AM_STATELESS_RENTER_NOT_LANDLORD`
+
+## Purpose
+
+Admit facts that were directly witnessed through connected Vercel and GitHub account surfaces without inventing KPGS adapter, renter, capability, evaluation or production-promotion evidence.
+
+This receipt intentionally separates:
+
+```text
+provider says a domain/deployment exists
+!=
+KPGS says the property is registration-complete
+!=
+KPGS staging/production promotion
+```
+
+Public HTTP reachability alone is not the ownership witness used here.
+
+## Starfall Salvage
+
+### Connected facts
+
+- Domain binding: `starfallsalvage.kopanolabs.com` is attached to Vercel project `prj_rik2lQSlmHm7CIUhEGZMprZ5CFcN` (`starfall-salvage`) inside team `team_w8Z8foT3ccswOxMiB4LypZ59`.
+- Current production deployment: `dpl_8Myns9BqgPovBtTaC1ZsrjtNwCuP`, state `READY`.
+- Current source commit: `fea307d09a8552cec72e0a6bcb5440cd173bef41`.
+- Connected GitHub resolves stable repository id `1229480004` as `RobynAwesome/starfall-salvage`; the exact current deployment commit exists there.
+- Vercel deployment metadata still records the source organization as `Kopano-Labs/starfall-salvage`. Stable repository id + exact commit are therefore retained as the cross-provider identity seam instead of pretending the naming discrepancy does not exist.
+- Prior READY production deployment `dpl_9X3gbZpWuRWK5N3XC7Unvtd1doDR` points to commit `b3253e44a7e129d5d2f323d579666f6e5182fd94` and is retained as the witnessed rollback target candidate.
+- Connected Vercel runtime-error aggregation returned no error groups for the selected seven-day window.
+
+### Starfall rollback procedure
+
+This is a **rollback procedure reference**, not automatic rollback authority.
+
+If a future KPGS-authorized production transition uses the current Starfall release and a rollback is required:
+
+1. Confirm the currently live deployment/release fingerprint still matches the release being rolled back.
+2. Re-check that `dpl_9X3gbZpWuRWK5N3XC7Unvtd1doDR` is still available as an eligible Vercel rollback candidate and corresponds to commit `b3253e44a7e129d5d2f323d579666f6e5182fd94`.
+3. Obtain the separately governed `estate.release.rollback` authority / human approval required by the active policy.
+4. Execute rollback only through an authorized provider surface; this repository receipt cannot perform that action by itself.
+5. Verify the public release fingerprint and critical route/health behavior after rollback.
+6. Emit the rollback evidence receipt and update canonical estate state through the governed registry transition.
+
+Until steps 3–6 have actually occurred, a rollback drill or rollback success MUST NOT be claimed.
+
+### Starfall admission verdict
+
+`declared_pending_witness -> witnessed` is supported by connected provider/repository evidence.
+
+Further lifecycle movement is **HOLD** because the versioned adapter, conformant Stateless Renter protocol, capability map, governed health/evidence endpoint, policy/risk/tier, exact-commit KPGS evaluation and rollback-drill receipts are not yet evidenced.
+
+## KasiLink
+
+### Connected facts
+
+- Connected GitHub repository: `RobynAwesome/KasiLink`, stable repository id `1195618604`.
+- Both current Vercel deployments resolve to exact source commit `1080fb18096cb2b5c9f8a9ea0d12b442b80329f4`.
+- Apex `kasilink.com` is attached to Vercel project `prj_07Q4oRr2okeBiPO12YotAzHZM10b` (`kasi-link.rsa`) and current READY deployment `dpl_9PMFHyTv9jP78sASJaZD5hGX47yr`.
+- `www.kasilink.com` is attached to Vercel project `prj_A1AvVl5WYRyTergoEcMsvEmMM3uX` (`kasi-link`) and current READY deployment `dpl_AA9iSMwcpHPGvqtRc5mEFjMpywha`.
+- The source commit has converged, but the provider project identities and domain ownership remain split.
+- Connected Vercel runtime aggregation currently reports MongoDB Atlas authentication failures on both project identities. The apex project has repeated failures for `/api/incidents`, `/api/water-alerts` and `/api/gigs`; the `www` project has a current `/api/gigs` authentication failure plus an older Clerk publishable-key middleware error in the sampled window.
+
+### KasiLink cutover boundary
+
+The current connected Vercel action surface can inspect projects, deployments, build/runtime evidence and deploy the current project, but exposes **no project-domain assignment/removal mutation operation**.
+
+Therefore:
+
+```text
+provider split witnessed = YES
+source commit convergence = YES
+safe domain cutover executed = NO
+canonical single-project release = NO
+migration/promotion = HOLD
+```
+
+No manual DNS value is guessed. No public HTTP response is substituted for provider control evidence. The future cutover must remain reversible and must receipt both the old and new provider bindings before and after mutation.
+
+### KasiLink admission verdict
+
+`declared_pending_witness -> witnessed` is supported for the existing provider/repository state.
+
+KasiLink remains **HOLD** for registration/migration because:
+
+- no single canonical Vercel project owns both public hostnames;
+- the connected provider surface cannot currently perform the required domain reassignment;
+- runtime authentication errors remain observed;
+- adapter/renter/capability/policy/evaluation/rollback evidence remains incomplete.
+
+## Anti-FOC boundaries
+
+- `witnessed` does not mean `registered`.
+- READY Vercel deployment does not mean KPGS production promotion.
+- same Git commit on two projects does not collapse two provider identities into one.
+- a rollback candidate is not an executed rollback drill.
+- runtime error absence for Starfall is an observation for a bounded time window, not a permanent health guarantee.
+- runtime errors for KasiLink are provider/runtime evidence; this receipt does not guess credentials or mutate secrets.
+- no provider mutation was performed by this evidence-admission slice.

--- a/governance/kpgs-vnext/estate-registry/evidence/live-provider-witness-2026-08-24.json
+++ b/governance/kpgs-vnext/estate-registry/evidence/live-provider-witness-2026-08-24.json
@@ -1,0 +1,138 @@
+{
+  "schema": "kpgs.live-provider-witness.v1",
+  "captured_at": "2026-08-24T00:24:25Z",
+  "estate_id": "kopano-sovereign-estate",
+  "authority_effect": "witness-only",
+  "provider_mutation_performed": false,
+  "properties": [
+    {
+      "domain": "starfallsalvage.kopanolabs.com",
+      "repository": {
+        "full_name": "RobynAwesome/starfall-salvage",
+        "commit_sha": "fea307d09a8552cec72e0a6bcb5440cd173bef41",
+        "stable_repository_id": "1229480004",
+        "evidence_ref": "github://RobynAwesome/starfall-salvage/commit/fea307d09a8552cec72e0a6bcb5440cd173bef41"
+      },
+      "provider": {
+        "name": "Vercel",
+        "team_ref": "vercel://team/team_w8Z8foT3ccswOxMiB4LypZ59"
+      },
+      "domain_bindings": [
+        {
+          "hostname": "starfallsalvage.kopanolabs.com",
+          "project_id": "prj_rik2lQSlmHm7CIUhEGZMprZ5CFcN",
+          "project_name": "starfall-salvage",
+          "evidence_ref": "vercel://team_w8Z8foT3ccswOxMiB4LypZ59/project/prj_rik2lQSlmHm7CIUhEGZMprZ5CFcN/domain/starfallsalvage.kopanolabs.com"
+        }
+      ],
+      "deployments": [
+        {
+          "role": "current",
+          "deployment_id": "dpl_8Myns9BqgPovBtTaC1ZsrjtNwCuP",
+          "project_id": "prj_rik2lQSlmHm7CIUhEGZMprZ5CFcN",
+          "state": "READY",
+          "target": "production",
+          "commit_sha": "fea307d09a8552cec72e0a6bcb5440cd173bef41",
+          "evidence_ref": "vercel://team_w8Z8foT3ccswOxMiB4LypZ59/deployment/dpl_8Myns9BqgPovBtTaC1ZsrjtNwCuP"
+        },
+        {
+          "role": "rollback-candidate",
+          "deployment_id": "dpl_9X3gbZpWuRWK5N3XC7Unvtd1doDR",
+          "project_id": "prj_rik2lQSlmHm7CIUhEGZMprZ5CFcN",
+          "state": "READY",
+          "target": "production",
+          "commit_sha": "b3253e44a7e129d5d2f323d579666f6e5182fd94",
+          "evidence_ref": "vercel://team_w8Z8foT3ccswOxMiB4LypZ59/deployment/dpl_9X3gbZpWuRWK5N3XC7Unvtd1doDR"
+        }
+      ],
+      "runtime_observation": {
+        "window": "7d",
+        "status": "NO_ERRORS_OBSERVED",
+        "summary": "Connected Vercel runtime-error aggregation returned no runtime errors for the Starfall project in the selected seven-day window."
+      },
+      "admission_recommendation": "WITNESS",
+      "unknowns": [
+        "versioned KPGS domain adapter implementation",
+        "Stateless Renter conformance and protocol version",
+        "governance policy/risk/tier for registration",
+        "bounded capability map",
+        "governed health/evidence endpoint",
+        "exact-commit KPGS evaluation receipt",
+        "executed rollback-drill receipt"
+      ],
+      "notes": [
+        "Connected Vercel deployment metadata records the source organization as Kopano-Labs/starfall-salvage, while connected GitHub currently resolves stable repository id 1229480004 as RobynAwesome/starfall-salvage. The stable repository id and exact commit are preserved as the cross-provider identity seam.",
+        "Witness admission does not imply staging or production promotion inside KPGS."
+      ]
+    },
+    {
+      "domain": "KasiLink.com",
+      "repository": {
+        "full_name": "RobynAwesome/KasiLink",
+        "commit_sha": "1080fb18096cb2b5c9f8a9ea0d12b442b80329f4",
+        "stable_repository_id": "1195618604",
+        "evidence_ref": "github://RobynAwesome/KasiLink/commit/1080fb18096cb2b5c9f8a9ea0d12b442b80329f4"
+      },
+      "provider": {
+        "name": "Vercel",
+        "team_ref": "vercel://team/team_w8Z8foT3ccswOxMiB4LypZ59"
+      },
+      "domain_bindings": [
+        {
+          "hostname": "kasilink.com",
+          "project_id": "prj_07Q4oRr2okeBiPO12YotAzHZM10b",
+          "project_name": "kasi-link.rsa",
+          "evidence_ref": "vercel://team_w8Z8foT3ccswOxMiB4LypZ59/project/prj_07Q4oRr2okeBiPO12YotAzHZM10b/domain/kasilink.com"
+        },
+        {
+          "hostname": "www.kasilink.com",
+          "project_id": "prj_A1AvVl5WYRyTergoEcMsvEmMM3uX",
+          "project_name": "kasi-link",
+          "evidence_ref": "vercel://team_w8Z8foT3ccswOxMiB4LypZ59/project/prj_A1AvVl5WYRyTergoEcMsvEmMM3uX/domain/www.kasilink.com"
+        }
+      ],
+      "deployments": [
+        {
+          "role": "split-current",
+          "deployment_id": "dpl_9PMFHyTv9jP78sASJaZD5hGX47yr",
+          "project_id": "prj_07Q4oRr2okeBiPO12YotAzHZM10b",
+          "state": "READY",
+          "target": "production",
+          "commit_sha": "1080fb18096cb2b5c9f8a9ea0d12b442b80329f4",
+          "evidence_ref": "vercel://team_w8Z8foT3ccswOxMiB4LypZ59/deployment/dpl_9PMFHyTv9jP78sASJaZD5hGX47yr"
+        },
+        {
+          "role": "split-current",
+          "deployment_id": "dpl_AA9iSMwcpHPGvqtRc5mEFjMpywha",
+          "project_id": "prj_A1AvVl5WYRyTergoEcMsvEmMM3uX",
+          "state": "READY",
+          "target": "production",
+          "commit_sha": "1080fb18096cb2b5c9f8a9ea0d12b442b80329f4",
+          "evidence_ref": "vercel://team_w8Z8foT3ccswOxMiB4LypZ59/deployment/dpl_AA9iSMwcpHPGvqtRc5mEFjMpywha"
+        }
+      ],
+      "runtime_observation": {
+        "window": "7d",
+        "status": "ERRORS_OBSERVED",
+        "summary": "Connected Vercel aggregation reports MongoDB Atlas authentication failures on both project identities. The apex project reports repeated /api/incidents, /api/water-alerts and /api/gigs failures; the www project reports a current /api/gigs authentication failure plus an older Clerk publishable-key middleware error in the sampled window."
+      },
+      "admission_recommendation": "WITNESS",
+      "unknowns": [
+        "single canonical Vercel project owning both apex and www",
+        "supported provider-domain mutation action in the currently connected Vercel tool surface",
+        "versioned KPGS domain adapter implementation",
+        "Stateless Renter conformance and protocol version",
+        "governance policy/risk/tier for registration",
+        "bounded capability map",
+        "governed health/evidence endpoint",
+        "exact-commit KPGS evaluation receipt",
+        "rollback drill for a future domain cutover"
+      ],
+      "notes": [
+        "Both Vercel projects currently deploy the same Git commit, but they remain distinct provider project identities and own different public hostnames.",
+        "The provider split remains a governed HOLD even though the source commit has converged.",
+        "The currently exposed Vercel connector has read/observe/deploy capabilities but no domain assignment/removal mutation action; no cutover was performed."
+      ]
+    }
+  ]
+}

--- a/governance/kpgs-vnext/estate-registry/live-provider-witness.schema.json
+++ b/governance/kpgs-vnext/estate-registry/live-provider-witness.schema.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kopanolabs.com/schemas/kpgs/estate-registry/live-provider-witness.schema.json",
+  "title": "KPGS Live Provider Witness Receipt",
+  "description": "Connected-account evidence for DNS/repository/deployment facts. A witness receipt records observed provider state; it does not grant registry transition or production authority.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "captured_at", "estate_id", "authority_effect", "properties"],
+  "properties": {
+    "schema": { "const": "kpgs.live-provider-witness.v1" },
+    "captured_at": { "type": "string", "format": "date-time" },
+    "estate_id": { "type": "string", "minLength": 1 },
+    "authority_effect": { "const": "witness-only" },
+    "provider_mutation_performed": { "type": "boolean" },
+    "properties": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "domain",
+          "repository",
+          "provider",
+          "domain_bindings",
+          "deployments",
+          "runtime_observation",
+          "admission_recommendation",
+          "unknowns"
+        ],
+        "properties": {
+          "domain": { "type": "string", "minLength": 3 },
+          "repository": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["full_name", "commit_sha", "evidence_ref"],
+            "properties": {
+              "full_name": { "type": "string", "minLength": 3 },
+              "commit_sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+              "stable_repository_id": { "type": ["string", "null"] },
+              "evidence_ref": { "type": "string", "minLength": 1 }
+            }
+          },
+          "provider": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name", "team_ref"],
+            "properties": {
+              "name": { "const": "Vercel" },
+              "team_ref": { "type": "string", "minLength": 1 }
+            }
+          },
+          "domain_bindings": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["hostname", "project_id", "project_name", "evidence_ref"],
+              "properties": {
+                "hostname": { "type": "string", "minLength": 3 },
+                "project_id": { "type": "string", "pattern": "^prj_" },
+                "project_name": { "type": "string", "minLength": 1 },
+                "evidence_ref": { "type": "string", "minLength": 1 }
+              }
+            }
+          },
+          "deployments": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["role", "deployment_id", "project_id", "state", "target", "commit_sha", "evidence_ref"],
+              "properties": {
+                "role": { "type": "string", "enum": ["current", "rollback-candidate", "split-current"] },
+                "deployment_id": { "type": "string", "pattern": "^dpl_" },
+                "project_id": { "type": "string", "pattern": "^prj_" },
+                "state": { "type": "string", "minLength": 1 },
+                "target": { "type": ["string", "null"] },
+                "commit_sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+                "evidence_ref": { "type": "string", "minLength": 1 }
+              }
+            }
+          },
+          "runtime_observation": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["window", "status", "summary"],
+            "properties": {
+              "window": { "type": "string", "minLength": 1 },
+              "status": { "type": "string", "enum": ["NO_ERRORS_OBSERVED", "ERRORS_OBSERVED", "NOT_CHECKED"] },
+              "summary": { "type": "string", "minLength": 1 }
+            }
+          },
+          "admission_recommendation": {
+            "type": "string",
+            "enum": ["WITNESS", "HOLD", "REJECT"]
+          },
+          "unknowns": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 1 },
+            "uniqueItems": true
+          },
+          "notes": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/governance/kpgs-vnext/estate-registry/validate_registry.py
+++ b/governance/kpgs-vnext/estate-registry/validate_registry.py
@@ -13,6 +13,8 @@ ROOT = HERE.parents[2]
 ESTATE = HERE / "estate.json"
 REGISTRY_SCHEMA = HERE / "estate-registry.schema.json"
 CANDIDATE_SCHEMA = HERE / "discovery-candidate.schema.json"
+LIVE_WITNESS_SCHEMA = HERE / "live-provider-witness.schema.json"
+LIVE_WITNESS_DIR = HERE / "evidence"
 REGISTRY_RUNTIME = HERE / "registry.py"
 LEASE_RUNTIME = HERE.parent / "security" / "capability_lease.py"
 
@@ -44,13 +46,37 @@ def main() -> None:
     estate = json.loads(ESTATE.read_text(encoding="utf-8"))
     registry_schema = json.loads(REGISTRY_SCHEMA.read_text(encoding="utf-8"))
     candidate_schema = json.loads(CANDIDATE_SCHEMA.read_text(encoding="utf-8"))
+    live_witness_schema = json.loads(LIVE_WITNESS_SCHEMA.read_text(encoding="utf-8"))
 
     domains = {item["domain"] for item in estate["properties"]}
     require(domains == INITIAL_DOMAINS, "initial canonical DNS estate drifted")
-    require(
-        all(item["status"] == "declared_pending_witness" for item in estate["properties"]),
-        "unwitnessed initial property was silently promoted",
+
+    allowed_property_states = set(
+        registry_schema["properties"]["properties"]["items"]["properties"]["status"]["enum"]
     )
+    for item in estate["properties"]:
+        status = item.get("status")
+        evidence = item.get("ownership_evidence") or []
+        require(status in allowed_property_states, f"{item['domain']} has invalid lifecycle status")
+        if status == "declared_pending_witness":
+            require(not evidence, f"{item['domain']} is pending but already carries ownership evidence")
+            require(
+                item.get("release", {}).get("live_ref") is None,
+                f"{item['domain']} must not claim a governed live release before witnessing",
+            )
+        elif status in {"witnessed", "registered", "staging", "production"}:
+            require(bool(evidence), f"{item['domain']} cannot be {status} without ownership/control evidence")
+        if status == "production":
+            release = item.get("release") or {}
+            rollback = item.get("rollback") or {}
+            require(
+                bool(release.get("live_ref") and release.get("evidence_ref")),
+                f"{item['domain']} production state requires exact live/evidence refs",
+            )
+            require(
+                bool(rollback.get("target_ref") and rollback.get("procedure_ref")),
+                f"{item['domain']} production state requires rollback refs",
+            )
 
     property_schema = registry_schema["properties"]["properties"]["items"]["properties"]
     for required_link in (
@@ -69,6 +95,44 @@ def main() -> None:
         "://" in property_schema["secret_provider_refs"]["items"]["pattern"],
         "secret provider fields no longer require references",
     )
+
+    require(
+        live_witness_schema.get("$schema") == "https://json-schema.org/draft/2020-12/schema",
+        "live provider witness schema must use draft 2020-12",
+    )
+    require(
+        live_witness_schema.get("properties", {}).get("authority_effect", {}).get("const")
+        == "witness-only",
+        "live provider witness must remain non-promoting",
+    )
+
+    receipt_witnessed_domains: set[str] = set()
+    for receipt_path in sorted(LIVE_WITNESS_DIR.glob("live-provider-witness-*.json")):
+        receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+        require(receipt.get("schema") == "kpgs.live-provider-witness.v1", f"invalid witness receipt schema in {receipt_path.name}")
+        require(receipt.get("authority_effect") == "witness-only", f"{receipt_path.name} widened witness authority")
+        require(
+            isinstance(receipt.get("provider_mutation_performed"), bool),
+            f"{receipt_path.name} must explicitly state provider mutation effect",
+        )
+        for observed in receipt.get("properties") or []:
+            domain = observed.get("domain")
+            require(domain in INITIAL_DOMAINS, f"{receipt_path.name} references unknown estate domain {domain}")
+            require(bool(observed.get("domain_bindings")), f"{domain} witness lacks provider domain binding")
+            require(bool(observed.get("deployments")), f"{domain} witness lacks deployment evidence")
+            if observed.get("admission_recommendation") == "WITNESS":
+                receipt_witnessed_domains.add(domain)
+
+    estate_by_domain = {item["domain"]: item for item in estate["properties"]}
+    for domain in receipt_witnessed_domains:
+        require(
+            estate_by_domain[domain]["status"] != "declared_pending_witness",
+            f"{domain} has admitted witness receipt but registry was not advanced to witnessed-or-later",
+        )
+        require(
+            bool(estate_by_domain[domain]["ownership_evidence"]),
+            f"{domain} witness admission lost ownership/control evidence",
+        )
 
     candidate_states = set(candidate_schema["properties"]["status"]["enum"])
     require(
@@ -182,8 +246,8 @@ def main() -> None:
     )
 
     print(
-        "KPGS-ESTATE PASS: discovery is unwitnessed-by-default, lease-scoped, "
-        "promotion-gated and plain-language queryable."
+        "KPGS-ESTATE PASS: discovery is unwitnessed-by-default, connected witness "
+        "receipts remain non-promoting, and lifecycle state is evidence-gated."
     )
 
 

--- a/governance/kpgs-vnext/migration/README.md
+++ b/governance/kpgs-vnext/migration/README.md
@@ -1,6 +1,7 @@
 # KPGS Canonical DNS Estate Migration Playbook
 
 Issue: #44
+Operational witness continuation: #102
 
 ## Purpose
 
@@ -74,6 +75,8 @@ The migration engine respects the canonical Estate Registry. `declared_pending_w
 
 A property may not be considered registered from memory, public search, repository visibility, or an application screenshot. The canonical registry requires witnessed ownership/domain-control evidence and the registration completeness contract from `../estate-registry/`.
 
+A `witnessed` property can still remain HOLD when registration completeness is missing. Connected provider evidence proves observed control/deployment facts; it does not manufacture owner/governance/capability/health/adapter/renter state.
+
 ## Adapter gate
 
 A property must declare a versioned adapter implementation. The reference implementation is:
@@ -137,6 +140,8 @@ A passing drill must:
 
 The drill proves recoverability. It does not grant rollback authority.
 
+A recorded provider rollback **candidate** is useful baseline evidence, but it is not the same thing as an executed rollback drill.
+
 ## Production eligibility
 
 Production remains `NOT_REACHED` until all of the following are present:
@@ -161,11 +166,15 @@ The capability-gated Estate Registry still owns the production transition.
 
 ## Current canonical estate behavior
 
-The six declared properties in `../estate-registry/estate.json` are intentionally `declared_pending_witness`.
+As of the connected-provider witness receipt on 2026-08-24:
 
-Therefore, running the migration assessor against the live canonical registry must currently produce **HOLD**, not auto-enrichment or migration claims.
+- `KasiLink.com` is `witnessed` with exact GitHub/Vercel evidence, but its apex and `www` hostnames remain attached to **two different Vercel project identities**. The singular deployment target remains intentionally `null`; both provider environments are preserved explicitly. Runtime authentication errors are also witnessed. Migration remains **HOLD**.
+- `starfallsalvage.kopanolabs.com` is `witnessed` with exact repository, Vercel project, current READY deployment, live release evidence and a real prior deployment recorded as rollback target. Adapter/renter/capability/governance/health/evaluation and rollback-drill evidence remain incomplete. Migration remains **HOLD**.
+- The other four declared estate properties remain `declared_pending_witness` until authoritative evidence is admitted.
 
-This is expected governance behavior until authoritative witness data is supplied.
+Machine evidence: `../estate-registry/evidence/live-provider-witness-2026-08-24.json`.
+
+Therefore, running the migration assessor against the current canonical registry must still produce **HOLD for all six properties**. The reason is now situational per property rather than the old blanket claim that every property lacks witness evidence.
 
 ## CI reference proof
 
@@ -183,12 +192,14 @@ These fixtures are not production registry state and are not DNS ownership evide
 - produce deterministic migration IDs for the same property/workflow;
 - apply the identical playbook to a second property.
 
+The live witness regression test separately proves that real provider evidence can advance a property to `witnessed` while missing KPGS gates still produce HOLD.
+
 ## Operator workflow
 
 1. Copy `migration-template.json` for the bounded workflow.
 2. Populate baseline references from witnessed/current systems.
-3. Update the canonical Estate Registry only through its capability-gated witness/register operations.
-4. Add adapter/renter/capability/health declarations to the registered property.
+3. Update the canonical Estate Registry only through admitted governance/review surfaces; runtime production mutations still require the capability-gated registry operation.
+4. Add adapter/renter/capability/health declarations only when their evidence exists.
 5. Run the exact-commit evaluation/evidence loop.
 6. Run migration assessment.
 7. If staging-eligible, request the separately authorized staging transition.
@@ -202,5 +213,6 @@ These fixtures are not production registry state and are not DNS ownership evide
 
 ```bash
 python -m unittest discover -s tests -p 'test_estate_migration.py' -v
+python -m unittest discover -s tests -p 'test_live_estate_witness_admission.py' -v
 python governance/kpgs-vnext/migration/assess_estate.py
 ```

--- a/tests/test_live_estate_witness_admission.py
+++ b/tests/test_live_estate_witness_admission.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import sys
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ESTATE_PATH = ROOT / "governance/kpgs-vnext/estate-registry/estate.json"
+WITNESS_PATH = (
+    ROOT
+    / "governance/kpgs-vnext/estate-registry/evidence/live-provider-witness-2026-08-24.json"
+)
+MIGRATION_PATH = ROOT / "governance/kpgs-vnext/migration/migration.py"
+
+spec = importlib.util.spec_from_file_location("kpgs_live_estate_migration", MIGRATION_PATH)
+assert spec and spec.loader
+migration = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = migration
+spec.loader.exec_module(migration)
+
+
+class LiveEstateWitnessAdmissionTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.estate = json.loads(ESTATE_PATH.read_text(encoding="utf-8"))
+        cls.witness = json.loads(WITNESS_PATH.read_text(encoding="utf-8"))
+        cls.records = {item["domain"]: item for item in cls.estate["properties"]}
+        cls.receipts = {item["domain"]: item for item in cls.witness["properties"]}
+
+    def test_only_witnessed_properties_move_from_pending_state(self):
+        self.assertEqual(len(self.records), 6)
+        self.assertEqual(self.records["KasiLink.com"]["status"], "witnessed")
+        self.assertEqual(
+            self.records["starfallsalvage.kopanolabs.com"]["status"], "witnessed"
+        )
+        for domain in (
+            "FivesArena.com",
+            "crisisconnect.kopanolabs.com",
+            "KopanoLabs.com",
+            "KRRababalela.com",
+        ):
+            self.assertEqual(self.records[domain]["status"], "declared_pending_witness")
+            self.assertEqual(self.records[domain]["ownership_evidence"], [])
+
+    def test_witness_receipt_is_non_mutating_provider_evidence(self):
+        self.assertEqual(self.witness["schema"], "kpgs.live-provider-witness.v1")
+        self.assertEqual(self.witness["authority_effect"], "witness-only")
+        self.assertFalse(self.witness["provider_mutation_performed"])
+        self.assertEqual(set(self.receipts), {"KasiLink.com", "starfallsalvage.kopanolabs.com"})
+        for receipt in self.receipts.values():
+            self.assertEqual(receipt["admission_recommendation"], "WITNESS")
+            self.assertTrue(receipt["domain_bindings"])
+            self.assertTrue(receipt["deployments"])
+            self.assertTrue(receipt["unknowns"])
+
+    def test_starfall_exact_provider_repo_release_and_rollback_receipts(self):
+        record = self.records["starfallsalvage.kopanolabs.com"]
+        self.assertEqual(
+            record["repositories"][0]["repository"], "RobynAwesome/starfall-salvage"
+        )
+        self.assertEqual(
+            record["repositories"][0]["ref"],
+            "commit://fea307d09a8552cec72e0a6bcb5440cd173bef41",
+        )
+        self.assertIn("prj_rik2lQSlmHm7CIUhEGZMprZ5CFcN", record["deployment"]["target"])
+        self.assertIn("dpl_8Myns9BqgPovBtTaC1ZsrjtNwCuP", record["release"]["live_ref"])
+        self.assertIn("dpl_9X3gbZpWuRWK5N3XC7Unvtd1doDR", record["rollback"]["target_ref"])
+        self.assertIn("#starfall-rollback-procedure", record["rollback"]["procedure_ref"])
+        self.assertIsNone(record["adapter"]["implementation"])
+        self.assertEqual(record["renter_compatibility"]["status"], "unknown")
+        self.assertIsNone(record["governance"]["policy_ref"])
+        self.assertNotIn("capabilities", record)
+        self.assertNotIn("health_endpoints", record)
+
+    def test_starfall_witness_does_not_self_promote_migration(self):
+        record = self.records["starfallsalvage.kopanolabs.com"]
+        result = migration.assess_migration(
+            estate_id=self.estate["estate_id"],
+            property_record=record,
+            workflow_id="live-estate-witness-2026-08-24",
+        )
+        self.assertEqual(result["recommendation"], "HOLD")
+        self.assertFalse(result["ready_for_staging"])
+        self.assertFalse(result["ready_for_production"])
+        self.assertEqual(result["stages"]["register"]["status"], "HOLD")
+        self.assertEqual(result["stages"]["adapter_integration"]["status"], "HOLD")
+        self.assertEqual(result["stages"]["renter_integration"]["status"], "HOLD")
+        self.assertFalse(result["canonical_registry_changed"])
+
+    def test_kasilink_preserves_split_provider_identity_and_hold(self):
+        record = self.records["KasiLink.com"]
+        self.assertEqual(record["repositories"][0]["repository"], "RobynAwesome/KasiLink")
+        self.assertEqual(
+            record["repositories"][0]["ref"],
+            "commit://1080fb18096cb2b5c9f8a9ea0d12b442b80329f4",
+        )
+        self.assertEqual(record["deployment"]["environment"], "production-split")
+        self.assertIsNone(record["deployment"]["target"])
+        targets = "\n".join(
+            item["target"] for item in record["deployment"]["environments"]
+        )
+        self.assertIn("prj_07Q4oRr2okeBiPO12YotAzHZM10b", targets)
+        self.assertIn("dpl_9PMFHyTv9jP78sASJaZD5hGX47yr", targets)
+        self.assertIn("prj_A1AvVl5WYRyTergoEcMsvEmMM3uX", targets)
+        self.assertIn("dpl_AA9iSMwcpHPGvqtRc5mEFjMpywha", targets)
+        self.assertIsNone(record["release"]["live_ref"])
+
+        result = migration.assess_migration(
+            estate_id=self.estate["estate_id"],
+            property_record=record,
+            workflow_id="live-estate-witness-2026-08-24",
+        )
+        self.assertEqual(result["recommendation"], "HOLD")
+        self.assertEqual(result["stages"]["baseline"]["status"], "HOLD")
+        self.assertEqual(result["stages"]["register"]["status"], "HOLD")
+        self.assertFalse(result["canonical_registry_changed"])
+
+    def test_connected_provider_refs_not_public_http_as_ownership_proof(self):
+        for domain in ("KasiLink.com", "starfallsalvage.kopanolabs.com"):
+            evidence = self.records[domain]["ownership_evidence"]
+            self.assertTrue(evidence)
+            for item in evidence:
+                self.assertFalse(item["ref"].startswith("http://"))
+                self.assertFalse(item["ref"].startswith("https://"))
+                self.assertTrue(
+                    item["ref"].startswith("vercel://")
+                    or item["ref"].startswith("github://")
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sovereign_estate_registry.py
+++ b/tests/test_sovereign_estate_registry.py
@@ -256,9 +256,8 @@ class SovereignEstateRegistryTests(unittest.TestCase):
 
     def test_initial_six_domains_remain_present_and_unpromoted(self):
         snapshot = self.registry.snapshot()
-        domains = {
-            item["domain"] for item in snapshot["properties"]
-        }
+        properties = {item["domain"]: item for item in snapshot["properties"]}
+        domains = set(properties)
         self.assertEqual(
             domains,
             {
@@ -270,10 +269,24 @@ class SovereignEstateRegistryTests(unittest.TestCase):
                 "KRRababalela.com",
             },
         )
+        self.assertEqual(properties["KasiLink.com"]["status"], "witnessed")
+        self.assertEqual(
+            properties["starfallsalvage.kopanolabs.com"]["status"], "witnessed"
+        )
+        for domain in (
+            "FivesArena.com",
+            "crisisconnect.kopanolabs.com",
+            "KopanoLabs.com",
+            "KRRababalela.com",
+        ):
+            self.assertEqual(
+                properties[domain]["status"], "declared_pending_witness"
+            )
+
+        promoted_states = {"registered", "staging", "production"}
         self.assertTrue(
             all(
-                item["status"]
-                == "declared_pending_witness"
+                item["status"] not in promoted_states
                 for item in snapshot["properties"]
             )
         )


### PR DESCRIPTION
Advances #102.

## Scope
This is a bounded **witness-admission** slice. It does not perform provider-domain cutover and does not claim KPGS registration/staging/production.

## Connected evidence admitted
### Starfall Salvage
- Vercel project/domain binding `prj_rik2lQSlmHm7CIUhEGZMprZ5CFcN` -> `starfallsalvage.kopanolabs.com`;
- current READY production deployment `dpl_8Myns9BqgPovBtTaC1ZsrjtNwCuP` -> commit `fea307d09a8552cec72e0a6bcb5440cd173bef41`;
- connected GitHub stable repo id `1229480004` currently resolves `RobynAwesome/starfall-salvage` and contains the exact commit;
- prior READY deployment `dpl_9X3gbZpWuRWK5N3XC7Unvtd1doDR` / commit `b3253e44a7e129d5d2f323d579666f6e5182fd94` recorded as rollback target candidate;
- Vercel 7-day runtime aggregation: no error groups observed.

### KasiLink
- GitHub `RobynAwesome/KasiLink` exact commit `1080fb18096cb2b5c9f8a9ea0d12b442b80329f4`;
- apex `kasilink.com` remains on `kasi-link.rsa` / `prj_07Q4oRr2okeBiPO12YotAzHZM10b` / deployment `dpl_9PMFHyTv9jP78sASJaZD5hGX47yr`;
- `www.kasilink.com` remains on `kasi-link` / `prj_A1AvVl5WYRyTergoEcMsvEmMM3uX` / deployment `dpl_AA9iSMwcpHPGvqtRc5mEFjMpywha`;
- both deployments now resolve the same Git commit but remain distinct provider project identities;
- current Vercel runtime aggregation reports MongoDB Atlas authentication failures on both project identities.

## Changes
- move only Starfall + KasiLink from `declared_pending_witness` -> `witnessed`;
- preserve exact connected Vercel/GitHub evidence refs;
- keep all adapter/renter/capability/governance/evaluation unknowns explicit;
- keep KasiLink singular deployment target `null` and preserve the two split production environments;
- record Starfall current release + real prior deployment rollback target and a non-authoritative rollback procedure;
- add `live-provider-witness.schema.json` + machine/human witness receipts;
- update registry/migration doctrine so `witnessed != registered` and provider READY never self-promotes;
- add regression proof that both enriched properties still assess `HOLD` and the other four estate members remain pending.

## Provider mutation boundary
The connected Vercel tool surface currently exposes no project-domain assignment/removal mutation action. `provider_mutation_performed=false`; no DNS/project cutover is claimed.

`I_AM_STATELESS_RENTER_NOT_LANDLORD`