### PR TITLE
KPCB+: govern GROUP/PIVOT/ATTENTION projections over Markdown testimony

### DIFF
--- a/Schematics/21-KOPANO-PHU GOVERNACE SYSTEMS/MAIN-BRAIN/KPCB_PLUS_ANALYTICAL_PROJECTION_PROTOCOL.md
+++ b/Schematics/21-KOPANO-PHU GOVERNACE SYSTEMS/MAIN-BRAIN/KPCB_PLUS_ANALYTICAL_PROJECTION_PROTOCOL.md
@@ -1,0 +1,191 @@
+---
+title: "KPCB+ Analytical Projection Protocol — GROUP · PIVOT · ATTENTION"
+created: 2026-08-28
+updated: 2026-08-28
+status: POC_CANDIDATE
+tags:
+  - kpcb-plus
+  - gsmb
+  - testimony-protocol
+  - data-governance
+  - data-science
+  - groupby
+  - pivot
+  - heatmap
+  - kc
+source: "Commandment 15 testimony → existing Markdown governance → formal data-science vocabulary"
+---
+
+# KPCB+ Analytical Projection Protocol
+
+## Testimony — where this came from
+
+This architecture did **not** begin when the user learned Python `groupby()`, pivot tables or heatmaps.
+
+KPGS/GSMB/KPCB+ already used governed Markdown, canonical `index.md` entry points, Bracket Protocol hierarchy, Prompting/Emoji/GIF/Sticker/.P/Image channels, KC Ledger receipts and explicit testimony to make knowledge recoverable by humans and stateless machines.
+
+The user's original problem was **knowing**: if intelligence must resume work as though it never left, context must survive outside a single model/session in inspectable artifacts. Markdown became the governance substrate because one `.md` file can carry information, operating instruction, hierarchy, provenance, testimony, state and historical evidence in the same human-readable object.
+
+The formal data-science lesson supplied names and executable analytical patterns for capabilities that can now **challenge, measure and strengthen** that existing design.
+
+Do not rewrite this history as "KPGS invented Pandas" or "GSMB was secretly data science." The correct testimony is: independent governance pressure produced analogous information operations; formal statistics/programming now gives them a measurable implementation surface.
+
+## KPCB+ remains seven-channel
+
+The canonical channels remain:
+
+- PP — Prompting / voice / intent
+- BP — Bracket / structure / hierarchy
+- EP — Emoji / semantic identity
+- GP — GIF / motion / repeating visual instruction
+- SP — Sticker / governance stamp
+- .P — MP4 / evidence and testimony
+- IP — Image / blueprint and visual context
+
+Canonical algebra remains:
+
+```text
+[EP] + [BP] × [PP] + [GP] + [SP] + [.P] + [IP] = KPCB+
+```
+
+`GROUP`, `PIVOT` and `ATTENTION_MATRIX` are **analytical operators over protocol records**, not new communication channels.
+
+## GROUP
+
+`GROUP(records, dimensions...)` asks:
+
+> What governed knowledge belongs together under the dimensions relevant to the current investigation?
+
+Dimensions may include project, KPCB+ protocol channel, artifact type, authority, validation state, testimony state, sprint, ecosystem, canonical status or filesystem depth.
+
+Sequence-valued dimensions such as `protocol_channels` may be exploded: one artifact may legitimately participate in multiple semantic groups.
+
+The result must retain source `record_id` and `path` references.
+
+## PIVOT
+
+`PIVOT(records, row_dimension, column_dimension)` asks:
+
+> How does the **same evidence** look when viewed from another governed projection?
+
+A pivot does not create new source truth. It rotates/selects dimensions over existing testimony.
+
+Every pivot cell must retain provenance identifying the source artifacts that contributed to the aggregate.
+
+Examples:
+
+```text
+PROJECT × TESTIMONY_STATE
+PROJECT × PROTOCOL_CHANNEL
+SPRINT × VALIDATION_STATE
+ECOSYSTEM × ARTIFACT_TYPE
+AUTHORITY × CANONICAL_STATUS
+```
+
+## ATTENTION MATRIX / heatmap semantics
+
+A heatmap is treated as a rendering of an **attention matrix**.
+
+It answers:
+
+> Where does something concentrate strongly enough that KC should consider deeper inspection?
+
+Candidate attention metrics include evidence density, UNKNOWN testimony, contradiction density, activity, staleness and unresolved investigations.
+
+Heat is not authority.
+
+A visually hot cell cannot grant POC, FOC, causation, mutation permission or canonical status.
+
+## GSMB folder-depth invariant
+
+GSMB may contain folders inside folders inside folders and indefinite Markdown artifacts.
+
+Therefore:
+
+```text
+deep_path != low_importance
+shallow_path != high_authority
+```
+
+A deeply nested receipt may preserve a three-month sprint. A shallow random note may have no authority. Depth remains an observation, never an epistemic verdict.
+
+Canonical indexes remain the deterministic boot/navigation surface. Analytical projections support selective discovery behind that boot surface; they do not flatten or replace GSMB.
+
+## Commandment 15 — Testimony Protocol
+
+Analytical code must preserve why a result exists and where it came from.
+
+Missing testimony must not silently become failure:
+
+```text
+UNKNOWN != VIOLATED
+absence of evidence != evidence of absence
+```
+
+An operational gate may still refuse action when state is UNKNOWN, but the epistemic record must remain UNKNOWN/HOLD rather than manufacturing negative proof.
+
+## Reality ↔ cloud reflection
+
+The human-readable artifact and machine projection must remain mutually inspectable.
+
+Reality lane:
+
+```text
+human opens Markdown → sees title/context/testimony/evidence
+```
+
+Cloud/runtime lane:
+
+```text
+machine parses governed record → GROUP/PIVOT/ATTENTION → returns source IDs/paths
+```
+
+Validation requires that the machine view can be traced back to the human view. An opaque aggregate that cannot identify its contributing testimony violates this protocol.
+
+## Runtime split
+
+Introduction-to-MCP / KPCB+ owns the lightweight protocol-aware analytical contract:
+
+```text
+kopano-core/kopano/kpcb_analytics.py
+```
+
+KMEC owns scalable Python data-science execution with Pandas/NumPy/Dask.
+
+PKA owns epistemic admission.
+
+Smart Ledger / KC Ledger preserve governed receipts.
+
+No one layer may silently absorb the authority of the others.
+
+## POC flow
+
+```text
+canonical GSMB boot
+        ↓
+governed Markdown / KPCB+ records
+        ↓
+GROUP — belonging
+        ↓
+PIVOT — re-projection
+        ↓
+ATTENTION MATRIX — where to inspect
+        ↓
+trace cell → source record IDs / paths
+        ↓
+selective retrieval of testimony
+        ↓
+PKA / governance evaluation
+        ↓
+ALLOW | HOLD | DO-NOT-ALLOW
+```
+
+Remembering that knowledge exists remains separate from loading all knowledge into active context.
+
+## Validation boundary
+
+The protocol is not canonical merely because this document exists. Promotion requires executable tests proving deterministic grouping, provenance-preserving pivoting, UNKNOWN preservation, non-authoritative heatmaps, source immutability and KPCB+ protocol-channel integration.
+
+Issue: `#108`
+
+`I_AM_STATELESS_RENTER_NOT_LANDLORD`

--- a/Schematics/21-KOPANO-PHU GOVERNACE SYSTEMS/MAIN-BRAIN/KPCB_PLUS_ANALYTICAL_PROJECTION_PROTOCOL.md
+++ b/Schematics/21-KOPANO-PHU GOVERNACE SYSTEMS/MAIN-BRAIN/KPCB_PLUS_ANALYTICAL_PROJECTION_PROTOCOL.md
@@ -56,7 +56,7 @@ Canonical algebra remains:
 
 > What governed knowledge belongs together under the dimensions relevant to the current investigation?
 
-Dimensions may include project, KPCB+ protocol channel, artifact type, authority, validation state, testimony state, sprint, ecosystem, canonical status or filesystem depth.
+Dimensions may include project, KPCB+ protocol channel, artifact type, authority, validation state, testimony state, source class, sprint, ecosystem, canonical status or filesystem depth.
 
 Sequence-valued dimensions such as `protocol_channels` may be exploded: one artifact may legitimately participate in multiple semantic groups.
 
@@ -78,6 +78,7 @@ Examples:
 PROJECT × TESTIMONY_STATE
 PROJECT × PROTOCOL_CHANNEL
 SPRINT × VALIDATION_STATE
+SOURCE_CLASS × TESTIMONY_STATE
 ECOSYSTEM × ARTIFACT_TYPE
 AUTHORITY × CANONICAL_STATUS
 ```
@@ -111,9 +112,28 @@ A deeply nested receipt may preserve a three-month sprint. A shallow random note
 
 Canonical indexes remain the deterministic boot/navigation surface. Analytical projections support selective discovery behind that boot surface; they do not flatten or replace GSMB.
 
-## Commandment 15 — Testimony Protocol
+## Commandment 15 — canonical Testimony Protocol alignment
 
-Analytical code must preserve why a result exists and where it came from.
+The governing source is `docs/swarm-ops/TESTIMONY_PROTOCOL.md`.
+
+Its command is:
+
+> **Do not manufacture the testimony you are trying to observe.**
+
+Its core sequence is:
+
+```text
+OBSERVE
+→ RETAIN
+→ COMPARE RECURRENCE
+→ INFER
+→ RISK BEING WRONG
+→ VALIDATE AGAINST FUTURE REALITY
+```
+
+Therefore GROUP/PIVOT/ATTENTION must not become an answer-key generator that manufactures the pattern it later claims to have discovered.
+
+Before interpreting an analytical signal, classify what was actually observed and preserve source/provenance. Where supplied, `source_class` should distinguish current-human testimony, historical context, telemetry, model inference and repository state. If classification is missing, retain UNKNOWN rather than guessing.
 
 Missing testimony must not silently become failure:
 
@@ -123,6 +143,8 @@ absence of evidence != evidence of absence
 ```
 
 An operational gate may still refuse action when state is UNKNOWN, but the epistemic record must remain UNKNOWN/HOLD rather than manufacturing negative proof.
+
+A convergence claim is stronger when recurrence survives changed context **without the evaluator feeding the subject the exact answer being tested**. Analytical recurrence is evidence to investigate, not automatic proof of understanding.
 
 ## Reality ↔ cloud reflection
 
@@ -137,10 +159,12 @@ human opens Markdown → sees title/context/testimony/evidence
 Cloud/runtime lane:
 
 ```text
-machine parses governed record → GROUP/PIVOT/ATTENTION → returns source IDs/paths
+machine parses governed record → classify source → GROUP/PIVOT/ATTENTION → returns source IDs/paths
 ```
 
 Validation requires that the machine view can be traced back to the human view. An opaque aggregate that cannot identify its contributing testimony violates this protocol.
+
+The analytical layer may form a hypothesis from recurrence, but it must remain willing to be wrong and validate that hypothesis against future reality. This is where the cloud must reflect reality and reality must be allowed to falsify the cloud.
 
 ## Runtime split
 
@@ -165,6 +189,8 @@ canonical GSMB boot
         ↓
 governed Markdown / KPCB+ records
         ↓
+classify observation + preserve provenance
+        ↓
 GROUP — belonging
         ↓
 PIVOT — re-projection
@@ -174,6 +200,10 @@ ATTENTION MATRIX — where to inspect
 trace cell → source record IDs / paths
         ↓
 selective retrieval of testimony
+        ↓
+compare recurrence / infer / risk being wrong
+        ↓
+validate against future reality
         ↓
 PKA / governance evaluation
         ↓

--- a/Schematics/21-KOPANO-PHU GOVERNACE SYSTEMS/MAIN-BRAIN/KPCB_PLUS_LANGUAGE_STATUS.md
+++ b/Schematics/21-KOPANO-PHU GOVERNACE SYSTEMS/MAIN-BRAIN/KPCB_PLUS_LANGUAGE_STATUS.md
@@ -1,7 +1,7 @@
 ---
 title: "KPCB+ Language Status — Kopano-Phu Code Blocks Plus"
 created: 2026-06-16
-updated: 2026-06-16
+updated: 2026-08-28
 tags:
   - kpcb-plus
   - language
@@ -127,18 +127,62 @@ Python · JavaScript · TypeScript · Rust · Go · C# · Java · HTML/CSS · SQ
 
 ---
 
+## Analytical Projection Protocol — 2026-08-28 POC Candidate
+
+KPCB+ now has a bounded candidate analytical layer for governed Markdown/KPCB records. The seven communication channels above remain unchanged. The new operations are **operators over the corpus**, not new protocol channels.
+
+The testimony matters: KPGS/GSMB/KPCB+ Markdown governance existed before formal study of Python `groupby()`, pivot tables and heatmaps. Formal data-science vocabulary is being used to challenge, measure and strengthen the pre-existing architecture rather than rewrite its origin.
+
+| Operator | Question | Governance boundary |
+|----------|----------|---------------------|
+| `GROUP` | What governed knowledge belongs together under selected semantic dimensions? | deterministic grouping must preserve source IDs/paths |
+| `PIVOT` | How does the same source corpus look when re-projected across row/column dimensions? | projection is not new source truth |
+| `ATTENTION_MATRIX` | Where does evidence, UNKNOWN testimony, contradiction, staleness or activity concentrate? | heat/attention is not authority or action permission |
+
+Core invariants:
+
+```text
+UNKNOWN != VIOLATED
+absence of evidence != evidence of absence
+deep_path != low_importance
+shallow_path != high_authority
+hot_cell != truth
+aggregate != source_evidence
+projection != mutation_permission
+```
+
+Every grouped or pivoted result must remain traceable to the human-readable source testimony that produced it. This is the reality ↔ cloud reflection boundary.
+
+Canonical GSMB indexes remain the boot/navigation surface. Analytical projections help KC remember **that knowledge exists**, locate it and decide where deeper inspection is useful without hydrating the entire Markdown corpus into active context.
+
+Runtime candidate: `kopano-core/kopano/kpcb_analytics.py`
+
+Contract: `docs/swarm-ops/KPCB_PLUS_ANALYTICAL_PROJECTION_SPEC.json`
+
+Durable testimony: `KPCB_PLUS_ANALYTICAL_PROJECTION_PROTOCOL.md`
+
+Issue: `#108`
+
+Promotion remains conditional on executable tests and canonical CI; document existence alone is not POC validation.
+
+---
+
 ## Runtime Artifacts
 
 | Artifact | Path |
 |----------|------|
 | Spec | `docs/swarm-ops/KPCB_PLUS_SPEC.json` |
+| Analytical projection spec | `docs/swarm-ops/KPCB_PLUS_ANALYTICAL_PROJECTION_SPEC.json` |
 | Runtime | `kopano-core/kopano/kpcb_plus.py` |
+| Analytical runtime | `kopano-core/kopano/kpcb_analytics.py` |
+| Analytical tests | `tests/test_kpcb_analytics.py` |
 | Schematic | `Schematics/.../KPCB_PLUS_LANGUAGE_STATUS.md` |
 
 ---
 
 ## Links
 
+- [[KPCB_PLUS_ANALYTICAL_PROJECTION_PROTOCOL|KPCB+ Analytical Projection Protocol]]
 - [[THARI_MAO_STATUS|THARI MAO Status]]
 - [[KPGS_THESIS_MMAO|MMAO Core Thesis]]
 - [[KPGS_GOVERNANCE_CORE|Governance Core]]

--- a/docs/swarm-ops/KPCB_PLUS_ANALYTICAL_PROJECTION_SPEC.json
+++ b/docs/swarm-ops/KPCB_PLUS_ANALYTICAL_PROJECTION_SPEC.json
@@ -7,7 +7,11 @@
   "testimony": {
     "origin": "KPGS/GSMB/KPCB+ Markdown governance predates the user's formal study of Pandas groupby, pivot_table and heatmaps.",
     "formal_learning_role": "Data-science study supplies computational vocabulary and falsifiable operators for strengthening existing information-governance intuitions; it is not claimed as the origin of the architecture.",
-    "commandment_15": "Why the work exists must travel with what the work does so future stateless renters can investigate claims from evidence rather than reconstructing intent by guesswork."
+    "canonical_protocol": "docs/swarm-ops/TESTIMONY_PROTOCOL.md",
+    "commandment_15": "Do not manufacture the testimony you are trying to observe.",
+    "sequence": ["OBSERVE", "RETAIN", "COMPARE_RECURRENCE", "INFER", "RISK_BEING_WRONG", "VALIDATE_AGAINST_FUTURE_REALITY"],
+    "classification_before_interpret": true,
+    "classification_rule": "Preserve source/provenance and distinguish current-human testimony, historical context, telemetry, model inference and repository state. Missing classification remains UNKNOWN rather than being guessed."
   },
   "kpcb_plus_boundary": {
     "canonical_channels_unchanged": ["PP", "BP", "EP", "GP", "SP", "dotP", "IP"],
@@ -39,10 +43,13 @@
     "hot_cell != truth",
     "aggregate != source_evidence",
     "projection != mutation_permission",
-    "every_aggregate_must_trace_to_source"
+    "every_aggregate_must_trace_to_source",
+    "analytical_recurrence != manufactured_understanding"
   ],
   "record_contract": {
     "required": ["record_id", "path"],
+    "optional_source_dimensions": ["source_class", "source_reference"],
+    "source_classes": ["CURRENT_HUMAN_TESTIMONY", "HISTORICAL_CONTEXT", "TELEMETRY", "MODEL_INFERENCE", "REPOSITORY_STATE", "UNKNOWN"],
     "governed_defaults": {
       "title": "UNKNOWN",
       "depth": "UNKNOWN",
@@ -57,12 +64,12 @@
       "ecosystem": "UNKNOWN",
       "evidence_count": 0
     },
-    "rule": "Missing epistemic metadata remains UNKNOWN. The analytical layer must not manufacture negative proof."
+    "rule": "Missing epistemic or source-class metadata remains UNKNOWN. The analytical layer must not manufacture negative proof or manufacture the testimony being evaluated."
   },
   "reality_cloud_reflection": {
     "human_surface": "Markdown/KPCB+ testimony remains directly inspectable.",
     "machine_surface": "GROUP/PIVOT/ATTENTION projections are deterministic machine views over those records.",
-    "validation": "A machine projection fails governance if a human cannot trace it back to source record IDs/paths."
+    "validation": "A machine projection fails governance if a human cannot trace it back to source record IDs/paths. Analytical hypotheses remain open to later reality falsification."
   },
   "runtime": {
     "module": "kopano-core/kopano/kpcb_analytics.py",

--- a/docs/swarm-ops/KPCB_PLUS_ANALYTICAL_PROJECTION_SPEC.json
+++ b/docs/swarm-ops/KPCB_PLUS_ANALYTICAL_PROJECTION_SPEC.json
@@ -1,0 +1,86 @@
+{
+  "schema": "kpcb_plus_analytical_projection_v1",
+  "document_id": "KPCB-ANALYTICS-2026",
+  "title": "KPCB+ Analytical Projection Protocol",
+  "authority": "Schematics MAIN BRAIN / Issue #108",
+  "status": "POC_CANDIDATE",
+  "testimony": {
+    "origin": "KPGS/GSMB/KPCB+ Markdown governance predates the user's formal study of Pandas groupby, pivot_table and heatmaps.",
+    "formal_learning_role": "Data-science study supplies computational vocabulary and falsifiable operators for strengthening existing information-governance intuitions; it is not claimed as the origin of the architecture.",
+    "commandment_15": "Why the work exists must travel with what the work does so future stateless renters can investigate claims from evidence rather than reconstructing intent by guesswork."
+  },
+  "kpcb_plus_boundary": {
+    "canonical_channels_unchanged": ["PP", "BP", "EP", "GP", "SP", "dotP", "IP"],
+    "algebra": "[EP] + [BP] * [PP] + [GP] + [SP] + [.P] + [IP] = KPCB+",
+    "analytical_operators_are_channels": false,
+    "reason": "GROUP, PIVOT and ATTENTION operate over governed KPCB+/GSMB records; they do not replace the seven semantic communication channels."
+  },
+  "operators": {
+    "GROUP": {
+      "question": "What governed knowledge belongs together under selected semantic dimensions?",
+      "properties": ["deterministic", "multi-dimension", "multi-value-explodable", "provenance-preserving"]
+    },
+    "PIVOT": {
+      "question": "How does the same governed corpus look when re-projected across row and column dimensions?",
+      "aggregations": ["count", "sum"],
+      "properties": ["same-source-corpus", "cell-provenance", "non-authoritative"]
+    },
+    "ATTENTION_MATRIX": {
+      "question": "Where does evidence density, UNKNOWN testimony, contradiction, staleness or activity concentrate?",
+      "render_hint": "heatmap",
+      "properties": ["attention-only", "heatmap-ready", "no-action-permission"]
+    }
+  },
+  "epistemic_invariants": [
+    "UNKNOWN != VIOLATED",
+    "absence_of_evidence != evidence_of_absence",
+    "deep_path != low_importance",
+    "shallow_path != high_authority",
+    "hot_cell != truth",
+    "aggregate != source_evidence",
+    "projection != mutation_permission",
+    "every_aggregate_must_trace_to_source"
+  ],
+  "record_contract": {
+    "required": ["record_id", "path"],
+    "governed_defaults": {
+      "title": "UNKNOWN",
+      "depth": "UNKNOWN",
+      "canonical_index": "UNKNOWN",
+      "project": "UNKNOWN",
+      "protocol_channels": [],
+      "artifact_type": "UNKNOWN",
+      "authority": "UNKNOWN",
+      "validation_state": "UNKNOWN",
+      "testimony_state": "UNKNOWN",
+      "sprint": "UNKNOWN",
+      "ecosystem": "UNKNOWN",
+      "evidence_count": 0
+    },
+    "rule": "Missing epistemic metadata remains UNKNOWN. The analytical layer must not manufacture negative proof."
+  },
+  "reality_cloud_reflection": {
+    "human_surface": "Markdown/KPCB+ testimony remains directly inspectable.",
+    "machine_surface": "GROUP/PIVOT/ATTENTION projections are deterministic machine views over those records.",
+    "validation": "A machine projection fails governance if a human cannot trace it back to source record IDs/paths."
+  },
+  "runtime": {
+    "module": "kopano-core/kopano/kpcb_analytics.py",
+    "dependency_posture": "standard-library-only inside Introduction-to-MCP",
+    "kmec_boundary": "KMEC owns scalable Pandas/NumPy/Dask execution and may consume/produce compatible governed record contracts after this POC validates.",
+    "pka_boundary": "PKA remains responsible for epistemic admission; this analytical layer does not redefine PKA verdict law."
+  },
+  "validation": {
+    "test_file": "tests/test_kpcb_analytics.py",
+    "required_cases": [
+      "deep important artifact remains discoverable and traceable",
+      "shallow artifact receives no inferred authority",
+      "input order does not change grouping result",
+      "pivot cells preserve source record IDs",
+      "UNKNOWN remains distinct from VIOLATED",
+      "attention matrix cannot grant action permission",
+      "projection does not mutate source corpus",
+      "KPCB+ protocol channels become dimensions without inventing testimony"
+    ]
+  }
+}

--- a/kopano-core/kopano/__init__.py
+++ b/kopano-core/kopano/__init__.py
@@ -7,3 +7,8 @@ from .department_contract_aliases import install_legacy_department_aliases
 # not add authority; it ensures legacy state is governed instead of falsely
 # failing as UNKNOWN_DEPARTMENT.
 install_legacy_department_aliases()
+
+# KPCB+ governed analytical projections. These operators expose GROUP/PIVOT/
+# ATTENTION semantics over protocol/context records while preserving source
+# testimony and refusing to infer authority/action permission from aggregates.
+from .kpcb_analytics import KPCBAnalyticalCorpus, KPCBAnalyticsError  # noqa: E402,F401

--- a/kopano-core/kopano/kpcb_analytics.py
+++ b/kopano-core/kopano/kpcb_analytics.py
@@ -1,0 +1,327 @@
+"""Governed analytical operators for KPCB+ / GSMB context records.
+
+This module gives KPCB+ a lightweight analytical projection layer inspired by
+formal data-science operations such as groupby, pivot tables and heatmaps.
+It deliberately does not depend on Pandas/Dask: KMEC owns scalable statistical
+execution. KPCB+ owns protocol/context semantics and provenance preservation.
+
+Core invariants:
+- UNKNOWN is not VIOLATED.
+- filesystem depth is not authority.
+- aggregates are projections, not source truth.
+- heat/attention is not action permission.
+- every aggregate remains traceable to source record IDs/paths.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from itertools import product
+from typing import Any, Iterable, Mapping, Sequence
+
+from .kpcb_plus import KPCBBlock
+
+
+UNKNOWN = "UNKNOWN"
+
+
+class KPCBAnalyticsError(ValueError):
+    """Raised when an analytical projection request is structurally invalid."""
+
+
+class KPCBAnalyticalCorpus:
+    """Immutable-in-practice corpus of governed KPCB+/Markdown observations.
+
+    Records are copied on admission and on output so analytical projections do
+    not mutate source testimony. A record MUST have a stable ``record_id`` and
+    ``path``. Missing epistemic fields are preserved as ``UNKNOWN`` rather than
+    being silently interpreted as failure.
+    """
+
+    def __init__(self, records: Iterable[Mapping[str, Any]]):
+        normalized = [self._normalize_record(record) for record in records]
+        ids = [record["record_id"] for record in normalized]
+        if len(ids) != len(set(ids)):
+            raise KPCBAnalyticsError("record_id values must be unique")
+        self._records = tuple(normalized)
+
+    @classmethod
+    def from_kpcb_blocks(
+        cls,
+        blocks: Iterable[Mapping[str, Any]],
+    ) -> "KPCBAnalyticalCorpus":
+        """Build governed observations from raw KPCB+ blocks.
+
+        Each item must provide ``record_id``, ``path`` and ``raw``. Additional
+        metadata is retained. KPCB+ parsing supplies hierarchy/title,
+        ``protocol_channels`` and compiler validation state. Testimony state is
+        NEVER inferred from channel presence and defaults to UNKNOWN unless the
+        caller explicitly supplies it.
+        """
+        records: list[dict[str, Any]] = []
+        for item in blocks:
+            if "raw" not in item:
+                raise KPCBAnalyticsError("KPCB block input requires raw")
+            block = KPCBBlock(str(item["raw"]))
+            validation = block.validate()
+            record = dict(item)
+            record.pop("raw", None)
+            record.setdefault("title", block.hierarchy or "UNNAMED")
+            record.setdefault("keynote", block.keynote)
+            record.setdefault("protocol_channels", list(validation["channels"]))
+            record.setdefault("validation_state", validation["verdict"])
+            record.setdefault("testimony_state", UNKNOWN)
+            records.append(record)
+        return cls(records)
+
+    @property
+    def records(self) -> tuple[dict[str, Any], ...]:
+        return tuple(deepcopy(record) for record in self._records)
+
+    def group_by(self, *dimensions: str) -> dict[str, Any]:
+        """Group governed records by one or more semantic dimensions.
+
+        Sequence-valued dimensions (for example ``protocol_channels``) are
+        exploded so one record may truthfully participate in multiple groups.
+        Group order and member order are deterministic regardless of input
+        record order.
+        """
+        dims = self._require_dimensions(dimensions)
+        grouped: dict[tuple[Any, ...], list[dict[str, Any]]] = {}
+
+        for record in self._records:
+            value_sets = [self._dimension_values(record, dim) for dim in dims]
+            for key in product(*value_sets):
+                grouped.setdefault(tuple(key), []).append(record)
+
+        groups = []
+        for key in sorted(grouped, key=self._sort_key):
+            members = sorted(grouped[key], key=lambda item: str(item["record_id"]))
+            groups.append(
+                {
+                    "key": {dim: value for dim, value in zip(dims, key)},
+                    "count": len(members),
+                    "record_ids": [member["record_id"] for member in members],
+                    "paths": [member["path"] for member in members],
+                }
+            )
+
+        return {
+            "operation": "GROUP",
+            "dimensions": list(dims),
+            "groups": groups,
+            "claims": self._non_authoritative_claims(),
+        }
+
+    def pivot(
+        self,
+        row_dimension: str,
+        column_dimension: str,
+        *,
+        value: str | None = None,
+        aggregation: str = "count",
+    ) -> dict[str, Any]:
+        """Re-project the same corpus across row/column dimensions.
+
+        Supported aggregations:
+        - ``count``: number of source records contributing to the cell.
+        - ``sum``: numeric sum of ``value`` across contributing source records.
+
+        Every cell preserves source record IDs and paths.
+        """
+        self._require_dimensions((row_dimension, column_dimension))
+        if aggregation not in {"count", "sum"}:
+            raise KPCBAnalyticsError("aggregation must be 'count' or 'sum'")
+        if aggregation == "sum" and not value:
+            raise KPCBAnalyticsError("sum aggregation requires value")
+
+        cells: dict[tuple[Any, Any], dict[str, Any]] = {}
+        row_values: set[Any] = set()
+        column_values: set[Any] = set()
+
+        for record in self._records:
+            rows = self._dimension_values(record, row_dimension)
+            columns = self._dimension_values(record, column_dimension)
+            for row_value, column_value in product(rows, columns):
+                row_values.add(row_value)
+                column_values.add(column_value)
+                key = (row_value, column_value)
+                cell = cells.setdefault(
+                    key,
+                    {"value": 0, "record_ids": [], "paths": []},
+                )
+                if aggregation == "count":
+                    increment = 1
+                else:
+                    raw_value = record.get(value, 0)
+                    if raw_value in (None, UNKNOWN):
+                        increment = 0
+                    elif isinstance(raw_value, (int, float)) and not isinstance(raw_value, bool):
+                        increment = raw_value
+                    else:
+                        raise KPCBAnalyticsError(
+                            f"sum value {value!r} must be numeric or missing; "
+                            f"record {record['record_id']!r} supplied {raw_value!r}"
+                        )
+                cell["value"] += increment
+                cell["record_ids"].append(record["record_id"])
+                cell["paths"].append(record["path"])
+
+        ordered_rows = sorted(row_values, key=self._sort_atom)
+        ordered_columns = sorted(column_values, key=self._sort_atom)
+        matrix = []
+        provenance = []
+        for row_value in ordered_rows:
+            matrix_row = []
+            provenance_row = []
+            for column_value in ordered_columns:
+                cell = cells.get((row_value, column_value))
+                if cell is None:
+                    matrix_row.append(0)
+                    provenance_row.append({"record_ids": [], "paths": []})
+                else:
+                    matrix_row.append(cell["value"])
+                    provenance_row.append(
+                        {
+                            "record_ids": sorted(cell["record_ids"], key=str),
+                            "paths": sorted(cell["paths"], key=str),
+                        }
+                    )
+            matrix.append(matrix_row)
+            provenance.append(provenance_row)
+
+        return {
+            "operation": "PIVOT",
+            "row_dimension": row_dimension,
+            "column_dimension": column_dimension,
+            "aggregation": aggregation,
+            "value_field": value,
+            "row_labels": ordered_rows,
+            "column_labels": ordered_columns,
+            "matrix": matrix,
+            "provenance": provenance,
+            "claims": self._non_authoritative_claims(),
+        }
+
+    def attention_matrix(
+        self,
+        row_dimension: str,
+        column_dimension: str,
+        *,
+        value: str | None = None,
+        aggregation: str = "count",
+        reason: str = "attention_density",
+    ) -> dict[str, Any]:
+        """Emit heatmap-ready data without granting authority or action.
+
+        This is deliberately a data matrix, not a renderer. UI layers may map
+        numeric intensity to color, but the matrix itself carries explicit
+        governance claims preventing visual intensity from becoming truth.
+        """
+        projection = self.pivot(
+            row_dimension,
+            column_dimension,
+            value=value,
+            aggregation=aggregation,
+        )
+        return {
+            **projection,
+            "operation": "ATTENTION_MATRIX",
+            "reason": reason,
+            "render_hint": "heatmap",
+            "claims": {
+                **self._non_authoritative_claims(),
+                "attention_only": True,
+                "action_permission": False,
+            },
+        }
+
+    def trace_cell(
+        self,
+        projection: Mapping[str, Any],
+        row_label: Any,
+        column_label: Any,
+    ) -> dict[str, Any]:
+        """Recover source records that contributed to one pivot/heatmap cell."""
+        rows = list(projection.get("row_labels", []))
+        columns = list(projection.get("column_labels", []))
+        try:
+            row_index = rows.index(row_label)
+            column_index = columns.index(column_label)
+        except ValueError as exc:
+            raise KPCBAnalyticsError("row/column label is not present in projection") from exc
+
+        provenance = projection.get("provenance")
+        if not isinstance(provenance, Sequence):
+            raise KPCBAnalyticsError("projection has no provenance matrix")
+        cell = provenance[row_index][column_index]
+        ids = set(cell.get("record_ids", []))
+        records = [deepcopy(record) for record in self._records if record["record_id"] in ids]
+        records.sort(key=lambda record: str(record["record_id"]))
+        return {
+            "row_label": row_label,
+            "column_label": column_label,
+            "record_ids": [record["record_id"] for record in records],
+            "paths": [record["path"] for record in records],
+            "records": records,
+        }
+
+    @staticmethod
+    def _normalize_record(record: Mapping[str, Any]) -> dict[str, Any]:
+        if not isinstance(record, Mapping):
+            raise KPCBAnalyticsError("records must be mappings")
+        if not record.get("record_id"):
+            raise KPCBAnalyticsError("record_id is required")
+        if not record.get("path"):
+            raise KPCBAnalyticsError("path is required")
+
+        normalized = deepcopy(dict(record))
+        normalized.setdefault("title", UNKNOWN)
+        normalized.setdefault("depth", UNKNOWN)
+        normalized.setdefault("canonical_index", UNKNOWN)
+        normalized.setdefault("project", UNKNOWN)
+        normalized.setdefault("protocol_channels", [])
+        normalized.setdefault("artifact_type", UNKNOWN)
+        normalized.setdefault("authority", UNKNOWN)
+        normalized.setdefault("validation_state", UNKNOWN)
+        normalized.setdefault("testimony_state", UNKNOWN)
+        normalized.setdefault("sprint", UNKNOWN)
+        normalized.setdefault("ecosystem", UNKNOWN)
+        normalized.setdefault("evidence_count", 0)
+        return normalized
+
+    def _require_dimensions(self, dimensions: Sequence[str]) -> tuple[str, ...]:
+        dims = tuple(dimensions)
+        if not dims:
+            raise KPCBAnalyticsError("at least one dimension is required")
+        for dim in dims:
+            if not isinstance(dim, str) or not dim.strip():
+                raise KPCBAnalyticsError("dimensions must be non-empty strings")
+        return dims
+
+    @staticmethod
+    def _dimension_values(record: Mapping[str, Any], dimension: str) -> tuple[Any, ...]:
+        value = record.get(dimension, UNKNOWN)
+        if value is None:
+            return (UNKNOWN,)
+        if isinstance(value, (list, tuple, set, frozenset)):
+            values = tuple(value)
+            return values if values else (UNKNOWN,)
+        return (value,)
+
+    @classmethod
+    def _sort_key(cls, key: tuple[Any, ...]) -> tuple[str, ...]:
+        return tuple(cls._sort_atom(value) for value in key)
+
+    @staticmethod
+    def _sort_atom(value: Any) -> str:
+        return f"{type(value).__name__}:{value!s}"
+
+    @staticmethod
+    def _non_authoritative_claims() -> dict[str, bool]:
+        return {
+            "source_truth_replaced": False,
+            "causal": False,
+            "authority_inferred": False,
+            "action_permission": False,
+        }

--- a/tests/test_kpcb_analytics.py
+++ b/tests/test_kpcb_analytics.py
@@ -146,6 +146,34 @@ def test_missing_testimony_stays_unknown_not_violated():
     assert record["canonical_index"] == UNKNOWN
 
 
+def test_classification_before_interpret_keeps_human_and_model_sources_distinct():
+    corpus = KPCBAnalyticalCorpus(
+        [
+            {
+                "record_id": "human-claim",
+                "path": "testimony/human.md",
+                "project": "A",
+                "testimony_state": "SATISFIED",
+                "source_class": "CURRENT_HUMAN_TESTIMONY",
+            },
+            {
+                "record_id": "model-claim",
+                "path": "inference/model.md",
+                "project": "A",
+                "testimony_state": "SATISFIED",
+                "source_class": "MODEL_INFERENCE",
+            },
+        ]
+    )
+
+    grouped = corpus.group_by("source_class", "testimony_state")
+    keys = [group["key"] for group in grouped["groups"]]
+
+    assert {"source_class": "CURRENT_HUMAN_TESTIMONY", "testimony_state": "SATISFIED"} in keys
+    assert {"source_class": "MODEL_INFERENCE", "testimony_state": "SATISFIED"} in keys
+    assert len(grouped["groups"]) == 2
+
+
 def test_pivot_reprojects_same_corpus_and_preserves_cell_provenance(gsm_b_records):
     corpus = KPCBAnalyticalCorpus(gsm_b_records)
     pivot = corpus.pivot("project", "testimony_state")

--- a/tests/test_kpcb_analytics.py
+++ b/tests/test_kpcb_analytics.py
@@ -1,0 +1,245 @@
+"""POC tests for KPCB+ governed analytical projection operators.
+
+Issue #108 testimony boundary:
+formal data-science vocabulary strengthens existing GSMB/KPCB+ governance;
+it does not replace source testimony or promote aggregates into authority.
+"""
+
+import os
+import sys
+from copy import deepcopy
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "kopano-core"))
+
+from kopano.kpcb_analytics import (  # noqa: E402
+    KPCBAnalyticalCorpus,
+    KPCBAnalyticsError,
+    UNKNOWN,
+)
+
+
+@pytest.fixture
+def gsm_b_records():
+    return [
+        {
+            "record_id": "canonical-home",
+            "path": "Schematics/00-Home/00-Home - Index.md",
+            "depth": 2,
+            "title": "Home Index",
+            "canonical_index": True,
+            "project": "GSMB",
+            "protocol_channels": ["BP", "PP"],
+            "artifact_type": "INDEX",
+            "authority": "CANONICAL",
+            "validation_state": "POC_VALIDATED",
+            "testimony_state": "SATISFIED",
+            "sprint": "BOOT",
+            "ecosystem": "KC",
+            "evidence_count": 8,
+        },
+        {
+            "record_id": "deep-three-month-receipt",
+            "path": "Schematics/03-Architecture/projects/new/sprint/phase-3/final/POC_RECEIPT.md",
+            "depth": 8,
+            "title": "Three Month Sprint Final Receipt",
+            "canonical_index": False,
+            "project": "Project-New",
+            "protocol_channels": ["BP", "dotP", "SP"],
+            "artifact_type": "POC_RECEIPT",
+            "authority": "PROJECT_EVIDENCE",
+            "validation_state": "POC_VALIDATED",
+            "testimony_state": "SATISFIED",
+            "sprint": "S3",
+            "ecosystem": "KC",
+            "evidence_count": 42,
+        },
+        {
+            "record_id": "deep-unknown",
+            "path": "Schematics/03-Architecture/projects/new/sprint/phase-3/questions/open.md",
+            "depth": 7,
+            "title": "Open Investigation",
+            "canonical_index": False,
+            "project": "Project-New",
+            "protocol_channels": ["PP", "EP"],
+            "artifact_type": "INVESTIGATION",
+            "authority": "WORKING",
+            "validation_state": "UNKNOWN",
+            "testimony_state": "UNKNOWN",
+            "sprint": "S3",
+            "ecosystem": "KC",
+            "evidence_count": 1,
+        },
+        {
+            "record_id": "shallow-random-note",
+            "path": "Schematics/random.md",
+            "depth": 1,
+            "title": "Random Note",
+            "canonical_index": False,
+            "project": "GSMB",
+            "protocol_channels": ["PP"],
+            "artifact_type": "NOTE",
+            "authority": "UNKNOWN",
+            "validation_state": "UNKNOWN",
+            "testimony_state": "UNKNOWN",
+            "sprint": "UNKNOWN",
+            "ecosystem": "KC",
+            "evidence_count": 0,
+        },
+        {
+            "record_id": "explicit-violation",
+            "path": "Schematics/11-AI HALLUCINATION - CRITICAL/Incidents/example.md",
+            "depth": 3,
+            "title": "Violation Witness",
+            "canonical_index": False,
+            "project": "GSMB",
+            "protocol_channels": ["BP", "SP", "dotP"],
+            "artifact_type": "INCIDENT",
+            "authority": "TESTIMONY",
+            "validation_state": "FOC_DETECTED",
+            "testimony_state": "VIOLATED",
+            "sprint": "AUDIT",
+            "ecosystem": "KC",
+            "evidence_count": 5,
+        },
+    ]
+
+
+def test_grouping_is_deterministic_and_depth_does_not_hide_important_record(gsm_b_records):
+    forward = KPCBAnalyticalCorpus(gsm_b_records).group_by("project", "testimony_state")
+    reverse = KPCBAnalyticalCorpus(reversed(gsm_b_records)).group_by("project", "testimony_state")
+
+    assert forward == reverse
+    project_group = next(
+        group
+        for group in forward["groups"]
+        if group["key"] == {"project": "Project-New", "testimony_state": "SATISFIED"}
+    )
+    assert "deep-three-month-receipt" in project_group["record_ids"]
+    assert any("POC_RECEIPT.md" in path for path in project_group["paths"])
+
+
+def test_shallow_path_does_not_infer_authority(gsm_b_records):
+    corpus = KPCBAnalyticalCorpus(gsm_b_records)
+    random_note = next(record for record in corpus.records if record["record_id"] == "shallow-random-note")
+
+    assert random_note["depth"] == 1
+    assert random_note["authority"] == "UNKNOWN"
+    assert random_note["canonical_index"] is False
+
+
+def test_missing_testimony_stays_unknown_not_violated():
+    corpus = KPCBAnalyticalCorpus(
+        [
+            {
+                "record_id": "missing-testimony",
+                "path": "Schematics/project/unfinished.md",
+                "project": "A",
+            }
+        ]
+    )
+
+    record = corpus.records[0]
+    assert record["testimony_state"] == UNKNOWN
+    assert record["testimony_state"] != "VIOLATED"
+    assert record["canonical_index"] == UNKNOWN
+
+
+def test_pivot_reprojects_same_corpus_and_preserves_cell_provenance(gsm_b_records):
+    corpus = KPCBAnalyticalCorpus(gsm_b_records)
+    pivot = corpus.pivot("project", "testimony_state")
+
+    assert pivot["operation"] == "PIVOT"
+    assert pivot["claims"]["source_truth_replaced"] is False
+    assert pivot["claims"]["action_permission"] is False
+
+    trace = corpus.trace_cell(pivot, "Project-New", "SATISFIED")
+    assert trace["record_ids"] == ["deep-three-month-receipt"]
+    assert trace["records"][0]["evidence_count"] == 42
+
+
+def test_pivot_can_sum_evidence_without_losing_source_trace(gsm_b_records):
+    corpus = KPCBAnalyticalCorpus(gsm_b_records)
+    pivot = corpus.pivot(
+        "project",
+        "testimony_state",
+        value="evidence_count",
+        aggregation="sum",
+    )
+    project_index = pivot["row_labels"].index("Project-New")
+    satisfied_index = pivot["column_labels"].index("SATISFIED")
+
+    assert pivot["matrix"][project_index][satisfied_index] == 42
+    assert pivot["provenance"][project_index][satisfied_index]["record_ids"] == [
+        "deep-three-month-receipt"
+    ]
+
+
+def test_attention_matrix_is_heatmap_ready_but_never_permission(gsm_b_records):
+    corpus = KPCBAnalyticalCorpus(gsm_b_records)
+    heat = corpus.attention_matrix("project", "testimony_state", reason="unknown_testimony_density")
+
+    assert heat["operation"] == "ATTENTION_MATRIX"
+    assert heat["render_hint"] == "heatmap"
+    assert heat["claims"]["attention_only"] is True
+    assert heat["claims"]["action_permission"] is False
+    assert heat["claims"]["authority_inferred"] is False
+
+
+def test_protocol_channel_dimension_explodes_without_erasing_record_identity(gsm_b_records):
+    corpus = KPCBAnalyticalCorpus(gsm_b_records)
+    grouped = corpus.group_by("protocol_channels")
+
+    dotp = next(group for group in grouped["groups"] if group["key"] == {"protocol_channels": "dotP"})
+    assert dotp["record_ids"] == ["deep-three-month-receipt", "explicit-violation"]
+
+
+def test_analytical_operations_do_not_mutate_source_records(gsm_b_records):
+    source = deepcopy(gsm_b_records)
+    corpus = KPCBAnalyticalCorpus(gsm_b_records)
+
+    corpus.group_by("project")
+    corpus.pivot("project", "testimony_state")
+    corpus.attention_matrix("project", "validation_state")
+
+    assert gsm_b_records == source
+
+
+def test_kpcb_blocks_become_analytical_records_without_inventing_testimony():
+    corpus = KPCBAnalyticalCorpus.from_kpcb_blocks(
+        [
+            {
+                "record_id": "kpcb-1",
+                "path": "Schematics/project/decision.kpcb.md",
+                "project": "Project-K",
+                "raw": """
+[Project-K] {decide}
+<Why this decision exists>
+(Understanding: inspect evidence before action)
+💬PP: Analyze the governed corpus
+☄️BP: [hierarchy: corpus -> projection]
+🥶EP: 🔬->KC_validate
+→ TARGET: Python 3.12
+→ 4Ws: WHO=kc | WHAT=projection | WHERE=gsmb | WHY=knowing
+""",
+            }
+        ]
+    )
+
+    record = corpus.records[0]
+    assert record["title"] == "Project-K"
+    assert set(record["protocol_channels"]) >= {"PP", "BP", "EP"}
+    assert record["validation_state"] == "POC_VALIDATED"
+    assert record["testimony_state"] == "UNKNOWN"
+
+
+def test_invalid_requests_fail_closed(gsm_b_records):
+    corpus = KPCBAnalyticalCorpus(gsm_b_records)
+
+    with pytest.raises(KPCBAnalyticsError):
+        corpus.group_by()
+    with pytest.raises(KPCBAnalyticsError):
+        corpus.pivot("project", "testimony_state", aggregation="sum")
+    with pytest.raises(KPCBAnalyticsError):
+        KPCBAnalyticalCorpus([{"record_id": "missing-path"}])


### PR DESCRIPTION
Closes #108 when validated and merged.

## Commandment 15 testimony

This PR does not claim the architecture originated from learning Pandas. GSMB/KPCB+ already governed knowledge through Markdown, canonical indexes, protocol channels, KC Ledger/testimony and selective context reconstruction. Formal study of `groupby`, pivot tables and heatmaps supplies executable analytical vocabulary that can now challenge and strengthen that pre-existing design.

Canonical Testimony Protocol authority is `docs/swarm-ops/TESTIMONY_PROTOCOL.md`: **do not manufacture the testimony you are trying to observe.** The analytical layer therefore follows `OBSERVE → RETAIN → COMPARE RECURRENCE → INFER → RISK BEING WRONG → VALIDATE AGAINST FUTURE REALITY`, with classification-before-interpret and preserved provenance. Human testimony, historical context, telemetry, model inference and repository state must remain distinguishable where classified; missing classification remains UNKNOWN.

## KPCB+ change

The canonical seven channels remain unchanged:

`PP · BP · EP · GP · SP · .P · IP`

This PR adds **analytical operators over governed protocol/context records**:

- `GROUP` — deterministic semantic belonging;
- `PIVOT` — re-project the same corpus while preserving cell provenance;
- `ATTENTION_MATRIX` — heatmap-ready attention data that cannot grant authority/action permission.

## Runtime

Adds `kopano-core/kopano/kpcb_analytics.py` with:

- `KPCBAnalyticalCorpus`;
- admission normalization preserving missing epistemic metadata as `UNKNOWN`;
- multi-dimensional deterministic grouping;
- multi-value protocol-channel explosion;
- count/sum pivot matrices;
- per-cell source `record_id` + `path` provenance;
- heatmap-ready attention matrices;
- cell-to-source trace recovery;
- raw KPCB+ block admission through the existing `KPCBBlock` parser;
- explicit non-authoritative claims (`causal=false`, `authority_inferred=false`, `action_permission=false`).

The runtime stays standard-library-only. Pandas/NumPy/Dask remain KMEC responsibilities.

## Falsification tests

`tests/test_kpcb_analytics.py` proves:

- deeply nested three-month-sprint evidence survives analytical projection;
- shallow path depth does not infer authority;
- missing testimony remains `UNKNOWN`, not `VIOLATED`;
- grouping is invariant to input order;
- current-human testimony and model inference remain distinct source classes before interpretation;
- pivot cells preserve source provenance;
- evidence-count sums remain traceable;
- heatmap/attention output cannot grant action permission;
- protocol-channel dimensions can be exploded without erasing identity;
- analytical operations do not mutate the source corpus;
- KPCB+ parsing supplies protocol/validation dimensions without inventing testimony;
- structurally invalid operations fail closed.

## Durable governance

Adds:

- `docs/swarm-ops/KPCB_PLUS_ANALYTICAL_PROJECTION_SPEC.json`
- `Schematics/21-KOPANO-PHU GOVERNACE SYSTEMS/MAIN-BRAIN/KPCB_PLUS_ANALYTICAL_PROJECTION_PROTOCOL.md`
- analytical projection status in `KPCB_PLUS_LANGUAGE_STATUS.md`

## Invariants

```text
UNKNOWN != VIOLATED
absence of evidence != evidence of absence
deep_path != low_importance
shallow_path != high_authority
hot_cell != truth
aggregate != source_evidence
projection != mutation_permission
analytical recurrence != manufactured understanding
```

## Boundaries

- Canonical GSMB indexes remain the boot/navigation authority.
- KPCB+ owns protocol/context analytical semantics.
- KMEC owns scalable Python data-science execution.
- PKA owns epistemic admission.
- Attention matrices are not governance decisions.

## Downstream

KMEC issue #13 is seeded as the Pandas/Dask adapter lane and remains HOLD until this upstream contract validates.

## POC gate

Do not merge on conceptual agreement alone. Require canonical CI/test evidence and exact-head review receipts.