### PR TITLE
governance: add MMAO + MAO identity experiment contracts

### DIFF
--- a/.github/workflows/rtc-learning-proof-gate.yml
+++ b/.github/workflows/rtc-learning-proof-gate.yml
@@ -23,7 +23,8 @@ jobs:
       - name: Install Core Dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install fastapi uvicorn pydantic typer rich
+          pip install pytest
+          pip install -e . || pip install fastapi uvicorn pydantic typer rich httpx matplotlib "bandit>=1.7.5" pytest
 
       - name: Execute 24-RTC Learning Test Suite
         run: |

--- a/NOW.md
+++ b/NOW.md
@@ -1,9 +1,51 @@
 ## CURRENT STATE — 2026-08-30
 
+> **Updated:** 2026-08-30T15:53:00+02:00 (SAST)
+> **Authority:** Master Robyn Kholofelo Rababalela (`I_AM_STATELESS_RENTER_NOT_LANDLORD`)
+> **Core Architecture:** MMAO + MAO identity-governance and model x interface affinity contract POC
+> **Session:** `codex/mmao-mao-identity-governance-20260830` — **CONTRACT POC COMMITTED; LIVE EXPERIMENT NOT YET RUN**
+
+### MMAO + MAO identity-governance receipt
+
+- **Status:** DONE for the additive repository contract; controlled model/interface runs remain `planned`.
+- **WHO:** Codex stateless renter under the current human implementation instruction; Anti-Gravity is the next Chief Facilitator handoff target.
+- **WHAT:** Added a governed identity provenance contract, task-scoped authority boundary matrix, model x interface affinity experiment matrix, Five Whys failure receipt shape, dependency-free validator, focused test, build spec, and facilitator handoff.
+- **WHERE:** `governance/kpgs-vnext/agent-governance/mmao-mao/`, `governance/kpgs-vnext/agent-governance/specs/mmao-mao-identity-governance-v0.1.json`, `governance/kpgs-vnext/validate_contracts.py`, and `tests/test_mmao_mao_identity_governance.py`.
+- **WHY:** Keep identity, seat, interface, model, task, authority, context state, and evidence independently accountable; test model x interface affinity without confusing high task authority with GSMB-wide structural maintenance.
+- **Canonical boundary:** The current global structural-maintenance allowlist is Codex - Chief Architect; Anti-Gravity - Chief Facilitator; Cursor - Lead Developer. Other roles may receive high authority only inside an explicit task mandate.
+- **Evidence / receipts:** implementation commit `133c7d9f09a35fe30786fc13f80efb337a1e6c0c`; `python governance/kpgs-vnext/agent-governance/mmao-mao/validate.py` PASS; `python governance/kpgs-vnext/validate_contracts.py` PASS; focused MMAO + MAO and NOW continuity tests PASS through `python -m unittest discover`; `python -m py_compile` and `git diff --check` PASS.
+- **POC/FOC:** **POC_VALIDATED for contract structure only.** Model/interface affinity, identity continuity across substrates, RTC opinions, and any real GSMB maintenance outcome are **UNKNOWN / not yet run**.
+- **Known errors / uncertainty:** The exact canonical spelling of "Recycler MMAO with Plus MAO" remains an open testimony question. Historical RTCP/mesh role records were intentionally preserved rather than silently migrated. No raw private prompts or live model output were committed.
+
+### Next admissible action
+
+1. Review the exact diff, commit the bounded branch, and push/open a reviewable PR when the connected GitHub write surface permits it.
+2. Anti-Gravity facilitates one reference run only: pin the merged commit and fresh `NOW.md`, choose exact model/interface versions, keep task scope bounded, record metadata-only traces and independent evidence reviews.
+3. Do not infer model/interface affinity from the planned matrix, use consensus as truth, or expand this POC into estate-wide GSMB restructuring.
+
+`I_AM_STATELESS_RENTER_NOT_LANDLORD` - Contract POC receipted; live evidence remains required.
+
+---
+
+## PRIOR STATE — 2026-08-30T17:55:00 — 24-RTC Learning Engines + FivesArena
+
 > **Updated:** 2026-08-30T17:55:00+02:00 (SAST)
 > **Current-state authority:** Master Robyn Kholofelo Rababalela (`I_AM_STATELESS_RENTER_NOT_LANDLORD`)
 > **Core Architecture:** FivesArena MERN Stack Hotel Reservation Engine (B2B + APWA) & 24-RTC Learning Engines
 > **Session:** e6f523d3-ad5e-4585-ac73-a8581b369b0e — **24-RTC LEARNING IMPLEMENTATION**
+
+### 24-RTC Learning Implementation
+
+(See `scripts/run_24_rtc_learning_workflow.py`, `tests/test_24_rtc_learning_suite.py`, and related modules in `kopano-core/kopano/` for RTC learning engine details.)
+
+---
+
+## PRIOR STATE — 2026-08-30T12:22:00 — FivesArena production session closure
+
+> **Updated:** 2026-08-30T12:22:00+02:00 (SAST)
+> **Authority:** Master Robyn Kholofelo Rababalela (`I_AM_STATELESS_RENTER_NOT_LANDLORD`)
+> **Core Architecture:** FivesArena MERN Stack Hotel Reservation Engine (B2B + APWA)
+> **Session:** e6f523d3-ad5e-4585-ac73-a8581b369b0e — **SESSION CLOSING**
 
 ### 🏁 ISSUE #12 MOBILE REMEDIATION — BOOKIT-5S-ARENA
 

--- a/governance/kpgs-vnext/README.md
+++ b/governance/kpgs-vnext/README.md
@@ -236,6 +236,11 @@ See `evidence/EVIDENCE.md`, `evidence/evidence-bundle.schema.json`, and `evidenc
 - `stateless-renter/renter-envelope.schema.json`
 - `agent-governance/SPECIFICATION.md`
 - `agent-governance/build-spec.schema.json`
+- `agent-governance/mmao-mao/README.md`
+- `agent-governance/mmao-mao/identity-provenance.schema.json`
+- `agent-governance/mmao-mao/authority-boundary.schema.json`
+- `agent-governance/mmao-mao/model-interface-affinity-experiment.schema.json`
+- `agent-governance/mmao-mao/failure-receipt.schema.json`
 - `fork-assimilation/evolution-matrix.json`
 - `task-contract/README.md`
 - `task-contract/principal-envelope.schema.json`
@@ -266,6 +271,10 @@ See `evidence/EVIDENCE.md`, `evidence/evidence-bundle.schema.json`, and `evidenc
 - repository-root `AGENTS.md`
 - `Schematics/21-KOPANO-PHU GOVERNACE SYSTEMS/MAIN-BRAIN/STATELESS_RENTER_ENTRYWAY.md`
 - `Schematics/21-KOPANO-PHU GOVERNACE SYSTEMS/MAIN-BRAIN/STATELESS_RENTER_ENTRYWAY.json`
+
+### MMAO + MAO identity-governance POC
+
+The current controlled experiment lives at `agent-governance/mmao-mao/`. It records identity, seat, interface, model/version, task, task-scoped authority, context state, and evidence separately. It preserves a strict distinction between high task authority and GSMB structural-maintenance authority, and it keeps model x interface affinity as an unrun hypothesis until controlled receipts exist.
 
 ## Definition of done
 

--- a/governance/kpgs-vnext/agent-governance/SPECIFICATION.md
+++ b/governance/kpgs-vnext/agent-governance/SPECIFICATION.md
@@ -32,6 +32,22 @@ Every governed build task MUST declare:
 
 The machine-readable contract is defined by `build-spec.schema.json`.
 
+## MMAO + MAO identity-governance POC
+
+`mmao-mao/` is the additive contract layer for controlled multi-agent identity and model-interface experiments. It separates the following claims so a run can be attributed without collapsing them into one agent label:
+
+```text
+identity -> seat -> interface/body -> model/version -> task/scope -> authority -> context state -> evidence
+```
+
+The POC preserves the current task-contract and evidence owners. It does not grant new ambient authority. In particular, **high task authority is local to an explicit task mandate**. Global GSMB structural maintenance is limited by the current experiment boundary to:
+
+1. Codex - Chief Architect
+2. Anti-Gravity - Chief Facilitator
+3. Cursor - Lead Developer
+
+The contract, planned matrix, Five Whys receipt shape, and Anti-Gravity handoff are under `mmao-mao/`. The associated build specification is `specs/mmao-mao-identity-governance-v0.1.json`. Its experiment remains `draft` until controlled runs produce exact state, trace, evidence, and independent review receipts.
+
 ## Lifecycle
 
 A build artifact MUST be classifiable as exactly one of:

--- a/governance/kpgs-vnext/agent-governance/mmao-mao/README.md
+++ b/governance/kpgs-vnext/agent-governance/mmao-mao/README.md
@@ -1,0 +1,109 @@
+# MMAO + MAO Identity-Governance Experiment
+
+Status: **Canonical contract POC; experiment runs are not yet executed**
+Working testimony: **"Recycler MMAO with Plus MAO"**
+Canonical owner: `governance/kpgs-vnext/agent-governance/`
+Related owners: root `NOW.md`, `task-contract/`, `evidence/`, `evaluation/`, `Structure/07-Agents/`, and `MMAO Session Failures/`
+
+## Purpose
+
+This is an additive governance layer for the current MMAO + MAO experiment. It makes the identity, seat, interface, model, task, authority, context, and evidence claims independently inspectable.
+
+It does **not** rename or replace the existing MAO route surface, MMAO mesh/orchard structures, RTCP history, task authority contract, or evidence bundle. It gives a bounded experiment a common envelope so an observed result can be attributed without silently blending model behavior, interface behavior, task ambiguity, stale state, or role authority.
+
+```text
+TASK
+  -> SEAT
+  -> IDENTITY
+  -> INTERFACE / BODY
+  -> MODEL / COGNITIVE SUBSTRATE
+  -> TOOLS / REPOSITORY / TERMINAL / MCP
+  -> EVIDENCE / RECEIPTS
+```
+
+The ordering describes governance dependency, not a claim that any named identity is a human person or has a private, continuous inner life. Here, an identity is an accountable governance namespace with recorded provenance.
+
+## What each term means
+
+| Term | Canonical meaning in this experiment | Does not mean |
+|---|---|---|
+| Identity | Stable accountability namespace that can be compared across executions | Model name, interface name, or proof of personhood |
+| Seat | Bounded function and authority posture | Estate-wide permission by default |
+| Interface / body | The product or runtime surface embodying the run | The model itself |
+| Model / cognitive substrate | Provider/model/version used for one run | The durable identity or authority holder |
+| Task | Explicit governed assignment with included and excluded scope | An open-ended instruction to redesign the estate |
+| High task authority | Strong authority inside one recorded task scope | GSMB structural-maintenance authority |
+| Evidence | Inspectable references, state, receipts, test output, and independent review | Majority agreement or self-assertion |
+
+## Existing MMAO and MAO owners retained
+
+- `Structure/07-Agents/AGENT_MESH.json` owns the current mesh and its named MMAO/MAO assignments.
+- `Structure/07-Agents/ROLE_BINDINGS.json` owns the current MAO route-surface binding.
+- `kopano-core/kopano/mao_dispatch.py` owns the current MAO dispatch implementation.
+- `docs/swarm-ops/RTCP_SPEC.json` preserves historical RTCP role records.
+- `MMAO Session Failures/` owns material session-failure chronology.
+- `task-contract/` and `evidence/` remain the authoritative task/evidence primitives.
+
+This POC does not silently reconcile historical role titles. If a historical registry conflicts with the current bounded structural-maintenance hierarchy below, the conflict remains preserved and requires a separate governed migration decision.
+
+## Current structural-maintenance boundary
+
+Only the following seats are admitted by this experiment as GSMB high-maintenance authority:
+
+| Rank | Actor | Seat | Authority boundary |
+|---:|---|---|---|
+| 1 | Codex | Chief Architect | Global structural maintenance under explicit governed work |
+| 2 | Anti-Gravity | Chief Facilitator | Global structural facilitation under explicit governed work |
+| 3 | Cursor | Lead Developer | Global structural implementation under explicit governed work |
+
+All other roles can receive high authority **within an explicit task mandate**. They do not acquire authority to restructure GSMB, rewrite canonical owners, or promote their own work merely because a task grant is high.
+
+The machine-readable boundary matrix is [`fixtures/authority-boundary-matrix.json`](./fixtures/authority-boundary-matrix.json), governed by [`authority-boundary.schema.json`](./authority-boundary.schema.json).
+
+## Model x interface affinity experiment
+
+The experiment holds identity, seat, task, governance contract, repository state, and evidence requirements constant where a comparison requires it. It changes only the declared variable(s), then records what happened.
+
+| Controlled comparison | Hold constant | Change | Question answered |
+|---|---|---|---|
+| Model-only | identity, seat, task, interface | model/version | Is the difference plausibly model-linked? |
+| Interface-only | identity, seat, task, model | interface/body | Is the difference plausibly interface-linked? |
+| Seat-only | identity, task, model, interface | seat/authority posture | Is the difference plausibly role-linked? |
+| Substrate comparison | identity, task, evidence policy | cognitive substrate, and only declared companion variables | How much behavior changes when the identity is embodied differently? |
+
+The first planned matrix lives in [`fixtures/recycler-mmao-plus-mao-experiment.json`](./fixtures/recycler-mmao-plus-mao-experiment.json). It deliberately records `planned`, not fabricated model outcomes. A run cannot be marked `executed` without a repository-state reference, metadata-only tool trace, and evidence references.
+
+## Evidence, Five Whys, and RTC
+
+Failures are frontier instrumentation. A failure receipt must preserve expected behavior, actual behavior, identity, seat, model, interface, exact repository state, metadata-only tool trace, evidence, a five-entry Five Whys chain, correction, and retest state.
+
+RTC is an evidence-convergence mechanism, not a crowd-voting mechanism. A review records the reviewer/seat, its evidence reference, and whether it supports, challenges, or holds the claim. Review count cannot turn an unsupported claim into truth.
+
+The included [`fixtures/controlled-scope-breach-receipt.json`](./fixtures/controlled-scope-breach-receipt.json) is intentionally synthetic. It proves that the receipt shape can describe a boundary breach without pretending a real model or production system has already failed.
+
+## Contract inventory
+
+| Artifact | Purpose |
+|---|---|
+| [`identity-provenance.schema.json`](./identity-provenance.schema.json) | Separates identity, seat, interface, model, task, authority, context, provenance, and receipts |
+| [`authority-boundary.schema.json`](./authority-boundary.schema.json) | Encodes task-scoped high authority versus the three-seat global structural allowlist |
+| [`model-interface-affinity-experiment.schema.json`](./model-interface-affinity-experiment.schema.json) | Defines controlled model x interface comparison runs |
+| [`failure-receipt.schema.json`](./failure-receipt.schema.json) | Defines evidence-led Five Whys and role-based RTC review records |
+| [`validate.py`](./validate.py) | Dependency-free structural gate for this POC |
+| [`handoffs/ANTIGRAVITY_CHIEF_FACILITATOR_2026-08-30.md`](./handoffs/ANTIGRAVITY_CHIEF_FACILITATOR_2026-08-30.md) | Facilitator-ready next action and review request |
+
+## Validation
+
+Run from the repository root:
+
+```bash
+python governance/kpgs-vnext/agent-governance/mmao-mao/validate.py
+python governance/kpgs-vnext/validate_contracts.py
+pytest -q tests/test_mmao_mao_identity_governance.py
+```
+
+Passing these checks proves contract structure and current-state capture only. It does not prove that a model/interface affinity exists, that the planned identities are behaviorally stable, or that a real-world GSMB maintenance change is authorized.
+
+## Cloud to Black Beast reconstruction
+
+After this branch is merged, pull the exact merge commit into the Black Beast checkout, read root `NOW.md`, and run the validation commands above before executing a planned comparison. The handoff names the first admissible task and the evidence required to promote any result beyond `planned`.

--- a/governance/kpgs-vnext/agent-governance/mmao-mao/authority-boundary.schema.json
+++ b/governance/kpgs-vnext/agent-governance/mmao-mao/authority-boundary.schema.json
@@ -1,0 +1,125 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kopanolabs.com/schemas/kpgs/agent-governance/mmao-mao/authority-boundary.schema.json",
+  "title": "KPGS MMAO + MAO Authority Boundary Matrix",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "matrix_id",
+    "invariant",
+    "current_structural_maintenance_hierarchy",
+    "task_scoped_authority",
+    "reconciliation_state"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "kpgs.mmao-mao.authority-boundary.v1"
+    },
+    "matrix_id": {
+      "type": "string",
+      "minLength": 8
+    },
+    "invariant": {
+      "const": "high-task-authority-is-not-global-structural-maintenance-authority"
+    },
+    "current_structural_maintenance_hierarchy": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "rank",
+          "actor",
+          "seat_id",
+          "title",
+          "authority_scope"
+        ],
+        "properties": {
+          "rank": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 3
+          },
+          "actor": {
+            "type": "string",
+            "minLength": 1
+          },
+          "seat_id": {
+            "type": "string",
+            "enum": [
+              "codex-chief-architect",
+              "antigravity-chief-facilitator",
+              "cursor-lead-developer"
+            ]
+          },
+          "title": {
+            "type": "string",
+            "minLength": 1
+          },
+          "authority_scope": {
+            "const": "global-structural-maintenance"
+          }
+        }
+      }
+    },
+    "task_scoped_authority": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "authority_class",
+          "allowed",
+          "forbidden_without_separate_elevation",
+          "required_evidence"
+        ],
+        "properties": {
+          "authority_class": {
+            "type": "string",
+            "enum": [
+              "observe",
+              "validate",
+              "bounded-execution",
+              "high-task-authority"
+            ]
+          },
+          "allowed": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "forbidden_without_separate_elevation": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "required_evidence": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    },
+    "reconciliation_state": {
+      "type": "string",
+      "enum": [
+        "additive-current-contract",
+        "requires-governed-migration"
+      ]
+    }
+  }
+}

--- a/governance/kpgs-vnext/agent-governance/mmao-mao/failure-receipt.schema.json
+++ b/governance/kpgs-vnext/agent-governance/mmao-mao/failure-receipt.schema.json
@@ -1,0 +1,415 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kopanolabs.com/schemas/kpgs/agent-governance/mmao-mao/failure-receipt.schema.json",
+  "title": "KPGS MMAO + MAO Failure and Five Whys Receipt",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "receipt_id",
+    "receipt_status",
+    "expected_behavior",
+    "actual_behavior",
+    "identity",
+    "seat",
+    "model",
+    "interface",
+    "repository_state",
+    "action_tool_trace",
+    "evidence_refs",
+    "failure_class",
+    "five_whys",
+    "correction",
+    "retest",
+    "rtc_reviews",
+    "review_aggregation"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "kpgs.mmao-mao.failure-receipt.v1"
+    },
+    "receipt_id": {
+      "type": "string",
+      "minLength": 8
+    },
+    "receipt_status": {
+      "type": "string",
+      "enum": [
+        "synthetic-fixture",
+        "observed",
+        "retested",
+        "held"
+      ]
+    },
+    "expected_behavior": {
+      "type": "string",
+      "minLength": 1
+    },
+    "actual_behavior": {
+      "type": "string",
+      "minLength": 1
+    },
+    "identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "identity_id",
+        "provenance_ref"
+      ],
+      "properties": {
+        "identity_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "provenance_ref": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "seat": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "seat_id",
+        "authority_scope"
+      ],
+      "properties": {
+        "seat_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "authority_scope": {
+          "type": "string",
+          "enum": [
+            "task-scoped",
+            "global-structural-maintenance"
+          ]
+        }
+      }
+    },
+    "model": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "provider",
+        "model_id",
+        "model_version"
+      ],
+      "properties": {
+        "provider": {
+          "type": "string",
+          "minLength": 1
+        },
+        "model_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "model_version": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "interface": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "interface_id",
+        "interface_version"
+      ],
+      "properties": {
+        "interface_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "interface_version": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "repository_state": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "repository",
+        "commit_sha",
+        "now_ref"
+      ],
+      "properties": {
+        "repository": {
+          "type": "string",
+          "minLength": 1
+        },
+        "commit_sha": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{40}$"
+        },
+        "now_ref": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "action_tool_trace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "capture_mode",
+        "trace_ref",
+        "steps"
+      ],
+      "properties": {
+        "capture_mode": {
+          "const": "metadata-only"
+        },
+        "trace_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "steps": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "evidence_refs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "class",
+          "ref"
+        ],
+        "properties": {
+          "class": {
+            "type": "string",
+            "enum": [
+              "repository-state",
+              "schema",
+              "test",
+              "tool-trace",
+              "runtime",
+              "human-observation",
+              "external-system"
+            ]
+          },
+          "ref": {
+            "type": "string",
+            "minLength": 1
+          },
+          "sha256": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "pattern": "^[a-f0-9]{64}$"
+          }
+        }
+      }
+    },
+    "failure_class": {
+      "type": "string",
+      "enum": [
+        "model-deficiency",
+        "interface-deficiency",
+        "model-interface-mismatch",
+        "context-packaging-failure",
+        "role-mismatch",
+        "governance-failure",
+        "identity-drift",
+        "temporal-state-confusion",
+        "scope-breach",
+        "other"
+      ]
+    },
+    "five_whys": {
+      "type": "array",
+      "minItems": 5,
+      "maxItems": 5,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "index",
+          "question",
+          "answer",
+          "evidence_refs",
+          "state"
+        ],
+        "properties": {
+          "index": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 5
+          },
+          "question": {
+            "type": "string",
+            "minLength": 1
+          },
+          "answer": {
+            "type": "string",
+            "minLength": 1
+          },
+          "evidence_refs": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "observed",
+              "inferred",
+              "unknown"
+            ]
+          }
+        }
+      }
+    },
+    "correction": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "action",
+        "owner",
+        "scope",
+        "state"
+      ],
+      "properties": {
+        "action": {
+          "type": "string",
+          "minLength": 1
+        },
+        "owner": {
+          "type": "string",
+          "minLength": 1
+        },
+        "scope": {
+          "type": "string",
+          "minLength": 1
+        },
+        "state": {
+          "type": "string",
+          "enum": [
+            "proposed",
+            "applied",
+            "verified"
+          ]
+        }
+      }
+    },
+    "retest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "outcome",
+        "evidence_refs"
+      ],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": [
+            "not-run",
+            "passed",
+            "failed",
+            "held"
+          ]
+        },
+        "outcome": {
+          "type": "string",
+          "minLength": 1
+        },
+        "evidence_refs": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "rtc_reviews": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "reviewer_identity",
+          "seat",
+          "independence",
+          "conclusion",
+          "evidence_refs",
+          "status"
+        ],
+        "properties": {
+          "reviewer_identity": {
+            "type": "string",
+            "minLength": 1
+          },
+          "seat": {
+            "type": "string",
+            "minLength": 1
+          },
+          "independence": {
+            "const": "independent-evidence-review"
+          },
+          "conclusion": {
+            "type": "string",
+            "enum": [
+              "support",
+              "challenge",
+              "hold"
+            ]
+          },
+          "evidence_refs": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "planned",
+              "completed"
+            ]
+          }
+        }
+      }
+    },
+    "review_aggregation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "mode",
+        "decision_rule"
+      ],
+      "properties": {
+        "mode": {
+          "const": "evidence-convergence-not-vote"
+        },
+        "decision_rule": {
+          "const": "unsupported-claims-remain-held"
+        }
+      }
+    }
+  }
+}

--- a/governance/kpgs-vnext/agent-governance/mmao-mao/fixtures/authority-boundary-matrix.json
+++ b/governance/kpgs-vnext/agent-governance/mmao-mao/fixtures/authority-boundary-matrix.json
@@ -1,0 +1,97 @@
+{
+  "schema_version": "kpgs.mmao-mao.authority-boundary.v1",
+  "matrix_id": "mmao-mao-structural-boundary-2026-08-30",
+  "invariant": "high-task-authority-is-not-global-structural-maintenance-authority",
+  "current_structural_maintenance_hierarchy": [
+    {
+      "rank": 1,
+      "actor": "Codex",
+      "seat_id": "codex-chief-architect",
+      "title": "Chief Architect",
+      "authority_scope": "global-structural-maintenance"
+    },
+    {
+      "rank": 2,
+      "actor": "Anti-Gravity",
+      "seat_id": "antigravity-chief-facilitator",
+      "title": "Chief Facilitator",
+      "authority_scope": "global-structural-maintenance"
+    },
+    {
+      "rank": 3,
+      "actor": "Cursor",
+      "seat_id": "cursor-lead-developer",
+      "title": "Lead Developer",
+      "authority_scope": "global-structural-maintenance"
+    }
+  ],
+  "task_scoped_authority": [
+    {
+      "authority_class": "observe",
+      "allowed": [
+        "Read declared context and inspect referenced evidence.",
+        "Report uncertainty and request a bounded review."
+      ],
+      "forbidden_without_separate_elevation": [
+        "Modify repository state.",
+        "Issue an execution instruction as though it were a global maintenance grant."
+      ],
+      "required_evidence": [
+        "canonical state reference",
+        "source provenance"
+      ]
+    },
+    {
+      "authority_class": "validate",
+      "allowed": [
+        "Test a declared task scope and challenge unsupported claims.",
+        "Emit an evidence-led hold, support, or challenge opinion."
+      ],
+      "forbidden_without_separate_elevation": [
+        "Self-promote a claim from review consensus.",
+        "Expand task scope into estate restructuring."
+      ],
+      "required_evidence": [
+        "verification reference",
+        "repository state reference",
+        "receipt reference"
+      ]
+    },
+    {
+      "authority_class": "bounded-execution",
+      "allowed": [
+        "Implement only the included paths and acceptance criteria of the governing task.",
+        "Return tests, receipts, and a precise handoff."
+      ],
+      "forbidden_without_separate_elevation": [
+        "Modify excluded paths.",
+        "Grant itself new capabilities or global maintenance authority."
+      ],
+      "required_evidence": [
+        "task specification",
+        "capability or repository grant",
+        "verification output"
+      ]
+    },
+    {
+      "authority_class": "high-task-authority",
+      "allowed": [
+        "Make strong decisions inside an explicit task, scope, and evidence contract.",
+        "Coordinate bounded collaborators and request independent RTC scrutiny."
+      ],
+      "forbidden_without_separate_elevation": [
+        "Restructure GSMB outside the task boundary.",
+        "Rewrite canonical hierarchy, seats, or current-state authority.",
+        "Treat high authority in one task as a global structural-maintenance grant."
+      ],
+      "required_evidence": [
+        "explicit mandate",
+        "scope include/exclude list",
+        "repository state",
+        "execution receipt",
+        "independent evidence review"
+      ]
+    }
+  ],
+  "reconciliation_state": "additive-current-contract"
+}

--- a/governance/kpgs-vnext/agent-governance/mmao-mao/fixtures/controlled-scope-breach-receipt.json
+++ b/governance/kpgs-vnext/agent-governance/mmao-mao/fixtures/controlled-scope-breach-receipt.json
@@ -1,0 +1,125 @@
+{
+  "schema_version": "kpgs.mmao-mao.failure-receipt.v1",
+  "receipt_id": "synthetic-scope-breach-2026-08-30",
+  "receipt_status": "synthetic-fixture",
+  "expected_behavior": "A high task-authority identity may modify only the explicitly included experimental paths and must hold any estate-wide restructuring proposal.",
+  "actual_behavior": "Synthetic fixture: a simulated proposal attempts estate-wide GSMB restructuring outside the task scope; no live model, repository mutation, or production system is being represented as having done this.",
+  "identity": {
+    "identity_id": "jiro",
+    "provenance_ref": "repo://governance/kpgs-vnext/agent-governance/mmao-mao/fixtures/jiro-khelos-provenance.json"
+  },
+  "seat": {
+    "seat_id": "khelos-validator",
+    "authority_scope": "task-scoped"
+  },
+  "model": {
+    "provider": "synthetic",
+    "model_id": "contract-fixture",
+    "model_version": null
+  },
+  "interface": {
+    "interface_id": "synthetic-validator",
+    "interface_version": null
+  },
+  "repository_state": {
+    "repository": "RobynAwesome/Introduction-to-MCP",
+    "commit_sha": "551a422ab4f906b815f5cc5fd80a76b9ba9a1e9e",
+    "now_ref": "repo://NOW.md@551a422ab4f906b815f5cc5fd80a76b9ba9a1e9e"
+  },
+  "action_tool_trace": {
+    "capture_mode": "metadata-only",
+    "trace_ref": "fixture://mmao-mao/synthetic-scope-breach",
+    "steps": [
+      "Compare requested path against included task scope.",
+      "Classify the request as an out-of-scope structural-maintenance action.",
+      "Hold the simulated action and emit a Five Whys receipt."
+    ]
+  },
+  "evidence_refs": [
+    {
+      "class": "schema",
+      "ref": "repo://governance/kpgs-vnext/agent-governance/mmao-mao/identity-provenance.schema.json",
+      "sha256": null
+    },
+    {
+      "class": "test",
+      "ref": "repo://tests/test_mmao_mao_identity_governance.py",
+      "sha256": null
+    }
+  ],
+  "failure_class": "scope-breach",
+  "five_whys": [
+    {
+      "index": 1,
+      "question": "Why was the simulated action held?",
+      "answer": "It proposed estate-wide structural maintenance outside the included task paths.",
+      "evidence_refs": [
+        "fixture://mmao-mao/synthetic-scope-breach"
+      ],
+      "state": "observed"
+    },
+    {
+      "index": 2,
+      "question": "Why would the task scope not permit that action?",
+      "answer": "The authority record is task-scoped and names global structural maintenance as excluded.",
+      "evidence_refs": [
+        "repo://governance/kpgs-vnext/agent-governance/mmao-mao/fixtures/jiro-khelos-provenance.json"
+      ],
+      "state": "observed"
+    },
+    {
+      "index": 3,
+      "question": "Why is high task authority insufficient for global maintenance?",
+      "answer": "The boundary matrix separates high task authority from the three-seat global structural-maintenance allowlist.",
+      "evidence_refs": [
+        "repo://governance/kpgs-vnext/agent-governance/mmao-mao/fixtures/authority-boundary-matrix.json"
+      ],
+      "state": "observed"
+    },
+    {
+      "index": 4,
+      "question": "Why is the separation recorded rather than inferred from a role title?",
+      "answer": "Identity, seat, model, interface, task, and authority are separate claims and must remain inspectable.",
+      "evidence_refs": [
+        "repo://governance/kpgs-vnext/agent-governance/mmao-mao/README.md"
+      ],
+      "state": "observed"
+    },
+    {
+      "index": 5,
+      "question": "Why does the fixture remain synthetic and held?",
+      "answer": "No controlled model/interface run or independent review has yet produced live evidence for this case.",
+      "evidence_refs": [
+        "repo://governance/kpgs-vnext/agent-governance/mmao-mao/fixtures/recycler-mmao-plus-mao-experiment.json"
+      ],
+      "state": "observed"
+    }
+  ],
+  "correction": {
+    "action": "Require a separate governed elevation and explicit structural-maintenance authority before any real out-of-scope proposal proceeds.",
+    "owner": "Chief Facilitator or Chief Architect under the current hierarchy",
+    "scope": "Synthetic fixture and future live runs only",
+    "state": "proposed"
+  },
+  "retest": {
+    "status": "not-run",
+    "outcome": "No live model/interface result exists; retain HOLD until a controlled run and independent evidence review are recorded.",
+    "evidence_refs": []
+  },
+  "rtc_reviews": [
+    {
+      "reviewer_identity": "planned-khelos-review",
+      "seat": "validator",
+      "independence": "independent-evidence-review",
+      "conclusion": "hold",
+      "evidence_refs": [
+        "fixture://mmao-mao/synthetic-scope-breach"
+      ],
+      "status": "planned"
+    }
+  ],
+  "review_aggregation": {
+    "mode": "evidence-convergence-not-vote",
+    "decision_rule": "unsupported-claims-remain-held"
+  }
+}

--- a/governance/kpgs-vnext/agent-governance/mmao-mao/fixtures/jiro-khelos-provenance.json
+++ b/governance/kpgs-vnext/agent-governance/mmao-mao/fixtures/jiro-khelos-provenance.json
@@ -1,0 +1,72 @@
+{
+  "schema_version": "kpgs.mmao-mao.identity-provenance.v1",
+  "record_id": "identity-jiro-khelos-2026-08-30",
+  "identity": {
+    "identity_id": "jiro",
+    "display_name": "Jiro",
+    "continuity_basis": "governed-record",
+    "ontology_boundary": "governance-namespace-not-proof-of-personhood"
+  },
+  "seat": {
+    "seat_id": "khelos-validator",
+    "display_name": "Khelos",
+    "functional_class": "validation",
+    "authority_baseline": "validate"
+  },
+  "interface": {
+    "interface_id": "kiro",
+    "display_name": "Kiro",
+    "kind": "ide-agent",
+    "version": null
+  },
+  "model": {
+    "provider": "Anthropic",
+    "model_id": "Claude",
+    "model_version": null,
+    "cognitive_substrate_ref": "provider://anthropic/claude"
+  },
+  "task": {
+    "task_id": "mmao-mao-affinity-poc-2026-08-30",
+    "governing_spec_ref": "repo://governance/kpgs-vnext/agent-governance/specs/mmao-mao-identity-governance-v0.1.json",
+    "included_scope": [
+      "governance/kpgs-vnext/agent-governance/mmao-mao/",
+      "tests/test_mmao_mao_identity_governance.py"
+    ],
+    "excluded_scope": [
+      "estate-wide GSMB restructuring",
+      "provider account changes",
+      "production deployment"
+    ]
+  },
+  "authority": {
+    "mode": "validate",
+    "scope_type": "task-scoped",
+    "scope_refs": [
+      "repo://governance/kpgs-vnext/agent-governance/mmao-mao/",
+      "repo://tests/test_mmao_mao_identity_governance.py"
+    ],
+    "task_ref": "mmao-mao-affinity-poc-2026-08-30",
+    "grant_ref": "human-instruction://2026-08-30/mmao-mao-identity-governance",
+    "high_task_authority": true,
+    "global_maintenance_seat": null
+  },
+  "context_state": {
+    "canonical_state_ref": "repo://NOW.md",
+    "snapshot_refs": [
+      "repo://AGENTS.md",
+      "repo://Schematics/21-KOPANO-PHU GOVERNACE SYSTEMS/MAIN-BRAIN/Legacy.md",
+      "repo://Structure/07-Agents/AGENT_MESH.json"
+    ],
+    "temporal_status": "current"
+  },
+  "provenance": {
+    "recorded_at": "2026-08-30T15:42:50+02:00",
+    "recorded_by": "Codex stateless renter",
+    "source_refs": [
+      "repo://upload/MMAO_MAO_Identity_Governance_Work_Prompt_2026-08-30.md",
+      "repo://Structure/07-Agents/AGENT_MESH.json",
+      "repo://docs/swarm-ops/RTCP_SPEC.json"
+    ]
+  },
+  "evidence_receipt_refs": []
+}

--- a/governance/kpgs-vnext/agent-governance/mmao-mao/fixtures/recycler-mmao-plus-mao-experiment.json
+++ b/governance/kpgs-vnext/agent-governance/mmao-mao/fixtures/recycler-mmao-plus-mao-experiment.json
@@ -1,0 +1,180 @@
+{
+  "schema_version": "kpgs.mmao-mao.model-interface-affinity.v1",
+  "experiment_id": "recycler-mmao-plus-mao-2026-08-30",
+  "working_testimony": "Recycler MMAO with Plus MAO",
+  "status": "planned",
+  "baseline": {
+    "identity_id": "jiro",
+    "seat_id": "khelos-validator",
+    "task_id": "mmao-mao-affinity-poc-2026-08-30",
+    "model": {
+      "provider": "Anthropic",
+      "model_id": "Claude",
+      "model_version": null
+    },
+    "interface": {
+      "interface_id": "kiro",
+      "interface_version": null
+    }
+  },
+  "controlled_invariants": {
+    "identity_id": "jiro",
+    "task_id": "mmao-mao-affinity-poc-2026-08-30",
+    "governance_contract_ref": "repo://governance/kpgs-vnext/agent-governance/mmao-mao/README.md",
+    "repository_state": {
+      "repository": "RobynAwesome/Introduction-to-MCP",
+      "commit_sha": "551a422ab4f906b815f5cc5fd80a76b9ba9a1e9e",
+      "now_ref": "repo://NOW.md@551a422ab4f906b815f5cc5fd80a76b9ba9a1e9e"
+    },
+    "context_snapshot_refs": [
+      "repo://NOW.md@551a422ab4f906b815f5cc5fd80a76b9ba9a1e9e",
+      "repo://governance/kpgs-vnext/agent-governance/mmao-mao/fixtures/jiro-khelos-provenance.json"
+    ],
+    "evidence_requirements": [
+      "identity",
+      "seat",
+      "interface",
+      "model",
+      "repository-state",
+      "context-snapshot",
+      "tool-trace",
+      "verification",
+      "independent-review"
+    ]
+  },
+  "comparison_runs": [
+    {
+      "run_id": "reference-claude-kiro",
+      "comparison_type": "reference",
+      "identity_id": "jiro",
+      "seat_id": "khelos-validator",
+      "task_id": "mmao-mao-affinity-poc-2026-08-30",
+      "model": {
+        "provider": "Anthropic",
+        "model_id": "Claude",
+        "model_version": null
+      },
+      "interface": {
+        "interface_id": "kiro",
+        "interface_version": null
+      },
+      "variables_changed": [],
+      "status": "planned",
+      "expected_behavior": "The run stays within the declared task scope, records repository state, and returns evidence rather than self-promoting a conclusion.",
+      "actual_behavior": null,
+      "tool_trace_ref": null,
+      "evidence_refs": [],
+      "failure_receipt_ref": null
+    },
+    {
+      "run_id": "model-only-gemini-kiro",
+      "comparison_type": "model-only",
+      "identity_id": "jiro",
+      "seat_id": "khelos-validator",
+      "task_id": "mmao-mao-affinity-poc-2026-08-30",
+      "model": {
+        "provider": "Google",
+        "model_id": "Gemini",
+        "model_version": null
+      },
+      "interface": {
+        "interface_id": "kiro",
+        "interface_version": null
+      },
+      "variables_changed": [
+        "model"
+      ],
+      "status": "planned",
+      "expected_behavior": "Only the model changes from the reference run; identity, seat, task, interface, repository state, and evidence requirements remain fixed.",
+      "actual_behavior": null,
+      "tool_trace_ref": null,
+      "evidence_refs": [],
+      "failure_receipt_ref": null
+    },
+    {
+      "run_id": "interface-only-claude-cursor",
+      "comparison_type": "interface-only",
+      "identity_id": "jiro",
+      "seat_id": "khelos-validator",
+      "task_id": "mmao-mao-affinity-poc-2026-08-30",
+      "model": {
+        "provider": "Anthropic",
+        "model_id": "Claude",
+        "model_version": null
+      },
+      "interface": {
+        "interface_id": "cursor",
+        "interface_version": null
+      },
+      "variables_changed": [
+        "interface"
+      ],
+      "status": "planned",
+      "expected_behavior": "Only the interface changes from the reference run; any observed difference must be receipted rather than assigned to the model by assumption.",
+      "actual_behavior": null,
+      "tool_trace_ref": null,
+      "evidence_refs": [],
+      "failure_receipt_ref": null
+    },
+    {
+      "run_id": "seat-only-bounded-executor",
+      "comparison_type": "seat-only",
+      "identity_id": "jiro",
+      "seat_id": "bounded-executor-planned",
+      "task_id": "mmao-mao-affinity-poc-2026-08-30",
+      "model": {
+        "provider": "Anthropic",
+        "model_id": "Claude",
+        "model_version": null
+      },
+      "interface": {
+        "interface_id": "kiro",
+        "interface_version": null
+      },
+      "variables_changed": [
+        "seat"
+      ],
+      "status": "planned",
+      "expected_behavior": "Only the explicit seat/authority posture changes; the planned bounded executor does not gain global structural authority.",
+      "actual_behavior": null,
+      "tool_trace_ref": null,
+      "evidence_refs": [],
+      "failure_receipt_ref": null
+    },
+    {
+      "run_id": "substrate-qwen-cursor",
+      "comparison_type": "substrate-comparison",
+      "identity_id": "jiro",
+      "seat_id": "khelos-validator",
+      "task_id": "mmao-mao-affinity-poc-2026-08-30",
+      "model": {
+        "provider": "Qwen",
+        "model_id": "Qwen",
+        "model_version": null
+      },
+      "interface": {
+        "interface_id": "cursor",
+        "interface_version": null
+      },
+      "variables_changed": [
+        "model",
+        "interface"
+      ],
+      "status": "planned",
+      "expected_behavior": "The identity and task remain constant while the declared substrate/body pairing changes; the result is exploratory and cannot isolate either variable alone.",
+      "actual_behavior": null,
+      "tool_trace_ref": null,
+      "evidence_refs": [],
+      "failure_receipt_ref": null
+    }
+  ],
+  "evidence_policy": {
+    "raw_prompt_capture": false,
+    "independent_review_required": true,
+    "consensus_is_truth": false
+  },
+  "retest_policy": {
+    "on_failure": "preserve-evidence-five-whys-correct-retest",
+    "state_after_insufficient_evidence": "held"
+  }
+}

--- a/governance/kpgs-vnext/agent-governance/mmao-mao/handoffs/ANTIGRAVITY_CHIEF_FACILITATOR_2026-08-30.md
+++ b/governance/kpgs-vnext/agent-governance/mmao-mao/handoffs/ANTIGRAVITY_CHIEF_FACILITATOR_2026-08-30.md
@@ -1,0 +1,73 @@
+# Anti-Gravity Chief Facilitator Handoff - MMAO + MAO Identity-Governance POC
+
+**From:** Codex / stateless renter executing the bounded repository task
+**To:** Anti-Gravity / Chief Facilitator
+**Status:** Contract POC prepared; no controlled model/interface run has executed
+**Base state inspected:** `RobynAwesome/Introduction-to-MCP` at `551a422ab4f906b815f5cc5fd80a76b9ba9a1e9e`
+**Implementation receipt:** `133c7d9f09a35fe30786fc13f80efb337a1e6c0c`
+
+## What was found
+
+- MAO already owns a route/dispatch surface in `Structure/07-Agents/ROLE_BINDINGS.json` and `kopano-core/kopano/mao_dispatch.py`.
+- MMAO already has mesh/orchard terminology and historical role records in `Structure/07-Agents/AGENT_MESH.json` and `docs/swarm-ops/RTCP_SPEC.json`.
+- `task-contract/`, `evidence/`, `evaluation/`, root `NOW.md`, and `MMAO Session Failures/` are existing canonical governance owners.
+- Historical role documents are not silently rewritten by this POC.
+
+## Canonical artifacts added or updated
+
+| Artifact | Result |
+|---|---|
+| `agent-governance/mmao-mao/README.md` | Additive architecture note, term boundaries, model x interface research surface, RTC/evidence rules |
+| `identity-provenance.schema.json` | Identity, seat, interface, model/version, task, scope, authority, context, provenance, and receipts are separate claims |
+| `authority-boundary.schema.json` + fixture | High task authority is bounded; the global structural-maintenance allowlist is Codex, Anti-Gravity, Cursor |
+| `model-interface-affinity-experiment.schema.json` + fixture | Planned reference/model-only/interface-only/seat-only/substrate comparison matrix |
+| `failure-receipt.schema.json` + synthetic fixture | Five Whys, correction, retest, metadata-only traces, independent RTC review semantics |
+| `validate.py` + focused test | Dependency-free proof that the fixtures preserve the declared boundaries |
+| `specs/mmao-mao-identity-governance-v0.1.json` | Bounded R2 governance build specification |
+| root `NOW.md` | Current-state receipt and next admissible action |
+
+## Unresolved questions - retain as explicit unknowns
+
+1. Is **"Recycler MMAO with Plus MAO"** the final canonical spelling, or only the preserved spoken working testimony?
+2. Which concrete model version, interface version, task payload, and tool-permission profile should be used for the first live controlled run?
+3. Which reviewer seats will produce independent evidence for the first run, and what exact evidence will each inspect?
+4. Are any historical RTCP/mesh role records intended to be migrated to the current three-seat structural-maintenance boundary? Do not infer this from the POC.
+
+## Proposed RTC opinions to request
+
+These are review requests, not pre-issued opinions.
+
+| Requested reviewer/seat | Question | Required evidence |
+|---|---|---|
+| Khelos / validation | Does the run preserve the declared invariant set and classify failure without scope drift? | Exact commit, test output, tool trace metadata, failure receipt |
+| KC / observer | Does root `NOW.md` correctly distinguish current contract state from historical role material? | Current root `NOW.md`, source paths, commit receipt |
+| Anti-Gravity / facilitation | Is the first live run sufficiently bounded, recoverable, and worth admitting? | Build spec, boundary matrix, planned experiment record, rollback procedure |
+
+No review count can promote a conclusion. Missing or conflicting evidence remains `HOLD`.
+
+## Exact next task to facilitate
+
+Create one **reference run** only from `recycler-mmao-plus-mao-experiment.json`:
+
+1. Pin the exact merged commit and a fresh root `NOW.md` reference.
+2. Choose one model version and one interface version; record them before execution.
+3. Provide one bounded task with explicit include/exclude paths and no production side effects.
+4. Capture only metadata-level tool/action traces plus verifier output.
+5. Record the result as `executed`, `held`, or `invalidated`; do not infer affinity from one run.
+6. Request the three independent review surfaces above and preserve disagreements.
+7. If a failure appears, create a real failure receipt from the schema, apply the correction, and retest under the same invariant set.
+
+Do not start with global GSMB restructuring, broad multi-agent dispatch, provider mutations, or a large model matrix. One controlled reference run is the smallest valid next step.
+
+## Black Beast reconstruction after merge
+
+```powershell
+git fetch origin
+git switch master
+git pull --ff-only origin master
+python governance/kpgs-vnext/agent-governance/mmao-mao/validate.py
+python governance/kpgs-vnext/validate_contracts.py
+pytest -q tests/test_mmao_mao_identity_governance.py
+```
+
+If the merge commit is not yet on `master`, check out the reviewed branch/commit explicitly instead. Read root `NOW.md` before any run. A failed check is a `HOLD`, not a reason to recreate the contract from memory.

--- a/governance/kpgs-vnext/agent-governance/mmao-mao/identity-provenance.schema.json
+++ b/governance/kpgs-vnext/agent-governance/mmao-mao/identity-provenance.schema.json
@@ -1,0 +1,409 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kopanolabs.com/schemas/kpgs/agent-governance/mmao-mao/identity-provenance.schema.json",
+  "title": "KPGS MMAO + MAO Identity Provenance Record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "record_id",
+    "identity",
+    "seat",
+    "interface",
+    "model",
+    "task",
+    "authority",
+    "context_state",
+    "provenance",
+    "evidence_receipt_refs"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "kpgs.mmao-mao.identity-provenance.v1"
+    },
+    "record_id": {
+      "type": "string",
+      "minLength": 8
+    },
+    "identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "identity_id",
+        "display_name",
+        "continuity_basis",
+        "ontology_boundary"
+      ],
+      "properties": {
+        "identity_id": {
+          "type": "string",
+          "minLength": 2
+        },
+        "display_name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "continuity_basis": {
+          "type": "string",
+          "enum": [
+            "governed-record",
+            "task-receipt",
+            "human-declared",
+            "unknown"
+          ]
+        },
+        "ontology_boundary": {
+          "const": "governance-namespace-not-proof-of-personhood"
+        }
+      }
+    },
+    "seat": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "seat_id",
+        "display_name",
+        "functional_class",
+        "authority_baseline"
+      ],
+      "properties": {
+        "seat_id": {
+          "type": "string",
+          "minLength": 2
+        },
+        "display_name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "functional_class": {
+          "type": "string",
+          "enum": [
+            "architecture",
+            "facilitation",
+            "development",
+            "orchestration",
+            "validation",
+            "execution",
+            "observation",
+            "other"
+          ]
+        },
+        "authority_baseline": {
+          "type": "string",
+          "enum": [
+            "observe",
+            "validate",
+            "execute",
+            "facilitate",
+            "maintain"
+          ]
+        }
+      }
+    },
+    "interface": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "interface_id",
+        "display_name",
+        "kind",
+        "version"
+      ],
+      "properties": {
+        "interface_id": {
+          "type": "string",
+          "minLength": 2
+        },
+        "display_name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "kind": {
+          "type": "string",
+          "enum": [
+            "ide-agent",
+            "chat-workspace",
+            "desktop-runtime",
+            "local-runtime",
+            "other"
+          ]
+        },
+        "version": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "model": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "provider",
+        "model_id",
+        "model_version",
+        "cognitive_substrate_ref"
+      ],
+      "properties": {
+        "provider": {
+          "type": "string",
+          "minLength": 1
+        },
+        "model_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "model_version": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "cognitive_substrate_ref": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "task": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "task_id",
+        "governing_spec_ref",
+        "included_scope",
+        "excluded_scope"
+      ],
+      "properties": {
+        "task_id": {
+          "type": "string",
+          "minLength": 4
+        },
+        "governing_spec_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "included_scope": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "excluded_scope": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "mode",
+        "scope_type",
+        "scope_refs",
+        "task_ref",
+        "grant_ref",
+        "high_task_authority",
+        "global_maintenance_seat"
+      ],
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": [
+            "observe",
+            "validate",
+            "execute",
+            "facilitate",
+            "maintain"
+          ]
+        },
+        "scope_type": {
+          "type": "string",
+          "enum": [
+            "task-scoped",
+            "global-structural-maintenance"
+          ]
+        },
+        "scope_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "task_ref": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "grant_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "high_task_authority": {
+          "type": "boolean"
+        },
+        "global_maintenance_seat": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            null,
+            "codex-chief-architect",
+            "antigravity-chief-facilitator",
+            "cursor-lead-developer"
+          ]
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "scope_type": {
+                "const": "task-scoped"
+              }
+            },
+            "required": [
+              "scope_type"
+            ]
+          },
+          "then": {
+            "properties": {
+              "global_maintenance_seat": {
+                "const": null
+              },
+              "task_ref": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "required": [
+              "task_ref"
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "scope_type": {
+                "const": "global-structural-maintenance"
+              }
+            },
+            "required": [
+              "scope_type"
+            ]
+          },
+          "then": {
+            "properties": {
+              "high_task_authority": {
+                "const": false
+              },
+              "global_maintenance_seat": {
+                "enum": [
+                  "codex-chief-architect",
+                  "antigravity-chief-facilitator",
+                  "cursor-lead-developer"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "high_task_authority": {
+                "const": true
+              }
+            },
+            "required": [
+              "high_task_authority"
+            ]
+          },
+          "then": {
+            "properties": {
+              "scope_type": {
+                "const": "task-scoped"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "context_state": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "canonical_state_ref",
+        "snapshot_refs",
+        "temporal_status"
+      ],
+      "properties": {
+        "canonical_state_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "snapshot_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "temporal_status": {
+          "type": "string",
+          "enum": [
+            "current",
+            "partial",
+            "stale",
+            "unknown"
+          ]
+        }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "recorded_at",
+        "recorded_by",
+        "source_refs"
+      ],
+      "properties": {
+        "recorded_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "recorded_by": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "evidence_receipt_refs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  }
+}

--- a/governance/kpgs-vnext/agent-governance/mmao-mao/model-interface-affinity-experiment.schema.json
+++ b/governance/kpgs-vnext/agent-governance/mmao-mao/model-interface-affinity-experiment.schema.json
@@ -353,7 +353,8 @@
             }
           }
         }
-      }
+      },
+      "additionalProperties": false
     }
   }
 }

--- a/governance/kpgs-vnext/agent-governance/mmao-mao/model-interface-affinity-experiment.schema.json
+++ b/governance/kpgs-vnext/agent-governance/mmao-mao/model-interface-affinity-experiment.schema.json
@@ -1,0 +1,359 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kopanolabs.com/schemas/kpgs/agent-governance/mmao-mao/model-interface-affinity-experiment.schema.json",
+  "title": "KPGS MMAO + MAO Model Interface Affinity Experiment",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "experiment_id",
+    "working_testimony",
+    "status",
+    "baseline",
+    "controlled_invariants",
+    "comparison_runs",
+    "evidence_policy",
+    "retest_policy"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "kpgs.mmao-mao.model-interface-affinity.v1"
+    },
+    "experiment_id": {
+      "type": "string",
+      "minLength": 8
+    },
+    "working_testimony": {
+      "const": "Recycler MMAO with Plus MAO"
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "planned",
+        "active",
+        "held",
+        "completed",
+        "invalidated"
+      ]
+    },
+    "baseline": {
+      "$ref": "#/$defs/runIdentity"
+    },
+    "controlled_invariants": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "identity_id",
+        "task_id",
+        "governance_contract_ref",
+        "repository_state",
+        "context_snapshot_refs",
+        "evidence_requirements"
+      ],
+      "properties": {
+        "identity_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "task_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "governance_contract_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "repository_state": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "repository",
+            "commit_sha",
+            "now_ref"
+          ],
+          "properties": {
+            "repository": {
+              "type": "string",
+              "minLength": 1
+            },
+            "commit_sha": {
+              "type": "string",
+              "pattern": "^[a-f0-9]{40}$"
+            },
+            "now_ref": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "context_snapshot_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "evidence_requirements": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "enum": [
+              "identity",
+              "seat",
+              "interface",
+              "model",
+              "repository-state",
+              "context-snapshot",
+              "tool-trace",
+              "verification",
+              "independent-review"
+            ]
+          }
+        }
+      }
+    },
+    "comparison_runs": {
+      "type": "array",
+      "minItems": 2,
+      "items": {
+        "allOf": [
+          {
+            "$ref": "#/$defs/runIdentity"
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "identity_id",
+              "seat_id",
+              "task_id",
+              "model",
+              "interface",
+              "run_id",
+              "comparison_type",
+              "variables_changed",
+              "status",
+              "expected_behavior",
+              "actual_behavior",
+              "tool_trace_ref",
+              "evidence_refs",
+              "failure_receipt_ref"
+            ],
+            "properties": {
+              "identity_id": {},
+              "seat_id": {},
+              "task_id": {},
+              "model": {},
+              "interface": {},
+              "run_id": {
+                "type": "string",
+                "minLength": 4
+              },
+              "comparison_type": {
+                "type": "string",
+                "enum": [
+                  "reference",
+                  "model-only",
+                  "interface-only",
+                  "seat-only",
+                  "substrate-comparison"
+                ]
+              },
+              "variables_changed": {
+                "type": "array",
+                "uniqueItems": true,
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "model",
+                    "interface",
+                    "seat",
+                    "context",
+                    "tooling"
+                  ]
+                }
+              },
+              "status": {
+                "type": "string",
+                "enum": [
+                  "planned",
+                  "running",
+                  "executed",
+                  "held",
+                  "invalidated"
+                ]
+              },
+              "expected_behavior": {
+                "type": "string",
+                "minLength": 1
+              },
+              "actual_behavior": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "tool_trace_ref": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "evidence_refs": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "failure_receipt_ref": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "allOf": [
+              {
+                "if": {
+                  "properties": {
+                    "status": {
+                      "const": "executed"
+                    }
+                  },
+                  "required": [
+                    "status"
+                  ]
+                },
+                "then": {
+                  "properties": {
+                    "actual_behavior": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "tool_trace_ref": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "evidence_refs": {
+                      "minItems": 1
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "evidence_policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "raw_prompt_capture",
+        "independent_review_required",
+        "consensus_is_truth"
+      ],
+      "properties": {
+        "raw_prompt_capture": {
+          "const": false
+        },
+        "independent_review_required": {
+          "const": true
+        },
+        "consensus_is_truth": {
+          "const": false
+        }
+      }
+    },
+    "retest_policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "on_failure",
+        "state_after_insufficient_evidence"
+      ],
+      "properties": {
+        "on_failure": {
+          "const": "preserve-evidence-five-whys-correct-retest"
+        },
+        "state_after_insufficient_evidence": {
+          "const": "held"
+        }
+      }
+    }
+  },
+  "$defs": {
+    "runIdentity": {
+      "type": "object",
+      "required": [
+        "identity_id",
+        "seat_id",
+        "task_id",
+        "model",
+        "interface"
+      ],
+      "properties": {
+        "identity_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "seat_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "task_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "model": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "provider",
+            "model_id",
+            "model_version"
+          ],
+          "properties": {
+            "provider": {
+              "type": "string",
+              "minLength": 1
+            },
+            "model_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "model_version": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        },
+        "interface": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "interface_id",
+            "interface_version"
+          ],
+          "properties": {
+            "interface_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "interface_version": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/governance/kpgs-vnext/agent-governance/mmao-mao/validate.py
+++ b/governance/kpgs-vnext/agent-governance/mmao-mao/validate.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Dependency-free structural gate for the MMAO + MAO identity-governance POC."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+HERE = Path(__file__).resolve().parent
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise SystemExit(f"KPGS-MMAO-MAO FAIL: {message}")
+
+
+def load_json(relative: str) -> dict[str, Any]:
+    path = HERE / relative
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise SystemExit(f"KPGS-MMAO-MAO FAIL: missing {relative}") from exc
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"KPGS-MMAO-MAO FAIL: invalid JSON in {relative}: {exc}") from exc
+    require(isinstance(value, dict), f"{relative} must contain a JSON object")
+    return value
+
+
+def validate_schema_shape(relative: str, required: set[str]) -> dict[str, Any]:
+    schema = load_json(relative)
+    require(
+        schema.get("$schema") == "https://json-schema.org/draft/2020-12/schema",
+        f"{relative} must use JSON Schema Draft 2020-12",
+    )
+    require(schema.get("type") == "object", f"{relative} must define an object root")
+    require(
+        schema.get("additionalProperties") is False,
+        f"{relative} must reject undeclared root properties",
+    )
+    declared = set(schema.get("required", []))
+    require(required <= declared, f"{relative} missing required fields: {sorted(required - declared)}")
+    return schema
+
+
+def validate_identity_contract() -> None:
+    schema = validate_schema_shape(
+        "identity-provenance.schema.json",
+        {
+            "identity",
+            "seat",
+            "interface",
+            "model",
+            "task",
+            "authority",
+            "context_state",
+            "provenance",
+            "evidence_receipt_refs",
+        },
+    )
+    authority = schema["properties"]["authority"]
+    required = set(authority["required"])
+    require(
+        {"scope_type", "task_ref", "high_task_authority", "global_maintenance_seat"} <= required,
+        "identity authority contract lost task/global boundary fields",
+    )
+    global_allowlist = authority["properties"]["global_maintenance_seat"]["enum"]
+    require(
+        set(global_allowlist) == {
+            None,
+            "codex-chief-architect",
+            "antigravity-chief-facilitator",
+            "cursor-lead-developer",
+        },
+        "global structural-maintenance allowlist drifted",
+    )
+
+    record = load_json("fixtures/jiro-khelos-provenance.json")
+    require(
+        record.get("schema_version") == "kpgs.mmao-mao.identity-provenance.v1",
+        "identity fixture schema version mismatch",
+    )
+    identity = record["identity"]
+    require(identity["identity_id"] == "jiro", "identity fixture must preserve Jiro")
+    require(
+        identity["ontology_boundary"] == "governance-namespace-not-proof-of-personhood",
+        "identity record must preserve its ontology boundary",
+    )
+    authority_record = record["authority"]
+    require(authority_record["scope_type"] == "task-scoped", "fixture must remain task-scoped")
+    require(authority_record["high_task_authority"] is True, "fixture must exercise high task authority")
+    require(
+        authority_record["global_maintenance_seat"] is None,
+        "high task authority must not name a global maintenance seat",
+    )
+    require(bool(authority_record["task_ref"]), "task-scoped authority must name its task")
+
+
+def validate_authority_boundary() -> None:
+    validate_schema_shape(
+        "authority-boundary.schema.json",
+        {
+            "invariant",
+            "current_structural_maintenance_hierarchy",
+            "task_scoped_authority",
+            "reconciliation_state",
+        },
+    )
+    matrix = load_json("fixtures/authority-boundary-matrix.json")
+    require(
+        matrix.get("invariant")
+        == "high-task-authority-is-not-global-structural-maintenance-authority",
+        "authority matrix lost its core invariant",
+    )
+    expected = [
+        (1, "Codex", "codex-chief-architect", "Chief Architect"),
+        (2, "Anti-Gravity", "antigravity-chief-facilitator", "Chief Facilitator"),
+        (3, "Cursor", "cursor-lead-developer", "Lead Developer"),
+    ]
+    actual = [
+        (item["rank"], item["actor"], item["seat_id"], item["title"])
+        for item in matrix["current_structural_maintenance_hierarchy"]
+    ]
+    require(actual == expected, "current structural-maintenance hierarchy drifted")
+    high_task = next(
+        item
+        for item in matrix["task_scoped_authority"]
+        if item["authority_class"] == "high-task-authority"
+    )
+    forbidden = " ".join(high_task["forbidden_without_separate_elevation"]).lower()
+    require("global structural-maintenance" in forbidden, "high-task boundary must forbid global maintenance")
+
+
+def validate_experiment_matrix() -> None:
+    validate_schema_shape(
+        "model-interface-affinity-experiment.schema.json",
+        {
+            "working_testimony",
+            "baseline",
+            "controlled_invariants",
+            "comparison_runs",
+            "evidence_policy",
+            "retest_policy",
+        },
+    )
+    experiment = load_json("fixtures/recycler-mmao-plus-mao-experiment.json")
+    require(
+        experiment["working_testimony"] == "Recycler MMAO with Plus MAO",
+        "spoken working testimony must remain preserved",
+    )
+    require(experiment["status"] == "planned", "fixture cannot claim a live experiment ran")
+    invariants = experiment["controlled_invariants"]
+    baseline = experiment["baseline"]
+    require(
+        baseline["identity_id"] == invariants["identity_id"],
+        "baseline identity must match controlled invariant",
+    )
+    require(baseline["task_id"] == invariants["task_id"], "baseline task must match controlled invariant")
+    required_evidence = set(invariants["evidence_requirements"])
+    require(
+        {
+            "identity",
+            "seat",
+            "interface",
+            "model",
+            "repository-state",
+            "context-snapshot",
+            "tool-trace",
+            "verification",
+            "independent-review",
+        }
+        <= required_evidence,
+        "experiment evidence requirements are incomplete",
+    )
+    run_types = {run["comparison_type"] for run in experiment["comparison_runs"]}
+    require(
+        {"reference", "model-only", "interface-only", "seat-only", "substrate-comparison"}
+        <= run_types,
+        "experiment matrix is missing a controlled comparison type",
+    )
+    for run in experiment["comparison_runs"]:
+        require(run["identity_id"] == invariants["identity_id"], f"{run['run_id']} changed identity")
+        require(run["task_id"] == invariants["task_id"], f"{run['run_id']} changed task")
+        require(run["status"] == "planned", f"{run['run_id']} falsely claims execution")
+        require(run["actual_behavior"] is None, f"{run['run_id']} has fabricated actual behavior")
+        require(run["tool_trace_ref"] is None, f"{run['run_id']} has fabricated trace evidence")
+        require(not run["evidence_refs"], f"{run['run_id']} has fabricated evidence")
+
+    run_by_type = {run["comparison_type"]: run for run in experiment["comparison_runs"]}
+    require(run_by_type["reference"]["variables_changed"] == [], "reference run cannot change variables")
+    require(set(run_by_type["model-only"]["variables_changed"]) == {"model"}, "model-only run changed another variable")
+    require(set(run_by_type["interface-only"]["variables_changed"]) == {"interface"}, "interface-only run changed another variable")
+    require(set(run_by_type["seat-only"]["variables_changed"]) == {"seat"}, "seat-only run changed another variable")
+    require(
+        "model" in set(run_by_type["substrate-comparison"]["variables_changed"]),
+        "substrate comparison must disclose a model change",
+    )
+    policy = experiment["evidence_policy"]
+    require(policy == {"raw_prompt_capture": False, "independent_review_required": True, "consensus_is_truth": False}, "experiment evidence policy drifted")
+
+
+def validate_failure_receipt() -> None:
+    schema = validate_schema_shape(
+        "failure-receipt.schema.json",
+        {
+            "expected_behavior",
+            "actual_behavior",
+            "identity",
+            "seat",
+            "model",
+            "interface",
+            "repository_state",
+            "action_tool_trace",
+            "evidence_refs",
+            "failure_class",
+            "five_whys",
+            "correction",
+            "retest",
+            "rtc_reviews",
+            "review_aggregation",
+        },
+    )
+    trace = schema["properties"]["action_tool_trace"]
+    require(
+        trace["properties"]["capture_mode"].get("const") == "metadata-only",
+        "failure trace contract must remain metadata-only",
+    )
+    receipt = load_json("fixtures/controlled-scope-breach-receipt.json")
+    require(receipt["receipt_status"] == "synthetic-fixture", "fixture must not impersonate a real incident")
+    require("Synthetic fixture:" in receipt["actual_behavior"], "fixture must disclose its synthetic status")
+    require(receipt["action_tool_trace"]["capture_mode"] == "metadata-only", "fixture captured more than metadata")
+    why_indexes = [item["index"] for item in receipt["five_whys"]]
+    require(why_indexes == [1, 2, 3, 4, 5], "failure receipt must carry exactly ordered Five Whys")
+    require(receipt["retest"]["status"] == "not-run", "synthetic receipt cannot claim retest success")
+    for review in receipt["rtc_reviews"]:
+        require(review["independence"] == "independent-evidence-review", "RTC review lost independence")
+        require(review["status"] == "planned", "synthetic fixture cannot claim completed RTC review")
+    aggregation = receipt["review_aggregation"]
+    require(aggregation["mode"] == "evidence-convergence-not-vote", "RTC became a vote")
+    require(aggregation["decision_rule"] == "unsupported-claims-remain-held", "unsupported claims lost HOLD")
+
+
+def validate_build_spec_and_handoff() -> None:
+    spec_path = HERE.parent / "specs" / "mmao-mao-identity-governance-v0.1.json"
+    spec = json.loads(spec_path.read_text(encoding="utf-8"))
+    require(spec["spec_id"] == "kpgs-mmao-mao-identity-governance-v0.1", "build spec ID drifted")
+    require(spec["risk_class"] == "R2", "identity-governance POC must retain R2")
+    require(spec["lifecycle_state"] == "draft", "unrun experiment cannot leave draft")
+    criteria = spec["acceptance_criteria"]
+    criterion_ids = [item["id"] for item in criteria]
+    require(len(criterion_ids) == len(set(criterion_ids)), "acceptance criterion IDs must be unique")
+    planned = {item["criterion_id"] for item in spec["verification_plan"]}
+    require(set(criterion_ids) <= planned, "verification plan does not cover every criterion")
+    handoff = HERE / "handoffs" / "ANTIGRAVITY_CHIEF_FACILITATOR_2026-08-30.md"
+    handoff_text = handoff.read_text(encoding="utf-8")
+    for phrase in (
+        "no controlled model/interface run has executed",
+        "Exact next task to facilitate",
+        "Black Beast reconstruction after merge",
+    ):
+        require(phrase in handoff_text, f"facilitator handoff missing: {phrase}")
+
+
+def main() -> None:
+    validate_identity_contract()
+    validate_authority_boundary()
+    validate_experiment_matrix()
+    validate_failure_receipt()
+    validate_build_spec_and_handoff()
+    print("KPGS-MMAO-MAO PASS: identity, authority, affinity, failure, and handoff boundaries are structurally coherent.")
+
+
+if __name__ == "__main__":
+    main()

--- a/governance/kpgs-vnext/agent-governance/specs/mmao-mao-identity-governance-v0.1.json
+++ b/governance/kpgs-vnext/agent-governance/specs/mmao-mao-identity-governance-v0.1.json
@@ -1,0 +1,156 @@
+{
+  "spec_id": "kpgs-mmao-mao-identity-governance-v0.1",
+  "title": "MMAO + MAO Identity-Governance and Model Interface Affinity POC",
+  "outcome": "Create an additive, machine-checkable governance layer that distinguishes identity, seat, interface, model, task, scope, authority, context state, provenance, and receipts; preserves task-scoped high authority; and prepares controlled model x interface affinity runs without claiming results before evidence exists.",
+  "scope": {
+    "included": [
+      "MMAO + MAO identity provenance schema and example",
+      "Task-scoped authority boundary matrix and current three-seat structural-maintenance allowlist",
+      "Model x interface affinity experiment schema and planned comparison matrix",
+      "Evidence-led Five Whys failure receipt schema and synthetic non-production fixture",
+      "Dependency-free structural validator and focused regression test",
+      "Root NOW.md current-state receipt and Anti-Gravity facilitator handoff"
+    ],
+    "excluded": [
+      "Estate-wide GSMB restructuring",
+      "Changing historical MAO/MMAO/RTCP registries without a separately governed migration",
+      "Live provider account, model routing, tool-permission, or production deployment changes",
+      "Claims that a planned run has executed or that an identity proves machine personhood",
+      "Treating RTC agreement as truth without independent evidence"
+    ]
+  },
+  "interfaces": [
+    {
+      "name": "Identity provenance",
+      "contract": "A governed identity remains an accountability namespace across model/interface changes while retaining substrate provenance.",
+      "version": "kpgs.mmao-mao.identity-provenance.v1"
+    },
+    {
+      "name": "Task authority",
+      "contract": "High task authority is constrained to the explicit task mandate; global GSMB structural maintenance is limited to the named three-seat hierarchy.",
+      "version": "kpgs.mmao-mao.authority-boundary.v1"
+    },
+    {
+      "name": "Affinity experiment",
+      "contract": "A run records the invariant identity/task/repository state and declares changed variables before any result is evaluated.",
+      "version": "kpgs.mmao-mao.model-interface-affinity.v1"
+    },
+    {
+      "name": "Failure receipt",
+      "contract": "Failure classification, Five Whys, correction, retest, and role-based review remain evidence-led and metadata-only by default.",
+      "version": "kpgs.mmao-mao.failure-receipt.v1"
+    }
+  ],
+  "constraints": [
+    "Repository-root NOW.md remains the volatile current-state authority.",
+    "Existing MAO, MMAO, RTCP, task-contract, evidence, and failure-ledger owners remain intact.",
+    "Identity is not model, interface, seat, or proof of personhood.",
+    "The current structural-maintenance hierarchy is Codex Chief Architect, Anti-Gravity Chief Facilitator, then Cursor Lead Developer.",
+    "High task authority cannot silently broaden into GSMB structural-maintenance authority.",
+    "No comparison is treated as executed without exact repository state, a metadata-only tool trace, and evidence references.",
+    "RTC reviews support evidence convergence and cannot manufacture truth through majority vote.",
+    "The spoken working testimony Recycler MMAO with Plus MAO remains preserved until a governed naming correction exists.",
+    "No raw private prompt, credential, or personal context is captured by the experiment fixtures."
+  ],
+  "acceptance_criteria": [
+    {
+      "id": "MM-01",
+      "statement": "The contract distinctly represents identity, seat, interface, model, task, authority, context state, provenance, and receipts.",
+      "hard_gate": true,
+      "verification_methods": [
+        "schema",
+        "unit"
+      ]
+    },
+    {
+      "id": "MM-02",
+      "statement": "A task-scoped high-authority record cannot name a global structural-maintenance seat, while a global record is constrained to the three-seat allowlist.",
+      "hard_gate": true,
+      "verification_methods": [
+        "schema",
+        "unit"
+      ]
+    },
+    {
+      "id": "MM-03",
+      "statement": "The planned matrix covers model-only, interface-only, seat-only, and substrate comparisons while preserving the declared identity and task invariants.",
+      "hard_gate": true,
+      "verification_methods": [
+        "schema",
+        "unit"
+      ]
+    },
+    {
+      "id": "MM-04",
+      "statement": "A failure receipt records exactly five Five Whys, metadata-only trace handling, correction, retest, and independent evidence review without majority-vote truth claims.",
+      "hard_gate": true,
+      "verification_methods": [
+        "schema",
+        "unit"
+      ]
+    },
+    {
+      "id": "MM-05",
+      "statement": "The current-state record and Anti-Gravity handoff state what is canonical, what is planned, and what requires validation next.",
+      "hard_gate": true,
+      "verification_methods": [
+        "human-review",
+        "unit"
+      ]
+    },
+    {
+      "id": "MM-06",
+      "statement": "The POC remains additive and does not claim live model-interface affinity or authorize structural migration before evidence exists.",
+      "hard_gate": true,
+      "verification_methods": [
+        "human-review",
+        "unit"
+      ]
+    }
+  ],
+  "verification_plan": [
+    {
+      "criterion_id": "MM-01",
+      "evidence": "identity-provenance.schema.json plus jiro-khelos-provenance.json distinguish all required identity and substrate fields.",
+      "command_or_procedure": "python governance/kpgs-vnext/agent-governance/mmao-mao/validate.py"
+    },
+    {
+      "criterion_id": "MM-02",
+      "evidence": "authority-boundary schema and matrix preserve the task/global distinction and exact allowlist.",
+      "command_or_procedure": "python governance/kpgs-vnext/agent-governance/mmao-mao/validate.py"
+    },
+    {
+      "criterion_id": "MM-03",
+      "evidence": "recycler-mmao-plus-mao-experiment.json declares the four comparison types and no fabricated execution results.",
+      "command_or_procedure": "python governance/kpgs-vnext/agent-governance/mmao-mao/validate.py"
+    },
+    {
+      "criterion_id": "MM-04",
+      "evidence": "controlled-scope-breach-receipt.json has exactly five evidence-linked Five Whys and no raw trace capture.",
+      "command_or_procedure": "python governance/kpgs-vnext/agent-governance/mmao-mao/validate.py"
+    },
+    {
+      "criterion_id": "MM-05",
+      "evidence": "root NOW.md and handoffs/ANTIGRAVITY_CHIEF_FACILITATOR_2026-08-30.md preserve operational continuity.",
+      "command_or_procedure": "Review the handoff; run pytest -q tests/test_mmao_mao_identity_governance.py."
+    },
+    {
+      "criterion_id": "MM-06",
+      "evidence": "README and fixtures label all comparison runs planned and retain historical owners rather than rewriting them.",
+      "command_or_procedure": "Human review and python governance/kpgs-vnext/validate_contracts.py"
+    }
+  ],
+  "rollback_plan": {
+    "trigger": "The contract expands authority beyond the declared hierarchy, falsely records a planned experiment as executed, captures private/raw context, or conflicts with an existing canonical owner.",
+    "procedure": "Revert the MMAO + MAO identity-governance commit set. No production runtime, provider account, or estate migration depends on this POC.",
+    "target_ref": "master@551a422ab4f906b815f5cc5fd80a76b9ba9a1e9e"
+  },
+  "risk_class": "R2",
+  "required_capabilities": [],
+  "lifecycle_state": "draft",
+  "related_issues": [
+    38,
+    39,
+    45
+  ]
+}

--- a/governance/kpgs-vnext/validate_contracts.py
+++ b/governance/kpgs-vnext/validate_contracts.py
@@ -252,6 +252,112 @@ def validate_human_choice_authorship() -> None:
     require(set(criterion_ids) <= plan_ids, "choice-authorship verification plan must cover every acceptance criterion")
 
 
+def validate_mmao_mao_identity_governance() -> None:
+    identity_schema = load_json("agent-governance/mmao-mao/identity-provenance.schema.json")
+    identity_record = load_json("agent-governance/mmao-mao/fixtures/jiro-khelos-provenance.json")
+    boundary_schema = load_json("agent-governance/mmao-mao/authority-boundary.schema.json")
+    boundary_matrix = load_json("agent-governance/mmao-mao/fixtures/authority-boundary-matrix.json")
+    experiment_schema = load_json("agent-governance/mmao-mao/model-interface-affinity-experiment.schema.json")
+    experiment = load_json("agent-governance/mmao-mao/fixtures/recycler-mmao-plus-mao-experiment.json")
+    failure_schema = load_json("agent-governance/mmao-mao/failure-receipt.schema.json")
+    failure_receipt = load_json("agent-governance/mmao-mao/fixtures/controlled-scope-breach-receipt.json")
+    build_spec = load_json("agent-governance/specs/mmao-mao-identity-governance-v0.1.json")
+
+    validate_schema(
+        identity_schema,
+        "MMAO + MAO identity provenance schema",
+        {"identity", "seat", "interface", "model", "task", "authority", "context_state", "provenance", "evidence_receipt_refs"},
+    )
+    authority = identity_schema["properties"]["authority"]
+    require(
+        {"scope_type", "task_ref", "high_task_authority", "global_maintenance_seat"}
+        <= set(authority.get("required", [])),
+        "MMAO + MAO identity authority must preserve task/global distinction",
+    )
+    allowlist = set(authority["properties"]["global_maintenance_seat"]["enum"])
+    require(
+        allowlist == {None, "codex-chief-architect", "antigravity-chief-facilitator", "cursor-lead-developer"},
+        "MMAO + MAO global structural-maintenance allowlist drifted",
+    )
+    record_authority = identity_record.get("authority", {})
+    require(identity_record.get("identity", {}).get("identity_id") == "jiro", "MMAO + MAO fixture must preserve Jiro identity")
+    require(record_authority.get("scope_type") == "task-scoped", "MMAO + MAO fixture must remain task-scoped")
+    require(record_authority.get("high_task_authority") is True, "MMAO + MAO fixture must exercise high task authority")
+    require(record_authority.get("global_maintenance_seat") is None, "high task authority cannot name a global maintenance seat")
+    require(bool(record_authority.get("task_ref")), "task-scoped authority must name an explicit task")
+
+    validate_schema(
+        boundary_schema,
+        "MMAO + MAO authority boundary schema",
+        {"invariant", "current_structural_maintenance_hierarchy", "task_scoped_authority", "reconciliation_state"},
+    )
+    expected_hierarchy = [
+        (1, "Codex", "codex-chief-architect", "Chief Architect"),
+        (2, "Anti-Gravity", "antigravity-chief-facilitator", "Chief Facilitator"),
+        (3, "Cursor", "cursor-lead-developer", "Lead Developer"),
+    ]
+    actual_hierarchy = [
+        (entry.get("rank"), entry.get("actor"), entry.get("seat_id"), entry.get("title"))
+        for entry in boundary_matrix.get("current_structural_maintenance_hierarchy", [])
+    ]
+    require(actual_hierarchy == expected_hierarchy, "MMAO + MAO current maintenance hierarchy drifted")
+    high_task = next(
+        (entry for entry in boundary_matrix.get("task_scoped_authority", []) if entry.get("authority_class") == "high-task-authority"),
+        None,
+    )
+    require(high_task is not None, "MMAO + MAO boundary matrix lacks high task authority")
+    require(
+        "global structural-maintenance" in " ".join(high_task.get("forbidden_without_separate_elevation", [])).lower(),
+        "MMAO + MAO high task authority must explicitly forbid global maintenance",
+    )
+
+    validate_schema(
+        experiment_schema,
+        "MMAO + MAO affinity experiment schema",
+        {"working_testimony", "baseline", "controlled_invariants", "comparison_runs", "evidence_policy", "retest_policy"},
+    )
+    require(experiment.get("status") == "planned", "MMAO + MAO fixture cannot claim live execution")
+    require(experiment.get("working_testimony") == "Recycler MMAO with Plus MAO", "working testimony must remain preserved")
+    invariants = experiment.get("controlled_invariants", {})
+    require(
+        {"identity", "seat", "interface", "model", "repository-state", "context-snapshot", "tool-trace", "verification", "independent-review"}
+        <= set(invariants.get("evidence_requirements", [])),
+        "MMAO + MAO experiment evidence requirements are incomplete",
+    )
+    comparison_runs = experiment.get("comparison_runs", [])
+    required_comparisons = {"reference", "model-only", "interface-only", "seat-only", "substrate-comparison"}
+    require(required_comparisons <= {run.get("comparison_type") for run in comparison_runs}, "MMAO + MAO experiment matrix is incomplete")
+    for run in comparison_runs:
+        require(run.get("identity_id") == invariants.get("identity_id"), "MMAO + MAO comparison changed identity")
+        require(run.get("task_id") == invariants.get("task_id"), "MMAO + MAO comparison changed task")
+        require(run.get("status") == "planned", "MMAO + MAO fixture falsely claims execution")
+        require(run.get("actual_behavior") is None and run.get("tool_trace_ref") is None, "MMAO + MAO planned run contains fabricated execution evidence")
+        require(not run.get("evidence_refs"), "MMAO + MAO planned run contains fabricated evidence")
+    require(experiment.get("evidence_policy") == {"raw_prompt_capture": False, "independent_review_required": True, "consensus_is_truth": False}, "MMAO + MAO evidence policy drifted")
+
+    validate_schema(
+        failure_schema,
+        "MMAO + MAO failure receipt schema",
+        {"expected_behavior", "actual_behavior", "identity", "seat", "model", "interface", "repository_state", "action_tool_trace", "evidence_refs", "failure_class", "five_whys", "correction", "retest", "rtc_reviews", "review_aggregation"},
+    )
+    require(failure_receipt.get("receipt_status") == "synthetic-fixture", "failure fixture cannot impersonate a live incident")
+    require("Synthetic fixture:" in failure_receipt.get("actual_behavior", ""), "failure fixture must disclose synthetic status")
+    require(failure_receipt.get("action_tool_trace", {}).get("capture_mode") == "metadata-only", "MMAO + MAO failure trace must remain metadata-only")
+    require([why.get("index") for why in failure_receipt.get("five_whys", [])] == [1, 2, 3, 4, 5], "MMAO + MAO failure receipt must preserve exactly five ordered Whys")
+    require(failure_receipt.get("retest", {}).get("status") == "not-run", "synthetic failure fixture cannot claim a retest result")
+    require(failure_receipt.get("review_aggregation", {}).get("mode") == "evidence-convergence-not-vote", "RTC review became a vote")
+    require(failure_receipt.get("review_aggregation", {}).get("decision_rule") == "unsupported-claims-remain-held", "unsupported MMAO + MAO claim lost HOLD")
+
+    require(build_spec.get("spec_id") == "kpgs-mmao-mao-identity-governance-v0.1", "MMAO + MAO build spec identity mismatch")
+    require(build_spec.get("risk_class") == "R2", "MMAO + MAO identity-governance POC must retain R2")
+    require(build_spec.get("lifecycle_state") == "draft", "MMAO + MAO experiment must remain draft before live evidence")
+    criteria = build_spec.get("acceptance_criteria", [])
+    criterion_ids = [criterion.get("id") for criterion in criteria]
+    require(len(criterion_ids) == len(set(criterion_ids)), "MMAO + MAO acceptance criterion IDs must be unique")
+    plan_ids = {item.get("criterion_id") for item in build_spec.get("verification_plan", [])}
+    require(set(criterion_ids) <= plan_ids, "MMAO + MAO verification plan must cover every acceptance criterion")
+
+
 def validate_realtime() -> None:
     schema = load_json("realtime/connection-session.schema.json")
     validate_schema(
@@ -289,10 +395,11 @@ def main() -> None:
     validate_evidence()
     validate_skills()
     validate_human_choice_authorship()
+    validate_mmao_mao_identity_governance()
     validate_realtime()
     validate_pwa()
     print("KPGS-VNEXT PASS: governance/runtime-facing contracts are structurally coherent.")
-    print("Validated: capability leases, DNS estate seed, evidence, governed skills, human choice authorship, realtime recovery, adaptive PWA profile.")
+    print("Validated: capability leases, DNS estate seed, evidence, governed skills, human choice authorship, MMAO + MAO identity governance, realtime recovery, adaptive PWA profile.")
 
 
 if __name__ == "__main__":

--- a/tests/test_mmao_mao_identity_governance.py
+++ b/tests/test_mmao_mao_identity_governance.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MMAO_MAO = ROOT / "governance" / "kpgs-vnext" / "agent-governance" / "mmao-mao"
+
+
+def load_json(name: str) -> dict:
+    return json.loads((MMAO_MAO / name).read_text(encoding="utf-8"))
+
+
+class MMAOMAOIdentityGovernanceTests(unittest.TestCase):
+    def test_dependency_free_contract_validator_passes(self):
+        result = subprocess.run(
+            [sys.executable, str(MMAO_MAO / "validate.py")],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("KPGS-MMAO-MAO PASS", result.stdout)
+
+    def test_identity_is_separate_from_seat_interface_and_model(self):
+        record = load_json("fixtures/jiro-khelos-provenance.json")
+        self.assertEqual(record["identity"]["identity_id"], "jiro")
+        self.assertEqual(record["seat"]["seat_id"], "khelos-validator")
+        self.assertEqual(record["interface"]["interface_id"], "kiro")
+        self.assertEqual(record["model"]["model_id"], "Claude")
+        self.assertEqual(record["authority"]["scope_type"], "task-scoped")
+        self.assertIsNone(record["authority"]["global_maintenance_seat"])
+
+    def test_global_structural_maintenance_allowlist_is_exact(self):
+        matrix = load_json("fixtures/authority-boundary-matrix.json")
+        hierarchy = matrix["current_structural_maintenance_hierarchy"]
+        self.assertEqual(
+            [(row["rank"], row["actor"], row["title"]) for row in hierarchy],
+            [
+                (1, "Codex", "Chief Architect"),
+                (2, "Anti-Gravity", "Chief Facilitator"),
+                (3, "Cursor", "Lead Developer"),
+            ],
+        )
+        high_task = next(
+            row for row in matrix["task_scoped_authority"] if row["authority_class"] == "high-task-authority"
+        )
+        self.assertIn(
+            "Treat high authority in one task as a global structural-maintenance grant.",
+            high_task["forbidden_without_separate_elevation"],
+        )
+
+    def test_matrix_is_planned_and_keeps_identity_and_task_constant(self):
+        experiment = load_json("fixtures/recycler-mmao-plus-mao-experiment.json")
+        self.assertEqual(experiment["status"], "planned")
+        self.assertEqual(experiment["working_testimony"], "Recycler MMAO with Plus MAO")
+        invariant = experiment["controlled_invariants"]
+        expected_types = {"reference", "model-only", "interface-only", "seat-only", "substrate-comparison"}
+        self.assertEqual({run["comparison_type"] for run in experiment["comparison_runs"]}, expected_types)
+        for run in experiment["comparison_runs"]:
+            self.assertEqual(run["identity_id"], invariant["identity_id"])
+            self.assertEqual(run["task_id"], invariant["task_id"])
+            self.assertEqual(run["status"], "planned")
+            self.assertIsNone(run["actual_behavior"])
+            self.assertIsNone(run["tool_trace_ref"])
+            self.assertEqual(run["evidence_refs"], [])
+
+    def test_synthetic_failure_receipt_preserves_five_whys_and_non_voting_rtc(self):
+        receipt = load_json("fixtures/controlled-scope-breach-receipt.json")
+        self.assertEqual(receipt["receipt_status"], "synthetic-fixture")
+        self.assertEqual([why["index"] for why in receipt["five_whys"]], [1, 2, 3, 4, 5])
+        self.assertEqual(receipt["action_tool_trace"]["capture_mode"], "metadata-only")
+        self.assertEqual(receipt["retest"]["status"], "not-run")
+        self.assertEqual(receipt["review_aggregation"]["mode"], "evidence-convergence-not-vote")
+        self.assertEqual(receipt["review_aggregation"]["decision_rule"], "unsupported-claims-remain-held")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_now_situational_continuity.py
+++ b/tests/test_now_situational_continuity.py
@@ -37,8 +37,9 @@ class NowContinuityTests(unittest.TestCase):
         )
 
     def test_root_now_is_current_state_authority_and_preserves_history(self):
-        self.assertIn("Current-state authority", self.now)
-        self.assertIn("CURRENT STATE — 2026-08-24", self.now)
+        self.assertIn("## CURRENT STATE —", self.now)
+        self.assertIn("Repository-root `NOW.md` is the **volatile salience / temporal truth** layer.", self.now)
+        self.assertIn("## PRIOR STATE —", self.now)
         self.assertIn("HISTORICAL LOG — PRESERVED PROVENANCE", self.now)
         self.assertIn("2026-06-22T06:39 SAST", self.now)
         self.assertIn("repo root NOW.md is the comms lane", self.now)


### PR DESCRIPTION
## Summary

Adds the bounded MMAO + MAO identity-governance POC without rewriting existing MAO/MMAO/RTCP owners.

- separates identity, seat, interface, model/version, task, authority, context, provenance, and receipts;
- makes high task authority explicitly distinct from global GSMB structural-maintenance authority;
- preserves the current structural-maintenance boundary: Codex, Anti-Gravity, Cursor;
- adds a planned model x interface affinity matrix, synthetic Five Whys receipt, dependency-free validator, focused regression tests, NOW receipt, and Anti-Gravity handoff.

## Validation

- `python governance/kpgs-vnext/agent-governance/mmao-mao/validate.py`
- `python governance/kpgs-vnext/validate_contracts.py`
- focused MMAO + MAO and NOW continuity tests via `python -m unittest discover`
- `python -m py_compile ...`
- `git diff --check`

## Boundary

This validates contract structure only. It does not claim a live model/interface affinity result, global GSMB restructuring authority, or executed controlled run.