### PR TITLE
license: adopt Apache-2.0 as canonical KPGS repository license

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,9 +4,17 @@ This repository is governed by KPGS provenance and promotion rules.
 
 ## Current license status
 
-The repository-wide license decision is **pending explicit human-owner approval** under issue #47. Do not assume that absence of a root `LICENSE` file grants reuse permission, and do not label repository-authored material with a repository-wide SPDX identifier until the decision record authorizes it.
+Repository-authored material that the owner has legal authority to license is governed by the **Apache License 2.0** (`Apache-2.0`) under issue #47.
 
-See `governance/kpgs-vnext/licensing/license-decision.json` and `governance/kpgs-vnext/licensing/PROVENANCE_AND_LICENSE_POLICY.md`.
+See the root `LICENSE`, `governance/kpgs-vnext/licensing/license-decision.json`, and `governance/kpgs-vnext/licensing/PROVENANCE_AND_LICENSE_POLICY.md`.
+
+The root Apache-2.0 declaration does not overwrite third-party, vendored, imported, fork-derived, path-specific or otherwise separately licensed material.
+
+## Contribution licensing
+
+Unless a contributor explicitly states otherwise in writing, any original Contribution intentionally submitted for inclusion in this repository is submitted under Apache-2.0 in accordance with Section 5 of the Apache License 2.0.
+
+A contributor must have the legal authority to submit the Contribution. Material copied, adapted, imported, vendored or fork-derived from another source does not become Apache-2.0 merely because it is submitted here; its upstream license and compatibility must be verified first.
 
 ## Contribution requirements
 
@@ -26,10 +34,12 @@ For adapted, imported, vendored, generated or fork-derived material, include pro
 
 Functional correctness alone does not make third-party material canonical. If source, license, compatibility, attribution or authorization is unresolved, the artifact remains `reference`, `pending` or `unknown` and must not be promoted to `validated` / `approved` on licensing grounds.
 
+For repository-authored material, Apache-2.0 may be used as the target license only where the repository owner or contributor actually has the authority to grant those rights.
+
 ## Generated material
 
 Generated code/docs/assets must preserve source lineage and human review. Generation never erases restrictions inherited from source code, prompts containing protected material, input assets or external dependencies.
 
 ## Third-party notices
 
-When attribution is required, update `THIRD_PARTY_NOTICES.md` and any source-level notices required by the upstream license.
+When attribution is required, update `THIRD_PARTY_NOTICES.md` and any source-level notices or license files required by the upstream license.

--- a/LICENSE
+++ b/LICENSE
@@ -174,3 +174,28 @@
       of your accepting any such warranty or additional liability.
 
    END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,176 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -2,6 +2,8 @@
 
 This file records third-party attribution required by material admitted into `RobynAwesome/Introduction-to-MCP`.
 
+The root `Apache-2.0` license governs only repository-authored material that the repository owner has legal authority to license. It does **not** relicense, replace, weaken, or erase upstream licenses, copyright notices, attribution requirements, path-specific terms, or other third-party rights.
+
 The presence of an entry here does not replace source-level notices or license files required by an upstream license.
 
 ## Registry

--- a/governance/kpgs-vnext/licensing/PROVENANCE_AND_LICENSE_POLICY.md
+++ b/governance/kpgs-vnext/licensing/PROVENANCE_AND_LICENSE_POLICY.md
@@ -1,22 +1,27 @@
 # KPGS Repository Provenance and License Policy
 
-Status: **PROPOSED GOVERNANCE POLICY**  
+Status: **ACTIVE — HUMAN APPROVED**  
 Issue: #47  
-Repository: `RobynAwesome/Introduction-to-MCP`
+Repository: `RobynAwesome/Introduction-to-MCP`  
+Canonical SPDX: `Apache-2.0`
 
 ## 1. Current legal state
 
-The repository currently has no root `LICENSE` file and no canonical repository-wide SPDX identifier. KPGS therefore treats the repository license state as **undecided** until the human repository owner explicitly chooses a license model.
+The repository owner has explicitly authorized **Apache License 2.0** as the canonical repository license for repository-authored material for which the owner has legal authority to license.
 
-The machine-readable source of this status is:
+The root `LICENSE` file contains the Apache License 2.0 text. The machine-readable source of the decision is:
 
 `governance/kpgs-vnext/licensing/license-decision.json`
 
-A recommendation is not authorization. No agent, model, renter, CI process or maintainer automation may convert `RECOMMENDED_NOT_AUTHORIZED` into a repository license.
+The repository-wide declaration does **not** overwrite third-party, vendored, imported, fork-derived, path-specific or otherwise separately licensed material.
 
 ## 2. Human decision boundary
 
-The repository owner must explicitly choose one of the supported policy states before repository-authored material can inherit a canonical repository license:
+The human-owner decision recorded under issue #47 is now `HUMAN_APPROVED` with canonical SPDX `Apache-2.0`.
+
+Any future change to the canonical legal model remains a human decision. No agent, model, renter, CI process or maintainer automation may silently change the repository license or infer authority over material whose rights are not established.
+
+Supported future decision states remain:
 
 - `MIT`
 - `Apache-2.0`
@@ -24,7 +29,7 @@ The repository owner must explicitly choose one of the supported policy states b
 - `UNLICENSED`
 - `PATH_SPECIFIC`
 
-If `PATH_SPECIFIC` is chosen, each governed path must expose its own license evidence and SPDX/proprietary state. A path-specific license may not silently overwrite an upstream third-party license.
+If `PATH_SPECIFIC` is used for any governed path, that path must expose its own license evidence and SPDX/proprietary state. A path-specific declaration may not silently overwrite an upstream third-party license.
 
 ## 3. Contribution provenance
 
@@ -56,15 +61,15 @@ Before canonical admission:
 2. upstream license must be known or explicit permission must exist;
 3. required attribution/NOTICE must be preserved;
 4. target path license must be known;
-5. compatibility must be evaluated against the target path;
+5. compatibility must be evaluated against Apache-2.0 or the explicitly governed target-path license;
 6. executable material must pass security and governance review;
 7. the resulting manifest must retain source lineage.
 
-While this repository's root license decision remains pending, KPGS must not claim deterministic repository-wide compatibility for new adapted/imported code. Such artifacts remain `pending`, `reference`, or separately licensed by path.
+A root Apache-2.0 declaration is not evidence that an imported artifact is Apache-2.0-compatible. Compatibility is evaluated per artifact/path from actual upstream rights and obligations.
 
 ## 5. Existing third-party material
 
-A later repository license declaration applies only where the repository owner has the legal authority to license the material.
+The repository-wide Apache-2.0 declaration applies only where the repository owner has the legal authority to license the material.
 
 It must not:
 
@@ -74,6 +79,8 @@ It must not:
 - convert noncommercial/research-only material into commercial material;
 - convert unlicensed reference material into reusable code;
 - imply ownership of upstream work.
+
+Where a repository path contains material under another valid license, that material remains governed by its own terms unless the rights holder explicitly authorizes relicensing.
 
 ## 6. NOTICE / attribution
 
@@ -89,7 +96,7 @@ The notice record should include:
 - required notice text or attribution reference;
 - local path(s) consuming the material.
 
-KPGS provenance manifests remain required even when the upstream license does not mandate a NOTICE file.
+Apache-2.0 does not require creation of a repository `NOTICE` file merely because Apache-2.0 is selected. If this Work later includes a `NOTICE` file, Apache-2.0 redistribution requirements for that NOTICE apply. KPGS provenance manifests remain required even where an upstream license does not mandate a NOTICE file.
 
 ## 7. Generated code and assets
 
@@ -111,15 +118,17 @@ A skill manifest may move to `license_status: verified-compatible` only when all
 
 1. its origin/source lineage is explicit;
 2. the relevant source and target license states are known;
-3. compatibility has been evaluated;
+3. compatibility with Apache-2.0 or the governed target-path license has been evaluated;
 4. required attribution/NOTICE is present;
 5. no conflicting upstream restriction is hidden;
 6. the repository/path license decision is human-authorized where required.
 
 If any element is unknown, the skill remains `pending` or `unknown` and cannot be promoted to `validated` / `approved` solely on functional CI success.
 
-## 9. Recommendation currently on record
+## 9. Canonical decision
 
-`MIT` is recorded as the current **recommendation**, based on existing MIT-licensed skill packaging already present elsewhere in the governed ecosystem. This is evidence of an ecosystem pattern, not a license grant for this repository.
+The prior MIT entry was a `RECOMMENDED_NOT_AUTHORIZED` ecosystem recommendation only. It never licensed this repository and is retained as historical evidence in `license-decision.json`.
 
-Canonical license state remains `AWAITING_HUMAN_DECISION` until the owner explicitly authorizes a policy.
+The human owner has now selected **Apache-2.0**. This decision is canonical for repository-authored material within the owner's licensing authority because it preserves permissive reuse while adding an explicit contributor patent grant and clearer contribution/redistribution terms appropriate to long-lived KPGS protocols, runtimes, SDKs and multi-contributor infrastructure.
+
+Canonical license state: `HUMAN_APPROVED / Apache-2.0`.

--- a/governance/kpgs-vnext/licensing/license-decision.json
+++ b/governance/kpgs-vnext/licensing/license-decision.json
@@ -1,22 +1,35 @@
 {
-  "schema_version": "1.0",
+  "schema_version": "1.1",
   "repository": "RobynAwesome/Introduction-to-MCP",
   "issue": 47,
-  "decision_status": "AWAITING_HUMAN_DECISION",
+  "decision_status": "HUMAN_APPROVED",
   "current_repository_state": {
-    "root_license_file_present": false,
-    "canonical_spdx": null,
-    "repository_wide_license_claim_allowed": false
+    "root_license_file_present": true,
+    "canonical_spdx": "Apache-2.0",
+    "repository_wide_license_claim_allowed": true,
+    "scope": "Repository-authored material for which the repository owner has legal authority to license. Existing or imported third-party, vendored, fork-derived, path-specific, or otherwise separately licensed material retains its own governing terms."
   },
-  "recommendation": {
+  "human_decision": {
+    "spdx": "Apache-2.0",
+    "status": "AUTHORIZED",
+    "authorized_by": "Kholofelo Robyn Rababalela",
+    "authorization_source": "Explicit human-owner instruction to plan and implement Apache-2.0 licensing through the canonical repository on 2026-09-05.",
+    "authorized_at": "2026-09-05T18:14:00+02:00",
+    "rationale": [
+      "Apache-2.0 remains permissive while adding an explicit patent grant and patent-termination mechanism relevant to long-lived KPGS protocols, runtimes, SDKs and multi-contributor infrastructure.",
+      "The repository already has provenance, attribution and compatibility governance that maps cleanly to Apache-2.0 redistribution and contribution requirements.",
+      "The decision preserves third-party and path-specific licensing rather than treating a root license as authority over material the owner does not control."
+    ]
+  },
+  "superseded_recommendation": {
     "spdx": "MIT",
-    "status": "RECOMMENDED_NOT_AUTHORIZED",
+    "status": "SUPERSEDED_BY_HUMAN_DECISION",
     "basis": [
-      "Existing FivesArena skill packaging in the user's governed ecosystem declares MIT.",
-      "Existing KRRababalela skill packaging in the user's governed ecosystem declares MIT.",
-      "A permissive single SPDX identifier would simplify KPGS skill/package compatibility checks if the human owner chooses it."
+      "Existing FivesArena skill packaging in the governed ecosystem declared MIT.",
+      "Existing KRRababalela skill packaging in the governed ecosystem declared MIT.",
+      "A permissive single SPDX identifier simplified compatibility checks."
     ],
-    "non_claim": "This recommendation does not license this repository and must not be treated as owner consent."
+    "non_claim": "The earlier MIT recommendation was never authorization and did not license this repository."
   },
   "allowed_human_decisions": [
     "MIT",
@@ -25,8 +38,8 @@
     "UNLICENSED",
     "PATH_SPECIFIC"
   ],
-  "promotion_rule": "No repository-authored artifact may move from license_status unknown/pending to verified-compatible solely from this recommendation. A current human-approved decision and corresponding repository/path license evidence are required.",
-  "third_party_rule": "Existing or imported third-party licenses must be preserved exactly and may never be overwritten by a repository-wide declaration.",
+  "promotion_rule": "Repository-authored material may move from license_status unknown/pending to verified-compatible only when the relevant human-authorized repository/path decision, provenance, compatibility and attribution evidence are all satisfied.",
+  "third_party_rule": "Existing or imported third-party licenses must be preserved exactly and may never be overwritten by the repository-wide Apache-2.0 declaration.",
   "generated_material_rule": "Generated code, documentation and assets require provenance and human review; generation does not erase upstream rights, attribution duties or source-license constraints.",
-  "updated_at": "2026-08-17T15:47:00+02:00"
+  "updated_at": "2026-09-05T18:14:00+02:00"
 }

--- a/governance/kpgs-vnext/licensing/validate_license_policy.py
+++ b/governance/kpgs-vnext/licensing/validate_license_policy.py
@@ -20,6 +20,19 @@ def require(condition: bool, message: str) -> None:
         raise SystemExit(f"KPGS-LICENSE FAIL: {message}")
 
 
+def require_apache_2_license(path: Path) -> None:
+    require(path.is_file(), "Apache-2.0 state requires a root LICENSE file")
+    text = path.read_text(encoding="utf-8")
+    for marker in (
+        "Apache License",
+        "Version 2.0, January 2004",
+        "Grant of Patent License",
+        "Submission of Contributions",
+        "END OF TERMS AND CONDITIONS",
+    ):
+        require(marker in text, f"root LICENSE is missing canonical Apache-2.0 marker: {marker}")
+
+
 def main() -> None:
     decision = json.loads(DECISION.read_text(encoding="utf-8"))
 
@@ -33,7 +46,6 @@ def main() -> None:
     require(status in {"AWAITING_HUMAN_DECISION", "HUMAN_APPROVED"}, "unsupported decision_status")
 
     current = decision.get("current_repository_state", {})
-    recommendation = decision.get("recommendation", {})
     promotion_rule = decision.get("promotion_rule", "")
     third_party_rule = decision.get("third_party_rule", "")
 
@@ -41,26 +53,49 @@ def main() -> None:
     require("third-party" in third_party_rule.lower() or "third party" in third_party_rule.lower(), "third-party preservation rule is missing")
 
     if status == "AWAITING_HUMAN_DECISION":
+        recommendation = decision.get("recommendation", {})
         require(current.get("canonical_spdx") is None, "pending state cannot claim a canonical SPDX license")
         require(current.get("repository_wide_license_claim_allowed") is False, "pending state cannot allow repository-wide licensing claims")
         require(recommendation.get("status") == "RECOMMENDED_NOT_AUTHORIZED", "recommendation must remain non-authoritative while pending")
         require(not LICENSE.exists(), "root LICENSE appeared while decision record still says awaiting human decision")
     else:
-        require(recommendation.get("status") != "RECOMMENDED_NOT_AUTHORIZED" or current.get("canonical_spdx") is not None, "human-approved state must carry an explicit legal outcome")
+        human = decision.get("human_decision", {})
+        canonical = current.get("canonical_spdx")
+        require(human.get("status") == "AUTHORIZED", "human-approved state requires explicit AUTHORIZED decision evidence")
+        require(human.get("spdx") == canonical, "human decision SPDX must match current canonical SPDX")
+        require(bool(human.get("authorized_by")), "human-approved state requires authorized_by evidence")
+        require(bool(human.get("authorization_source")), "human-approved state requires authorization source evidence")
         require(current.get("repository_wide_license_claim_allowed") in {True, False}, "approved state must explicitly declare repository-wide claim authority")
-        if current.get("canonical_spdx") in {"MIT", "Apache-2.0"}:
-            require(LICENSE.is_file(), "approved open-source SPDX state requires a root LICENSE file")
+        require("third-party" in current.get("scope", "").lower() or "third party" in current.get("scope", "").lower(), "approved scope must preserve third-party boundaries")
+
+        if canonical == "Apache-2.0":
+            require(current.get("root_license_file_present") is True, "Apache-2.0 state must declare root LICENSE present")
+            require(current.get("repository_wide_license_claim_allowed") is True, "canonical Apache-2.0 state must authorize repository-authored licensing claims")
+            require_apache_2_license(LICENSE)
+        elif canonical == "MIT":
+            require(LICENSE.is_file(), "approved MIT state requires a root LICENSE file")
+        elif canonical in {"PROPRIETARY", "UNLICENSED", None}:
+            require(current.get("repository_wide_license_claim_allowed") is False, "non-open repository states cannot authorize open repository-wide SPDX claims")
 
     contributing = CONTRIBUTING.read_text(encoding="utf-8")
     require("provenance" in contributing.lower(), "contribution policy must preserve provenance")
     require("license" in contributing.lower(), "contribution policy must state license handling")
 
+    notices = NOTICES.read_text(encoding="utf-8")
+    require("does **not** relicense" in notices or "does not relicense" in notices.lower(), "third-party notice registry must state that root licensing does not relicense upstream material")
+
     policy = POLICY.read_text(encoding="utf-8")
     for phrase in ("Existing third-party material", "Generated code and assets", "KPGS skill promotion gate"):
         require(phrase in policy, f"policy missing required section: {phrase}")
 
+    if status == "HUMAN_APPROVED" and current.get("canonical_spdx") == "Apache-2.0":
+        require("ACTIVE — HUMAN APPROVED" in policy, "Apache-2.0 policy must be active and human approved")
+        require("Canonical license state: `HUMAN_APPROVED / Apache-2.0`." in policy, "policy must expose canonical Apache-2.0 decision")
+        require("Apache License 2.0" in contributing, "CONTRIBUTING.md must expose Apache-2.0 contribution terms")
+
+    canonical = current.get("canonical_spdx")
     print("KPGS-LICENSE PASS: repository license state is explicit and provenance promotion rules are structurally governed.")
-    print(f"Decision status: {status}; recommendation: {recommendation.get('spdx')} ({recommendation.get('status')}).")
+    print(f"Decision status: {status}; canonical SPDX: {canonical}.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #47.

## Human decision

The repository owner explicitly selected `Apache-2.0` as the canonical license for repository-authored material within the owner's legal authority.

This PR implements that decision through the existing KPGS licensing/provenance governance rather than bypassing it.

## Changes

- add root `LICENSE` with Apache License 2.0 text;
- move `license-decision.json` to `HUMAN_APPROVED / Apache-2.0`;
- retain the prior MIT recommendation as superseded historical evidence rather than rewriting it as if it were authorization;
- activate the provenance/license policy and bind compatibility checks to Apache-2.0;
- align contribution terms with Apache-2.0 Section 5 while preserving explicit contributor/legal-authority boundaries;
- state clearly that the root license does not relicense third-party, vendored, imported, fork-derived or path-specific material;
- harden `validate_license_policy.py` to require canonical Apache-2.0 markers and consistent human-approval evidence.

## Safety invariant

**The root Apache-2.0 declaration applies only to repository-authored material the owner has authority to license. Existing third-party/path-specific licenses and notices remain controlling for their material.**

## Validation

This touches governed licensing paths already watched by `.github/workflows/kpgs-vnext-phase0-gate.yml`. Merge only after the KPGS vNext contract gate passes.