### PR TITLE
fix(security): browserslist GHSA-73wf + fail-closed dependency firewall

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,55 @@
+# Dependabot keeps npm/pip floors warm; CI dependency firewall fails closed on known GHSA floors.
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - security
+
+  - package-ecosystem: npm
+    directory: /kopano-core/studio
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - security
+
+  - package-ecosystem: npm
+    directory: /apps/kc-dashboard
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - security
+
+  - package-ecosystem: npm
+    directory: /tools/kpgs-browser-mcp
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - security
+
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - security
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  dependency-firewall:
+    name: Dependency firewall (npm floors)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Enforce DEPENDENCY_FIREWALL floors
+        run: python scripts/kc_dependency_firewall_gate.py
+
   lint-and-test:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    needs: dependency-firewall
     strategy:
       fail-fast: false
       matrix:
@@ -72,6 +90,7 @@ jobs:
   cli-package-check:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    needs: dependency-firewall
 
     steps:
       - uses: actions/checkout@v4
@@ -106,6 +125,7 @@ jobs:
   gui-check:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    needs: dependency-firewall
 
     defaults:
       run:
@@ -136,6 +156,7 @@ jobs:
     name: Agent build PoC (Bracket / BlackMask / Guardian / Identi / LPM / KPEFS)
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    needs: dependency-firewall
 
     steps:
       - uses: actions/checkout@v4

--- a/apps/kc-dashboard/package.json
+++ b/apps/kc-dashboard/package.json
@@ -22,5 +22,8 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "typescript": "7.0.2"
+  },
+  "overrides": {
+    "browserslist": ">=4.28.7"
   }
 }

--- a/docs/swarm-ops/DEPENDENCY_FIREWALL.json
+++ b/docs/swarm-ops/DEPENDENCY_FIREWALL.json
@@ -1,0 +1,32 @@
+{
+  "schema": "kopano.dependency_firewall.v1",
+  "purpose": "KHELOS-style npm minimum-version firewall. CI fails closed if any tracked lockfile installs a package below the floor.",
+  "admitted_by": "GHSA-73wf-gq98-2v4g / CVE-2026-73088 remediation + recurrence prevention",
+  "updated_at": "2026-09-08",
+  "npm": {
+    "minimum_versions": {
+      "browserslist": "4.28.7"
+    },
+    "blocked_advisories": [
+      {
+        "ghsa": "GHSA-73wf-gq98-2v4g",
+        "cve": "CVE-2026-73088",
+        "package": "browserslist",
+        "patched": "4.28.7"
+      }
+    ],
+    "lockfile_globs": [
+      "package-lock.json",
+      "**/package-lock.json"
+    ],
+    "ignore_path_substrings": [
+      "node_modules/",
+      ".git/"
+    ]
+  },
+  "enforcement": {
+    "ci_script": "scripts/kc_dependency_firewall_gate.py",
+    "package_json_overrides": "browserslist >= 4.28.7 in root, kopano-core/studio, apps/kc-dashboard",
+    "dependabot": ".github/dependabot.yml"
+  }
+}

--- a/kopano-core/studio/package-lock.json
+++ b/kopano-core/studio/package-lock.json
@@ -1466,9 +1466,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.12",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.12.tgz",
-      "integrity": "sha512-qyq26DxfY4awP2gIRXhhLWfwzwI+N5Nxk6iQi8EFizIaWIjqicQTE4sLnZZVdeKPRcVNoJOkkpfzoIYuvCKaIQ==",
+      "version": "2.11.21",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.21.tgz",
+      "integrity": "sha512-uh8vpY/1/YyFkunIDFH/12p7/7VdPKA1hejMVEbdkEaWnUz0Hesvx5EbiU6XxjyHZIOju+ZMbQJkRh+es3/spQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1490,9 +1490,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.9",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.9.tgz",
+      "integrity": "sha512-EWazOblFYUvlGZcfGhPUPmYh3nikUxBVb+y9MJun5f3hBi812X+8MSQTujLBtgK3cf51fJWbWfOjyeO954d+Eg==",
       "dev": true,
       "funding": [
         {
@@ -1510,11 +1510,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.11.20",
+        "caniuse-lite": "^1.0.30001810",
+        "electron-to-chromium": "^1.5.420",
+        "node-releases": "^2.0.54",
+        "update-browserslist-db": "^1.3.2"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1534,9 +1534,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001781",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001781.tgz",
-      "integrity": "sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==",
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
       "dev": true,
       "funding": [
         {
@@ -1663,9 +1663,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.328",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.328.tgz",
-      "integrity": "sha512-QNQ5l45DzYytThO21403XN3FvK0hOkWDG8viNf6jqS42msJ8I4tGDSpBCgvDRRPnkffafiwAym2X2eHeGD2V0w==",
+      "version": "1.5.423",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.423.tgz",
+      "integrity": "sha512-rRZfTSY8ptHYMQxa+uIycJMFKmY1T0GIApNMXJYGehguTZa56TEEl19pKPCoBqk5Gpf7QizZn/jt7xur+DYxag==",
       "dev": true,
       "license": "ISC"
     },
@@ -2585,11 +2585,14 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.36",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
-      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+      "version": "2.0.54",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
+      "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -2985,9 +2988,9 @@
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+      "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
       "dev": true,
       "funding": [
         {

--- a/kopano-core/studio/package.json
+++ b/kopano-core/studio/package.json
@@ -29,5 +29,8 @@
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.57.0",
     "vite": "^8.1.5"
+  },
+  "overrides": {
+    "browserslist": ">=4.28.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "scripts": {
     "build": "npm --prefix apps/kc-dashboard install && npm --prefix apps/kc-dashboard run build",
     "build:studio": "npm --prefix apps/kc-dashboard run build",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "firewall:deps": "python scripts/kc_dependency_firewall_gate.py"
   },
   "repository": {
     "type": "git",
@@ -27,5 +28,8 @@
   "bugs": {
     "url": "https://github.com/RobynAwesome/Introduction-to-MCP/issues"
   },
-  "homepage": "https://github.com/RobynAwesome/Introduction-to-MCP#readme"
+  "homepage": "https://github.com/RobynAwesome/Introduction-to-MCP#readme",
+  "overrides": {
+    "browserslist": ">=4.28.7"
+  }
 }

--- a/scripts/kc_dependency_firewall_gate.py
+++ b/scripts/kc_dependency_firewall_gate.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Fail closed when npm lockfiles install packages below the dependency firewall floor.
+
+Policy source: docs/swarm-ops/DEPENDENCY_FIREWALL.json
+Primary trigger: GHSA-73wf-gq98-2v4g (browserslist <= 4.28.6).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+POLICY_PATH = ROOT / "docs" / "swarm-ops" / "DEPENDENCY_FIREWALL.json"
+
+
+def parse_version(value: str) -> tuple[int, ...]:
+    """Parse a leading numeric semver prefix into comparable ints."""
+    core = value.strip().lstrip("vV").split("+", 1)[0].split("-", 1)[0]
+    parts: list[int] = []
+    for token in core.split("."):
+        digits = "".join(ch for ch in token if ch.isdigit())
+        if not digits:
+            break
+        parts.append(int(digits))
+    if not parts:
+        raise ValueError(f"unparseable version: {value!r}")
+    return tuple(parts)
+
+
+def version_lt(installed: str, minimum: str) -> bool:
+    a = parse_version(installed)
+    b = parse_version(minimum)
+    width = max(len(a), len(b))
+    a_pad = a + (0,) * (width - len(a))
+    b_pad = b + (0,) * (width - len(b))
+    return a_pad < b_pad
+
+
+def load_policy() -> dict[str, Any]:
+    if not POLICY_PATH.is_file():
+        raise SystemExit(f"FIREWALL FAIL: missing policy at {POLICY_PATH}")
+    return json.loads(POLICY_PATH.read_text(encoding="utf-8"))
+
+
+def discover_lockfiles(policy: dict[str, Any]) -> list[Path]:
+    ignore = policy.get("npm", {}).get("ignore_path_substrings", [])
+    found: list[Path] = []
+    for path in ROOT.rglob("package-lock.json"):
+        rel = path.relative_to(ROOT).as_posix()
+        if any(token in rel for token in ignore):
+            continue
+        found.append(path)
+    return sorted(found)
+
+
+def packages_from_lock(lock: dict[str, Any]) -> dict[str, str]:
+    """Map package name -> installed version from npm lockfile v1/v2/v3 shapes."""
+    out: dict[str, str] = {}
+
+    packages = lock.get("packages")
+    if isinstance(packages, dict):
+        for key, meta in packages.items():
+            if not isinstance(meta, dict):
+                continue
+            version = meta.get("version")
+            if not isinstance(version, str) or not version:
+                continue
+            name = meta.get("name")
+            if isinstance(name, str) and name:
+                out[name] = version
+                continue
+            # key like "node_modules/browserslist" or "node_modules/foo/node_modules/bar"
+            if "node_modules/" in key:
+                leaf = key.rsplit("node_modules/", 1)[-1]
+                if leaf and not leaf.startswith("."):
+                    out[leaf] = version
+
+    def walk_deps(node: dict[str, Any]) -> None:
+        deps = node.get("dependencies")
+        if not isinstance(deps, dict):
+            return
+        for name, meta in deps.items():
+            if not isinstance(meta, dict):
+                continue
+            version = meta.get("version")
+            if isinstance(version, str) and version:
+                out[name] = version
+            walk_deps(meta)
+
+    walk_deps(lock)
+    return out
+
+
+def check_lockfile(path: Path, floors: dict[str, str]) -> list[str]:
+    violations: list[str] = []
+    try:
+        lock = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return [f"{path.relative_to(ROOT).as_posix()}: invalid JSON ({exc})"]
+
+    installed = packages_from_lock(lock)
+    rel = path.relative_to(ROOT).as_posix()
+    for name, minimum in floors.items():
+        version = installed.get(name)
+        if version is None:
+            continue
+        try:
+            if version_lt(version, minimum):
+                violations.append(
+                    f"{rel}: {name}@{version} is below firewall floor {minimum}"
+                )
+        except ValueError as exc:
+            violations.append(f"{rel}: {name}@{version} ({exc})")
+    return violations
+
+
+def main() -> int:
+    policy = load_policy()
+    floors = policy.get("npm", {}).get("minimum_versions", {})
+    if not isinstance(floors, dict) or not floors:
+        print("FIREWALL FAIL: npm.minimum_versions missing/empty", file=sys.stderr)
+        return 2
+
+    lockfiles = discover_lockfiles(policy)
+    if not lockfiles:
+        print("FIREWALL FAIL: no package-lock.json files discovered", file=sys.stderr)
+        return 2
+
+    violations: list[str] = []
+    for lockfile in lockfiles:
+        violations.extend(check_lockfile(lockfile, floors))
+
+    print(f"Dependency firewall: scanned {len(lockfiles)} lockfile(s)")
+    for name, minimum in sorted(floors.items()):
+        print(f"  floor {name} >= {minimum}")
+
+    if violations:
+        print("FIREWALL FAIL: blocked packages detected", file=sys.stderr)
+        for item in violations:
+            print(f"  - {item}", file=sys.stderr)
+        print(
+            "Remediate with npm overrides + lockfile refresh, then re-run "
+            "scripts/kc_dependency_firewall_gate.py",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("FIREWALL PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Patch `browserslist` in `kopano-core/studio` from 4.28.1 → 4.28.9 (closes GHSA-73wf-gq98-2v4g / CVE-2026-73088)
- Pin npm `overrides` (`browserslist >= 4.28.7`) at root, studio, and kc-dashboard
- Add `docs/swarm-ops/DEPENDENCY_FIREWALL.json` + `scripts/kc_dependency_firewall_gate.py`
- Wire CI `dependency-firewall` job so other jobs fail closed if floors are violated
- Enable Dependabot weekly updates for npm/pip/actions

## Test plan
- [x] `python scripts/kc_dependency_firewall_gate.py` → FIREWALL PASS
- [ ] CI dependency-firewall job green on this PR
- [ ] Confirm Dependabot alert GHSA-73wf on Introduction-to-MCP closes after merge

Made with [Cursor](https://cursor.com)