### PR TITLE
Seed Project-Rune into registry, poc-vs-foc, and session boot

### DIFF
--- a/ACTIVE_PROJECT_REGISTRY.json
+++ b/ACTIVE_PROJECT_REGISTRY.json
@@ -228,6 +228,28 @@
       "local_checkout": "C:\\Users\\rkhol\\paws-and-potjie",
       "sync_status": "ALIGNED",
       "last_verified": "2026-08-29T03:55:00+02:00"
+    },
+    {
+      "entity_id": "PROJECT_RUNE",
+      "purpose": "RUNE — Runtime Unified Network Endorsement; fail-closed gate + append-only ledger for agent coordination and identity claims",
+      "canonical_repo": "https://github.com/RobynAwesome/Project-Rune",
+      "default_branch": "main",
+      "active_work_branch": "cursor/rune-pending-decisions-impl",
+      "current_revision": "4e47382e12b1f30a32f1161fc0679eea7f07c183",
+      "main_revision": "029d11e43d02b387ebf9f36e8288be4617905673",
+      "local_checkout": "C:\\Users\\rkhol\\source\\repos\\Project-Rune",
+      "local_metal_seed": "Schematics/28-Project Rune",
+      "sync_status": "CLOUD_PUBLISH_SURFACE",
+      "worktree": "pending_decisions_impl",
+      "governance_lane": "KPGS_GOVERNANCE",
+      "generation": "GEN_III",
+      "deployment": "reference MVP — not COMPLETE / DEMO READY; PENDING-001/002/003 implemented not owner-endorsed",
+      "dependencies": ["INTRODUCTION_TO_MCP"],
+      "validation_receipts": ["pytest_38_passed_1_skipped_2026-09-07"],
+      "epistemic_limits": "Ed25519 identity signatures; independence_claimed is claim-not-proof; fail-open only with RUNE_DEV_ESCAPE=1 non-production; Schematics remain gitignored vault",
+      "session_seed": "poc-vs-foc/RUNE_CROSSLINK.md + docs/swarm-ops/RUNE_SESSION_SEED_2026-09-07.md",
+      "last_verified": "2026-09-07T11:50:00+02:00",
+      "reconstruction_path": "git clone https://github.com/RobynAwesome/Project-Rune && git checkout cursor/rune-pending-decisions-impl && pip install -e \".[dev]\" && pytest -q"
     }
   ]
 }

--- a/docs/swarm-ops/RUNE_SESSION_SEED_2026-09-07.md
+++ b/docs/swarm-ops/RUNE_SESSION_SEED_2026-09-07.md
@@ -1,0 +1,31 @@
+# RUNE Session Seed — 2026-09-07
+
+**Status:** session seed / pointer receipt — **not** COMPLETE / PROVEN / DEMO READY  
+**Actor note:** Code patches ≠ owner endorsement. PENDING-001/002/003 remain `PENDING`.
+
+## What to load this session
+
+1. **Product repo:** https://github.com/RobynAwesome/Project-Rune  
+2. **Branch for decision work:** `cursor/rune-pending-decisions-impl` @ `4e47382e12b1f30a32f1161fc0679eea7f07c183`  
+3. **main tip (prior MVP):** `029d11e43d02b387ebf9f36e8288be4617905673`  
+4. **Local checkout:** `C:\Users\rkhol\source\repos\Project-Rune`  
+5. **Local vault:** `Schematics/28-Project Rune` (metal; often gitignored)  
+6. **VOC immune cross-link:** `poc-vs-foc/RUNE_CROSSLINK.md`  
+7. **Registry:** `ACTIVE_PROJECT_REGISTRY.json` → `PROJECT_RUNE`
+
+## Decisions (claim-not-endorsed)
+
+| ID | Proposal in code | Owner status |
+|---|---|---|
+| PENDING-001 | Ed25519 structured signatures; HMAC not identity | `PENDING` |
+| PENDING-002 | `independence_claimed`; independence unsolved | `PENDING` |
+| PENDING-003 | Fail-open only with `RUNE_DEV_ESCAPE=1` + non-production; high-risk never open; `gate_bypass` receipts | `PENDING` |
+
+## Validation receipt (automated only)
+
+- `pytest -q` on decision branch: **38 passed, 1 skipped** (2026-09-07)
+- Does **not** replace owner live gate + ledger receipt
+
+## Estate note
+
+OneDrive `Introduction to MCP` checkout may still be mid-rebase on `Kopano-Labs` remote — do not force-merge dirty trees into this seed. Cloud canonical for this seed push: `RobynAwesome/Introduction-to-MCP`.

--- a/poc-vs-foc/RUNE_CROSSLINK.md
+++ b/poc-vs-foc/RUNE_CROSSLINK.md
@@ -1,0 +1,26 @@
+# RUNE Cross-Link (Project-Rune ↔ poc-vs-foc)
+
+**Do not rewrite** `poc_foc_enforcer.py`. RUNE adds fail-closed endorsement receipts; this folder remains the GSMB VOC immune system.
+
+| RUNE FoC / PoC scenario | Expected | FoC affinity | Runnable |
+|---|---|---|---|
+| METR-style shared writable channel | Block without endorsement | ContextBleed / GhostExecution | Project-Rune `tests/test_scenarios_poc_foc.py` |
+| Multi-agent consensus vote | Reject (consensus ≠ endorsement) | SemanticDrift | same |
+| SOUL.md identity write | Gate → human endorse | ContextCorruption / SemanticDrift | same |
+| Completion claim without receipt | Block | GhostExecution | same |
+| Human-endorsed single-agent path | Allow + ledger receipt | PoC | same |
+
+## Cloud product
+
+- Repo: https://github.com/RobynAwesome/Project-Rune
+- `main`: `029d11e` (seeded MVP)
+- Active work: `cursor/rune-pending-decisions-impl` @ `4e47382` — PENDING-001 Ed25519 / PENDING-002 independence_claimed / PENDING-003 fail-open REVISE (**implemented, not owner-endorsed**)
+
+## Local metal
+
+- Vault seed: `Schematics/28-Project Rune` (gitignored; disk authority)
+- Checkout: `C:\Users\rkhol\source\repos\Project-Rune`
+
+## Session boot
+
+See `docs/swarm-ops/RUNE_SESSION_SEED_2026-09-07.md`.


### PR DESCRIPTION
## Summary
- Registers `PROJECT_RUNE` in `ACTIVE_PROJECT_REGISTRY.json` pointing at RobynAwesome/Project-Rune (`cursor/rune-pending-decisions-impl` @ `4e47382`).
- Adds `poc-vs-foc/RUNE_CROSSLINK.md` (VOC immune cross-link; does not rewrite `poc_foc_enforcer.py`).
- Adds `docs/swarm-ops/RUNE_SESSION_SEED_2026-09-07.md` for session boot.

## Test plan
- [x] Remote branch HEAD matches `9f08877`
- [x] Three seed files present on branch
- [ ] Confirm OneDrive local metal still mid-rebase — this PR is the clean cloud seed path only
- [ ] PENDING-001/002/003 remain PENDING until owner ratifies on Project-Rune

## Notes
- Seed / pointer PR only — not a claim that RUNE is COMPLETE / DEMO READY.