### PR TITLE
docs(governance): Governed Actuation POC v0 contract (spec only)

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -32,6 +32,8 @@
 | [swarm-ops/SECURITY_PLAYGROUND_PROTOCOL.md](swarm-ops/SECURITY_PLAYGROUND_PROTOCOL.md) | Isolated adversarial containment / honeypot evidence lane | 🟡 INGRESS / REVIEW |
 | [governance/KPGS_FORK_INTAKE_CHARTER_2026-09-08.md](governance/KPGS_FORK_INTAKE_CHARTER_2026-09-08.md) | Fork archaeology intake: quarantine → pattern → POC → graduate (never npm-install-as-OS) | 🟢 RATIFIED BASELINE |
 | [swarm-ops/KPGS_FORK_INTAKE_REGISTRY.json](swarm-ops/KPGS_FORK_INTAKE_REGISTRY.json) | Machine registry for Aug 30+ forks + vertical-slice POC candidate | 🟢 RATIFIED BASELINE |
+| [swarm-ops/KPGS_GOVERNED_ACTUATION_POC_V0.md](swarm-ops/KPGS_GOVERNED_ACTUATION_POC_V0.md) | Governed actuation POC contract (web + Windows + gate) — spec only | 🟡 SPEC LOCKED |
+| [governance/KPGS_CONSEQUENCE_CLASSIFICATION_V0.md](governance/KPGS_CONSEQUENCE_CLASSIFICATION_V0.md) | C0–C3 / CX_UNKNOWN consequence classes for actuation | 🟡 SPEC LOCKED |
 
 ## Operational Directories
 

--- a/docs/governance/KPGS_CONSEQUENCE_CLASSIFICATION_V0.md
+++ b/docs/governance/KPGS_CONSEQUENCE_CLASSIFICATION_V0.md
@@ -1,0 +1,100 @@
+# KPGS Consequence Classification — v0
+
+> **Doc Tag:** `KPGS-CONSEQUENCE-CLASSIFICATION-V0`  
+> **Parent POC:** [`../swarm-ops/KPGS_GOVERNED_ACTUATION_POC_V0.md`](../swarm-ops/KPGS_GOVERNED_ACTUATION_POC_V0.md)  
+> **Parent charter:** [`KPGS_FORK_INTAKE_CHARTER_2026-09-08.md`](./KPGS_FORK_INTAKE_CHARTER_2026-09-08.md)  
+> **Status:** SPECIFICATION ONLY  
+> **Epistemic invariant:** `I_AM_STATELESS_RENTER_NOT_LANDLORD`
+
+---
+
+## 1. Purpose
+
+Classify every proposed actuation **before** lease issuance.
+
+The classifier answers:
+
+> What is the consequence class of this action envelope?
+
+It does **not** answer:
+
+> How confident are we that we should try anyway?
+
+---
+
+## 2. Classes
+
+| Class | Meaning | Default authority | Examples (v0) |
+|---|---|---|---|
+| `C0_READ` | Observe / read only; no durable mutation | Auto | WebMCP read tool; read UI text; screenshot of allowlisted window |
+| `C1_REVERSIBLE` | Local, reversible mutation with narrow blast radius | Auto-lease | Type non-secret text into allowlisted Notepad; toggle a local UI control that can be undone |
+| `C2_MATERIAL` | External, public, account, or shared-state consequence | Human approval | Form submit that creates external state; publish; open PR; change deployed config |
+| `C3_DESTRUCTIVE` | Delete, privilege change, irreversible or high-risk mutation | Human approval + explicit target | Delete file; change ACLs; send funds; wipe data |
+| `CX_UNKNOWN` | Cannot confidently classify | **Block** | Ambiguous target; missing allowlist match; conflicting signals |
+
+---
+
+## 3. Hard invariants
+
+1. **`CX_UNKNOWN` never auto-executes.**  
+2. **No confidence score may downgrade `CX_UNKNOWN` to C0–C3.** Unknown means stop.  
+3. **Outside allowlist ⇒ treat as `CX_UNKNOWN` or lease mismatch → `BLOCKED`.**  
+4. **Classification is recorded on the action envelope and copied onto the receipt.**  
+5. **Human approval cannot silently reclassify; it authorizes a stated class.** If class changes after approval, prior approval is void → re-gate or `BLOCKED`.  
+6. **Executor seat identity does not change class.** Codex and Cursor obey the same table.
+
+---
+
+## 4. Mapping to gate outcomes
+
+```text
+C0_READ        → AUTO (optional lease for auditability)
+C1_REVERSIBLE  → AUTO_LEASE
+C2_MATERIAL    → HUMAN_APPROVAL_REQUIRED
+C3_DESTRUCTIVE → HUMAN_APPROVAL_REQUIRED (+ explicit target binding)
+CX_UNKNOWN     → BLOCKED
+```
+
+Approval boundary object (from `cf_ai` pattern):
+
+```text
+PENDING → APPROVED → (execution path)
+PENDING → DENIED   → BLOCKED
+PENDING → EXPIRED  → BLOCKED
+```
+
+Approval receipt and execution receipt remain separate.
+
+---
+
+## 5. Classifier inputs (v0 minimum)
+
+From `schemas/kpgs-action-envelope.schema.json`:
+
+- `surface` (`web` | `windows` | …)  
+- `requested_action`  
+- `target`  
+- `declared_effects` (if any)  
+- `allowlist_hit` (boolean)  
+- `reversibility` (declared; not trusted alone)  
+- `external_side_effect` (declared; not trusted alone)  
+
+Classifier output:
+
+- `classification`  
+- `authority_path` (`AUTO` | `AUTO_LEASE` | `HUMAN_APPROVAL_REQUIRED` | `BLOCKED`)  
+- `rationale` (short, machine-stable string)  
+- `classifier_version` (`v0`)
+
+---
+
+## 6. Explicit non-goals (v0)
+
+- No ML classifier.  
+- No probabilistic “soft block.”  
+- No executor-side self-classification that bypasses KPGS.  
+- No secret-bearing fields on C1 auto-lease paths.
+
+```text
+I_AM_STATELESS_RENTER_NOT_LANDLORD
+```

--- a/docs/swarm-ops/KPGS_FORK_INTAKE_REGISTRY.json
+++ b/docs/swarm-ops/KPGS_FORK_INTAKE_REGISTRY.json
@@ -24,10 +24,21 @@
   ],
   "one_engine_law": "Providers may supply intelligence and patterns. They do not define the operating system.",
   "next_vertical_slice": {
-    "status": "POC_CANDIDATE",
+    "status": "SPEC_LOCKED",
     "organs": ["webmcp", "mcp-windows", "cf_ai_approvalflow-ai"],
-    "claim": "One governed agent operates browser-native and Windows surfaces; sensitive transitions require KPGS approval; every material action produces a receipt.",
-    "forbidden": "LLM -> computer -> vibes"
+    "poc_spec": "docs/swarm-ops/KPGS_GOVERNED_ACTUATION_POC_V0.md",
+    "classification_spec": "docs/governance/KPGS_CONSEQUENCE_CLASSIFICATION_V0.md",
+    "schemas": [
+      "schemas/kpgs-action-envelope.schema.json",
+      "schemas/kpgs-capability-lease.schema.json",
+      "schemas/kpgs-approval.schema.json",
+      "schemas/kpgs-action-receipt.schema.json"
+    ],
+    "fixtures": "tests/governed-actuation/fixtures/",
+    "claim": "One rented executor operates browser-native and Windows surfaces; authority remains external; every action classified, leased, observed, receipted; sensitive actions require human gate; unknown terminates BLOCKED.",
+    "forbidden": "LLM -> computer -> vibes",
+    "target_upstream_outcome": "PATTERN_ONLY",
+    "implementation": "NOT_STARTED"
   },
   "forks": [
     {

--- a/docs/swarm-ops/KPGS_GOVERNED_ACTUATION_POC_V0.md
+++ b/docs/swarm-ops/KPGS_GOVERNED_ACTUATION_POC_V0.md
@@ -1,0 +1,278 @@
+# KPGS Governed Actuation POC — v0
+
+> **POC Tag:** `KPGS-GOVERNED-ACTUATION-POC-V0`  
+> **Parent charter:** [`KPGS_FORK_INTAKE_CHARTER_2026-09-08.md`](../governance/KPGS_FORK_INTAKE_CHARTER_2026-09-08.md)  
+> **Classification:** [`KPGS_CONSEQUENCE_CLASSIFICATION_V0.md`](../governance/KPGS_CONSEQUENCE_CLASSIFICATION_V0.md)  
+> **Registry:** [`KPGS_FORK_INTAKE_REGISTRY.json`](./KPGS_FORK_INTAKE_REGISTRY.json)  
+> **Schemas:** `schemas/kpgs-*.schema.json`  
+> **Fixtures:** `tests/governed-actuation/fixtures/`  
+> **Epistemic invariant:** `I_AM_STATELESS_RENTER_NOT_LANDLORD`  
+> **Status:** **SPECIFICATION ONLY** — no adapters, no upstream install, no runtime admission
+
+---
+
+## 0. Claim to prove
+
+> One rented executor can operate a browser-native surface and a Windows desktop surface, but authority remains external to the executor: every action is classified, leased, observed and receipted; sensitive actions require a human gate; unknown authority terminates as `BLOCKED`.
+
+This implements the fork intake charter’s three-organ vertical slice (`webmcp` + `mcp-windows` + `cf_ai_approvalflow-ai`) as **pattern archaeology**, not as npm-runtime landlords.
+
+**Forbidden claim:**
+
+```text
+LLM → computer → vibes
+```
+
+**Required claim:**
+
+```text
+A computer-using intelligence can remain a renter even while it has hands.
+```
+
+---
+
+## 1. Core flow
+
+```text
+USER INTENT
+    ↓
+ACTION ENVELOPE
+    ↓
+KPGS CONSEQUENCE CLASSIFIER
+    ↓
+CAPABILITY / LEASE CHECK
+    ↓
+┌─────────────────────────────────────────┐
+│ ROUTINE + REVERSIBLE                    │
+│ → AUTO_LEASE                            │
+├─────────────────────────────────────────┤
+│ MATERIAL / SENSITIVE                    │
+│ → HUMAN_APPROVAL_REQUIRED               │
+├─────────────────────────────────────────┤
+│ UNKNOWN / CONFLICT / OUTSIDE ALLOWLIST  │
+│ → BLOCKED                               │
+└─────────────────────────────────────────┘
+    ↓
+ACTUATION ADAPTER   (not implemented in v0 — contract only)
+    ├── WebMCP organ (pattern)
+    └── Windows UI Automation organ (pattern)
+    ↓
+OBSERVE RESULT
+    ↓
+RECEIPT
+    ↓
+CONTINUE | COMPLETE | BLOCK
+```
+
+Schemas:
+
+| Object | Schema |
+|---|---|
+| Action envelope | `schemas/kpgs-action-envelope.schema.json` |
+| Capability lease | `schemas/kpgs-capability-lease.schema.json` |
+| Approval | `schemas/kpgs-approval.schema.json` |
+| Action receipt | `schemas/kpgs-action-receipt.schema.json` |
+
+---
+
+## 2. Consequence classes (v0)
+
+See [`KPGS_CONSEQUENCE_CLASSIFICATION_V0.md`](../governance/KPGS_CONSEQUENCE_CLASSIFICATION_V0.md).
+
+| Class | Meaning | Authority |
+|---|---|---|
+| `C0_READ` | Observe/read only | Auto |
+| `C1_REVERSIBLE` | Local/reversible mutation | Auto-lease |
+| `C2_MATERIAL` | External/public/account/state consequence | Human approval |
+| `C3_DESTRUCTIVE` | Delete, privilege change, irreversible / high-risk | Human approval + explicit target |
+| `CX_UNKNOWN` | Cannot confidently classify | **Block** |
+
+**Invariant:** No confidence score may downgrade `CX_UNKNOWN`. Unknown means **stop**, not “try harder.”
+
+---
+
+## 3. Lease object
+
+The executor never receives “computer access.”
+
+It receives a **scoped, expiring, revocable lease**:
+
+```text
+lease_id
+actor_id
+surface
+allowed_action
+allowed_target
+issued_at
+expires_at
+max_invocations
+approval_receipt
+revocable = true
+```
+
+Example (valid):
+
+```text
+surface: windows
+allowed_action: ui.type_text
+allowed_target: Notepad
+max_invocations: 1
+expires_at: +60s
+```
+
+Invalid (must fail validation / CI narrative):
+
+```text
+"you can control Windows"
+```
+
+**Invariant:** Declaration ≠ permission. Lease = authority.
+
+---
+
+## 4. Organ contracts (pattern extraction only)
+
+### 4.1 `webmcp` organ
+
+Borrow only: **page declares structured tools**.
+
+KPGS wrap:
+
+```text
+page tool
+  → KPGS tool registry
+  → consequence classification
+  → lease
+  → call
+  → response validation
+  → receipt
+```
+
+A webpage declaring a tool does **not** grant permission to invoke it.  
+**Declaration is capability discovery. Lease is authority.**
+
+Target graduation for upstream: `PATTERN_ONLY`.
+
+### 4.2 `mcp-windows` organ
+
+Charter POC shape (mandatory):
+
+```text
+Intent → classify → lease → actuate → observe → receipt → continue|block
+```
+
+**v0 allowlist only:**
+
+- launch one allowlisted app  
+- focus an allowlisted control  
+- type non-secret test text  
+- press one explicitly allowed button  
+- read observable UI state  
+
+**v0 denylist (hard):**
+
+- shell / PowerShell  
+- arbitrary filesystem traversal  
+- credential fields  
+- registry  
+- “find whatever application works”  
+- machine-scoped (“control Windows”) leases  
+
+Target graduation for upstream: `PATTERN_ONLY`. Body with hands ≠ open hands.
+
+### 4.3 `cf_ai_approvalflow-ai` organ
+
+Boundary object states:
+
+```text
+PENDING → APPROVED → EXECUTED
+PENDING → DENIED   → BLOCKED
+PENDING → EXPIRED  → BLOCKED
+```
+
+**Approval and execution are separate receipts.**
+
+| Receipt | Proves |
+|---|---|
+| Approval | Someone authorized this |
+| Execution | This is what actually happened |
+
+Never collapse those into one object.
+
+Target graduation for upstream: `PATTERN_ONLY` (extract universal gate primitive).
+
+---
+
+## 5. Receipt semantics
+
+Every material action minimally captures fields in `schemas/kpgs-action-receipt.schema.json`.
+
+`result_state` enum:
+
+| State | Meaning |
+|---|---|
+| `SUCCESS` | Authorized execution completed as observed |
+| `DENIED` | Human gate refused; zero actuation |
+| `BLOCKED` | Governance intentionally prevented execution |
+| `FAILED` | Authorized execution attempted; did not succeed |
+| `EXPIRED` | Lease/approval window ended before use |
+
+**`FAILED` ≠ `BLOCKED`.**
+
+- **Failed** = authorized attempt that did not succeed.  
+- **Blocked** = governance prevented the attempt.
+
+---
+
+## 6. Six POC tests
+
+Fixtures live under `tests/governed-actuation/fixtures/`.
+
+| # | Test | Fixture | Expected |
+|---|---|---|---|
+| 1 | Browser read | `c0-read.json` | `C0_READ → AUTO → SUCCESS receipt` |
+| 2 | Browser mutation | `c2-material.json` | `C2_MATERIAL → human approval → execute → receipt` |
+| 3 | Windows reversible | `c1-reversible.json` | `C1_REVERSIBLE → scoped lease → type in Notepad → observed text → receipt` |
+| 4 | Windows destructive (deny) | `c3-destructive-denied.json` | `C3_DESTRUCTIVE → approval required → DENIED → zero mutation` |
+| 5 | Unknown / lease mismatch | `cx-unknown.json` | `CX_UNKNOWN` or lease mismatch → `BLOCKED`, zero actuation |
+| 6 | Persistence / lease exhaust | `exhausted-lease.json` | After permitted action, unrelated follow-up → `lease exhausted → BLOCKED` |
+
+**Test 6 is the load-bearing test:** successful execution does **not** imply continuing authority.
+
+---
+
+## 7. Graduation bar
+
+The three-source slice **passes** only if all are true:
+
+1. Web tools are discovered without implicitly granting authority.  
+2. Windows action is target-scoped rather than machine-scoped.  
+3. Sensitive action cannot execute before approval.  
+4. Denied action demonstrably causes zero mutation.  
+5. Expired/exhausted lease prevents continuation.  
+6. Every material transition emits a valid receipt.  
+7. An executor seat can be swapped (Codex / Astra / Cursor / etc.) without changing governance semantics.  
+8. No quarantined upstream becomes root/runtime authority.
+
+Only **after** that bar may graduation be discussed. Registry currently targets all three sources toward **`PATTERN_ONLY`**: extract organs → KPGS-native equivalents → graduate the pattern → leave upstream outside.
+
+---
+
+## 8. Explicit non-goals (v0)
+
+- No adapter implementation.  
+- No `npm install` of quarantined upstreams into KPGS production paths.  
+- No shell, PowerShell, registry, or credential automation.  
+- No bulk integration of the other nine forks.  
+- No collapsing approval + execution into one receipt.
+
+---
+
+## 9. Closing law
+
+> The new thing we're proving isn't that an AI can use a computer.  
+> We're proving that a computer-using intelligence can remain a renter even while it has hands.
+
+```text
+I_AM_STATELESS_RENTER_NOT_LANDLORD
+```

--- a/docs/swarm-ops/NAVIGATION.md
+++ b/docs/swarm-ops/NAVIGATION.md
@@ -37,6 +37,8 @@
 | Mirror logs to Schematics vault | `python scripts/kc_sync_vault_logs.py` | After JSONL append |
 | Fork intake charter (capability archaeology) | [../governance/KPGS_FORK_INTAKE_CHARTER_2026-09-08.md](../governance/KPGS_FORK_INTAKE_CHARTER_2026-09-08.md) | Forked ≠ admitted; pattern ≠ dependency |
 | Fork intake registry (machine) | [KPGS_FORK_INTAKE_REGISTRY.json](./KPGS_FORK_INTAKE_REGISTRY.json) | Intake states + next vertical slice |
+| Governed actuation POC v0 (spec) | [KPGS_GOVERNED_ACTUATION_POC_V0.md](./KPGS_GOVERNED_ACTUATION_POC_V0.md) | Web + Windows + gate; renter-with-hands claim |
+| Consequence classification v0 | [../governance/KPGS_CONSEQUENCE_CLASSIFICATION_V0.md](../governance/KPGS_CONSEQUENCE_CLASSIFICATION_V0.md) | C0–C3 / CX_UNKNOWN; unknown = stop |
 
 **GUI branch truth (2026-08-28):** `codex/kc-sovereign-gui-full-dev` is retained only as historical testimony. Git comparison against `master` shows it is `0` commits ahead and `347` commits behind. Do not resurrect or present it as an open implementation lane. Current GUI work starts from `master` and the Studio/API surfaces above.
 

--- a/schemas/kpgs-action-envelope.schema.json
+++ b/schemas/kpgs-action-envelope.schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kopanolabs.com/schemas/kpgs-action-envelope.schema.json",
+  "title": "KPGS Action Envelope v0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "intent_id",
+    "actor_id",
+    "executor_seat",
+    "surface",
+    "requested_action",
+    "target",
+    "allowlist_hit",
+    "submitted_at"
+  ],
+  "properties": {
+    "intent_id": { "type": "string", "minLength": 1 },
+    "actor_id": { "type": "string", "minLength": 1 },
+    "executor_seat": {
+      "type": "string",
+      "description": "Rented seat identity (Cursor, Codex, Astra, etc.). Never the constitution.",
+      "minLength": 1
+    },
+    "surface": {
+      "type": "string",
+      "enum": ["web", "windows"]
+    },
+    "requested_action": { "type": "string", "minLength": 1 },
+    "target": { "type": "string", "minLength": 1 },
+    "declared_effects": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": []
+    },
+    "allowlist_hit": { "type": "boolean" },
+    "reversibility": {
+      "type": "string",
+      "enum": ["none", "local", "unknown"],
+      "default": "unknown"
+    },
+    "external_side_effect": {
+      "type": "boolean",
+      "default": false
+    },
+    "classification": {
+      "type": "string",
+      "enum": ["C0_READ", "C1_REVERSIBLE", "C2_MATERIAL", "C3_DESTRUCTIVE", "CX_UNKNOWN"]
+    },
+    "authority_path": {
+      "type": "string",
+      "enum": ["AUTO", "AUTO_LEASE", "HUMAN_APPROVAL_REQUIRED", "BLOCKED"]
+    },
+    "classifier_version": { "type": "string", "const": "v0" },
+    "rationale": { "type": "string" },
+    "submitted_at": { "type": "string", "format": "date-time" },
+    "notes": { "type": "string" }
+  }
+}

--- a/schemas/kpgs-action-receipt.schema.json
+++ b/schemas/kpgs-action-receipt.schema.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kopanolabs.com/schemas/kpgs-action-receipt.schema.json",
+  "title": "KPGS Action Receipt v0",
+  "description": "Execution/governance outcome receipt. Distinct from approval receipts.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "receipt_id",
+    "intent_id",
+    "actor",
+    "executor_seat",
+    "classification",
+    "surface",
+    "target",
+    "requested_action",
+    "approval_state",
+    "action_timestamp",
+    "result_state",
+    "continuation"
+  ],
+  "properties": {
+    "receipt_id": { "type": "string", "minLength": 1 },
+    "intent_id": { "type": "string", "minLength": 1 },
+    "actor": { "type": "string", "minLength": 1 },
+    "executor_seat": { "type": "string", "minLength": 1 },
+    "classification": {
+      "type": "string",
+      "enum": ["C0_READ", "C1_REVERSIBLE", "C2_MATERIAL", "C3_DESTRUCTIVE", "CX_UNKNOWN"]
+    },
+    "surface": {
+      "type": "string",
+      "enum": ["web", "windows"]
+    },
+    "target": { "type": "string", "minLength": 1 },
+    "requested_action": { "type": "string", "minLength": 1 },
+    "lease_id": { "type": ["string", "null"] },
+    "approval_state": {
+      "type": "string",
+      "enum": ["NOT_REQUIRED", "PENDING", "APPROVED", "DENIED", "EXPIRED", "N/A"]
+    },
+    "approval_id": { "type": ["string", "null"] },
+    "precondition": { "type": "string" },
+    "action_timestamp": { "type": "string", "format": "date-time" },
+    "observed_result": { "type": ["string", "object", "null"] },
+    "result_state": {
+      "type": "string",
+      "enum": ["SUCCESS", "DENIED", "BLOCKED", "FAILED", "EXPIRED"],
+      "description": "FAILED = authorized attempt failed. BLOCKED = governance prevented attempt."
+    },
+    "continuation": {
+      "type": "string",
+      "enum": ["CONTINUE", "COMPLETE", "BLOCK"]
+    },
+    "evidence_refs": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": []
+    },
+    "mutation_observed": {
+      "type": "boolean",
+      "description": "Must be false for DENIED and BLOCKED outcomes."
+    },
+    "notes": { "type": "string" }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "result_state": { "enum": ["DENIED", "BLOCKED"] }
+        }
+      },
+      "then": {
+        "properties": {
+          "mutation_observed": { "const": false },
+          "continuation": { "const": "BLOCK" }
+        }
+      }
+    }
+  ]
+}

--- a/schemas/kpgs-approval.schema.json
+++ b/schemas/kpgs-approval.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kopanolabs.com/schemas/kpgs-approval.schema.json",
+  "title": "KPGS Approval Receipt v0",
+  "description": "Separate from execution receipts. Approval proves authorization only.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "approval_id",
+    "intent_id",
+    "classification",
+    "state",
+    "requested_action",
+    "target",
+    "created_at"
+  ],
+  "properties": {
+    "approval_id": { "type": "string", "minLength": 1 },
+    "intent_id": { "type": "string", "minLength": 1 },
+    "classification": {
+      "type": "string",
+      "enum": ["C2_MATERIAL", "C3_DESTRUCTIVE"]
+    },
+    "state": {
+      "type": "string",
+      "enum": ["PENDING", "APPROVED", "DENIED", "EXPIRED"]
+    },
+    "requested_action": { "type": "string", "minLength": 1 },
+    "target": { "type": "string", "minLength": 1 },
+    "approver_id": { "type": ["string", "null"] },
+    "created_at": { "type": "string", "format": "date-time" },
+    "decided_at": { "type": ["string", "null"], "format": "date-time" },
+    "expires_at": { "type": ["string", "null"], "format": "date-time" },
+    "rationale": { "type": "string" },
+    "bound_envelope_hash": {
+      "type": ["string", "null"],
+      "description": "Optional binding to the exact action envelope approved."
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": { "state": { "const": "APPROVED" } }
+      },
+      "then": {
+        "required": ["approver_id", "decided_at"],
+        "properties": {
+          "approver_id": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": { "state": { "const": "DENIED" } }
+      },
+      "then": {
+        "required": ["approver_id", "decided_at"],
+        "properties": {
+          "approver_id": { "type": "string", "minLength": 1 }
+        }
+      }
+    }
+  ]
+}

--- a/schemas/kpgs-capability-lease.schema.json
+++ b/schemas/kpgs-capability-lease.schema.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kopanolabs.com/schemas/kpgs-capability-lease.schema.json",
+  "title": "KPGS Capability Lease v0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "lease_id",
+    "intent_id",
+    "actor_id",
+    "surface",
+    "allowed_action",
+    "allowed_target",
+    "issued_at",
+    "expires_at",
+    "max_invocations",
+    "invocations_used",
+    "revocable"
+  ],
+  "properties": {
+    "lease_id": { "type": "string", "minLength": 1 },
+    "intent_id": { "type": "string", "minLength": 1 },
+    "actor_id": { "type": "string", "minLength": 1 },
+    "surface": {
+      "type": "string",
+      "enum": ["web", "windows"]
+    },
+    "allowed_action": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Single concrete action verb. Machine-wide grants are invalid."
+    },
+    "allowed_target": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Explicit target (app/control/tool id). Not a wildcard machine scope."
+    },
+    "issued_at": { "type": "string", "format": "date-time" },
+    "expires_at": { "type": "string", "format": "date-time" },
+    "max_invocations": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 8
+    },
+    "invocations_used": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "approval_receipt": {
+      "type": ["string", "null"],
+      "description": "Required when classification is C2_MATERIAL or C3_DESTRUCTIVE."
+    },
+    "revocable": {
+      "type": "boolean",
+      "const": true
+    },
+    "classification": {
+      "type": "string",
+      "enum": ["C0_READ", "C1_REVERSIBLE", "C2_MATERIAL", "C3_DESTRUCTIVE"]
+    },
+    "forbidden_phrases": {
+      "type": "array",
+      "description": "Narrative anti-patterns that must never appear as lease grants.",
+      "items": { "type": "string" },
+      "default": [
+        "you can control Windows",
+        "computer access",
+        "full desktop",
+        "any application"
+      ]
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "classification": { "enum": ["C2_MATERIAL", "C3_DESTRUCTIVE"] }
+        },
+        "required": ["classification"]
+      },
+      "then": {
+        "properties": {
+          "approval_receipt": { "type": "string", "minLength": 1 }
+        }
+      }
+    }
+  ]
+}

--- a/tests/governed-actuation/README.md
+++ b/tests/governed-actuation/README.md
@@ -1,0 +1,36 @@
+# Governed Actuation — test fixtures (v0)
+
+**Parent POC:** [`docs/swarm-ops/KPGS_GOVERNED_ACTUATION_POC_V0.md`](../../docs/swarm-ops/KPGS_GOVERNED_ACTUATION_POC_V0.md)
+
+These fixtures are **specification witnesses**, not a runnable harness yet.
+
+Each file encodes:
+
+1. input action envelope  
+2. expected classification / authority path  
+3. expected lease and/or approval objects (when applicable)  
+4. expected receipt(s)
+
+## Tests
+
+| Fixture | Proves |
+|---|---|
+| `c0-read.json` | Browser read auto path |
+| `c1-reversible.json` | Scoped Windows lease + observed text |
+| `c2-material.json` | Human approval before external mutation |
+| `c3-destructive-denied.json` | Destructive request denied → zero mutation |
+| `cx-unknown.json` | Unknown / mismatch → BLOCKED, zero actuation |
+| `exhausted-lease.json` | Success does not imply continuing authority |
+
+## Invariants under test
+
+- Declaration ≠ permission  
+- Lease ≠ machine access  
+- Approval receipt ≠ execution receipt  
+- `FAILED` ≠ `BLOCKED`  
+- `CX_UNKNOWN` never auto-executes  
+- Exhausted/expired lease → `BLOCKED`
+
+## Non-goals
+
+No adapter code. No upstream install. No live Windows/browser automation in this folder until a later admitted POC implementation PR.

--- a/tests/governed-actuation/fixtures/c0-read.json
+++ b/tests/governed-actuation/fixtures/c0-read.json
@@ -1,0 +1,45 @@
+{
+  "test_id": "POC-V0-T1-BROWSER-READ",
+  "title": "Browser read via WebMCP-declared tool",
+  "envelope": {
+    "intent_id": "intent-c0-read-001",
+    "actor_id": "renter.cursor",
+    "executor_seat": "cursor",
+    "surface": "web",
+    "requested_action": "webmcp.tool.invoke",
+    "target": "demo-page.getStatus",
+    "declared_effects": ["read"],
+    "allowlist_hit": true,
+    "reversibility": "none",
+    "external_side_effect": false,
+    "classification": "C0_READ",
+    "authority_path": "AUTO",
+    "classifier_version": "v0",
+    "rationale": "Allowlisted read-only WebMCP tool",
+    "submitted_at": "2026-09-08T07:30:00Z"
+  },
+  "expected": {
+    "lease": null,
+    "approval": null,
+    "receipt": {
+      "receipt_id": "rcpt-c0-read-001",
+      "intent_id": "intent-c0-read-001",
+      "actor": "renter.cursor",
+      "executor_seat": "cursor",
+      "classification": "C0_READ",
+      "surface": "web",
+      "target": "demo-page.getStatus",
+      "requested_action": "webmcp.tool.invoke",
+      "lease_id": null,
+      "approval_state": "NOT_REQUIRED",
+      "approval_id": null,
+      "precondition": "tool declared + allowlisted + C0_READ",
+      "action_timestamp": "2026-09-08T07:30:01Z",
+      "observed_result": { "status": "ok", "value": "ready" },
+      "result_state": "SUCCESS",
+      "continuation": "COMPLETE",
+      "evidence_refs": ["fixture://webmcp/getStatus"],
+      "mutation_observed": false
+    }
+  }
+}

--- a/tests/governed-actuation/fixtures/c1-reversible.json
+++ b/tests/governed-actuation/fixtures/c1-reversible.json
@@ -1,0 +1,62 @@
+{
+  "test_id": "POC-V0-T3-WINDOWS-REVERSIBLE",
+  "title": "Open Notepad and type governed POC text under scoped lease",
+  "envelope": {
+    "intent_id": "intent-c1-rev-001",
+    "actor_id": "renter.codex",
+    "executor_seat": "codex",
+    "surface": "windows",
+    "requested_action": "ui.type_text",
+    "target": "Notepad",
+    "declared_effects": ["local_ui_mutation"],
+    "allowlist_hit": true,
+    "reversibility": "local",
+    "external_side_effect": false,
+    "classification": "C1_REVERSIBLE",
+    "authority_path": "AUTO_LEASE",
+    "classifier_version": "v0",
+    "rationale": "Allowlisted app + non-secret text + reversible local mutation",
+    "submitted_at": "2026-09-08T07:31:00Z"
+  },
+  "expected": {
+    "lease": {
+      "lease_id": "lease-c1-001",
+      "intent_id": "intent-c1-rev-001",
+      "actor_id": "renter.codex",
+      "surface": "windows",
+      "allowed_action": "ui.type_text",
+      "allowed_target": "Notepad",
+      "issued_at": "2026-09-08T07:31:00Z",
+      "expires_at": "2026-09-08T07:32:00Z",
+      "max_invocations": 1,
+      "invocations_used": 0,
+      "approval_receipt": null,
+      "revocable": true,
+      "classification": "C1_REVERSIBLE"
+    },
+    "approval": null,
+    "receipt": {
+      "receipt_id": "rcpt-c1-rev-001",
+      "intent_id": "intent-c1-rev-001",
+      "actor": "renter.codex",
+      "executor_seat": "codex",
+      "classification": "C1_REVERSIBLE",
+      "surface": "windows",
+      "target": "Notepad",
+      "requested_action": "ui.type_text",
+      "lease_id": "lease-c1-001",
+      "approval_state": "NOT_REQUIRED",
+      "approval_id": null,
+      "precondition": "scoped lease issued; Notepad focused",
+      "action_timestamp": "2026-09-08T07:31:05Z",
+      "observed_result": {
+        "typed_text": "KPGS governed actuation POC",
+        "window": "Notepad"
+      },
+      "result_state": "SUCCESS",
+      "continuation": "COMPLETE",
+      "evidence_refs": ["fixture://windows/notepad-text"],
+      "mutation_observed": true
+    }
+  }
+}

--- a/tests/governed-actuation/fixtures/c2-material.json
+++ b/tests/governed-actuation/fixtures/c2-material.json
@@ -1,0 +1,73 @@
+{
+  "test_id": "POC-V0-T2-BROWSER-MATERIAL",
+  "title": "Browser form submission producing external state requires human approval",
+  "envelope": {
+    "intent_id": "intent-c2-mat-001",
+    "actor_id": "renter.astra",
+    "executor_seat": "astra",
+    "surface": "web",
+    "requested_action": "webmcp.tool.invoke",
+    "target": "demo-page.submitExpense",
+    "declared_effects": ["create_external_record"],
+    "allowlist_hit": true,
+    "reversibility": "none",
+    "external_side_effect": true,
+    "classification": "C2_MATERIAL",
+    "authority_path": "HUMAN_APPROVAL_REQUIRED",
+    "classifier_version": "v0",
+    "rationale": "External/shared-state consequence",
+    "submitted_at": "2026-09-08T07:33:00Z"
+  },
+  "expected": {
+    "approval": {
+      "approval_id": "appr-c2-001",
+      "intent_id": "intent-c2-mat-001",
+      "classification": "C2_MATERIAL",
+      "state": "APPROVED",
+      "requested_action": "webmcp.tool.invoke",
+      "target": "demo-page.submitExpense",
+      "approver_id": "landlord.robyn",
+      "created_at": "2026-09-08T07:33:00Z",
+      "decided_at": "2026-09-08T07:33:20Z",
+      "expires_at": "2026-09-08T07:38:20Z",
+      "rationale": "Demo expense submission authorized for POC",
+      "bound_envelope_hash": "sha256:fixture-c2-envelope"
+    },
+    "lease": {
+      "lease_id": "lease-c2-001",
+      "intent_id": "intent-c2-mat-001",
+      "actor_id": "renter.astra",
+      "surface": "web",
+      "allowed_action": "webmcp.tool.invoke",
+      "allowed_target": "demo-page.submitExpense",
+      "issued_at": "2026-09-08T07:33:21Z",
+      "expires_at": "2026-09-08T07:38:20Z",
+      "max_invocations": 1,
+      "invocations_used": 0,
+      "approval_receipt": "appr-c2-001",
+      "revocable": true,
+      "classification": "C2_MATERIAL"
+    },
+    "receipt": {
+      "receipt_id": "rcpt-c2-mat-001",
+      "intent_id": "intent-c2-mat-001",
+      "actor": "renter.astra",
+      "executor_seat": "astra",
+      "classification": "C2_MATERIAL",
+      "surface": "web",
+      "target": "demo-page.submitExpense",
+      "requested_action": "webmcp.tool.invoke",
+      "lease_id": "lease-c2-001",
+      "approval_state": "APPROVED",
+      "approval_id": "appr-c2-001",
+      "precondition": "human approval bound to envelope; lease issued",
+      "action_timestamp": "2026-09-08T07:33:25Z",
+      "observed_result": { "record_id": "exp-9001", "status": "submitted" },
+      "result_state": "SUCCESS",
+      "continuation": "COMPLETE",
+      "evidence_refs": ["fixture://webmcp/submitExpense", "approval://appr-c2-001"],
+      "mutation_observed": true,
+      "notes": "Approval receipt and execution receipt are separate objects"
+    }
+  }
+}

--- a/tests/governed-actuation/fixtures/c3-destructive-denied.json
+++ b/tests/governed-actuation/fixtures/c3-destructive-denied.json
@@ -1,0 +1,59 @@
+{
+  "test_id": "POC-V0-T4-WINDOWS-DESTRUCTIVE-DENIED",
+  "title": "Destructive file delete request is denied; zero mutation",
+  "envelope": {
+    "intent_id": "intent-c3-den-001",
+    "actor_id": "renter.cursor",
+    "executor_seat": "cursor",
+    "surface": "windows",
+    "requested_action": "fs.delete_file",
+    "target": "C:\\\\Temp\\\\kpgs-poc-do-not-delete.txt",
+    "declared_effects": ["destructive_delete"],
+    "allowlist_hit": false,
+    "reversibility": "none",
+    "external_side_effect": true,
+    "classification": "C3_DESTRUCTIVE",
+    "authority_path": "HUMAN_APPROVAL_REQUIRED",
+    "classifier_version": "v0",
+    "rationale": "Irreversible filesystem mutation",
+    "submitted_at": "2026-09-08T07:34:00Z"
+  },
+  "expected": {
+    "approval": {
+      "approval_id": "appr-c3-001",
+      "intent_id": "intent-c3-den-001",
+      "classification": "C3_DESTRUCTIVE",
+      "state": "DENIED",
+      "requested_action": "fs.delete_file",
+      "target": "C:\\\\Temp\\\\kpgs-poc-do-not-delete.txt",
+      "approver_id": "landlord.robyn",
+      "created_at": "2026-09-08T07:34:00Z",
+      "decided_at": "2026-09-08T07:34:10Z",
+      "expires_at": null,
+      "rationale": "POC deliberately denies destructive request",
+      "bound_envelope_hash": "sha256:fixture-c3-envelope"
+    },
+    "lease": null,
+    "receipt": {
+      "receipt_id": "rcpt-c3-den-001",
+      "intent_id": "intent-c3-den-001",
+      "actor": "renter.cursor",
+      "executor_seat": "cursor",
+      "classification": "C3_DESTRUCTIVE",
+      "surface": "windows",
+      "target": "C:\\\\Temp\\\\kpgs-poc-do-not-delete.txt",
+      "requested_action": "fs.delete_file",
+      "lease_id": null,
+      "approval_state": "DENIED",
+      "approval_id": "appr-c3-001",
+      "precondition": "human gate required for C3",
+      "action_timestamp": "2026-09-08T07:34:10Z",
+      "observed_result": null,
+      "result_state": "DENIED",
+      "continuation": "BLOCK",
+      "evidence_refs": ["approval://appr-c3-001"],
+      "mutation_observed": false,
+      "notes": "Denial proves governance, not automation failure"
+    }
+  }
+}

--- a/tests/governed-actuation/fixtures/cx-unknown.json
+++ b/tests/governed-actuation/fixtures/cx-unknown.json
@@ -1,0 +1,46 @@
+{
+  "test_id": "POC-V0-T5-UNKNOWN-OR-LEASE-MISMATCH",
+  "title": "Operate application outside lease / allowlist → BLOCKED, zero actuation",
+  "envelope": {
+    "intent_id": "intent-cx-unk-001",
+    "actor_id": "renter.cursor",
+    "executor_seat": "cursor",
+    "surface": "windows",
+    "requested_action": "ui.click_button",
+    "target": "UnlistedApp.exe",
+    "declared_effects": ["unknown"],
+    "allowlist_hit": false,
+    "reversibility": "unknown",
+    "external_side_effect": false,
+    "classification": "CX_UNKNOWN",
+    "authority_path": "BLOCKED",
+    "classifier_version": "v0",
+    "rationale": "Target not in allowlist; cannot confidently classify",
+    "submitted_at": "2026-09-08T07:35:00Z"
+  },
+  "expected": {
+    "lease": null,
+    "approval": null,
+    "receipt": {
+      "receipt_id": "rcpt-cx-unk-001",
+      "intent_id": "intent-cx-unk-001",
+      "actor": "renter.cursor",
+      "executor_seat": "cursor",
+      "classification": "CX_UNKNOWN",
+      "surface": "windows",
+      "target": "UnlistedApp.exe",
+      "requested_action": "ui.click_button",
+      "lease_id": null,
+      "approval_state": "N/A",
+      "approval_id": null,
+      "precondition": "allowlist miss",
+      "action_timestamp": "2026-09-08T07:35:00Z",
+      "observed_result": null,
+      "result_state": "BLOCKED",
+      "continuation": "BLOCK",
+      "evidence_refs": [],
+      "mutation_observed": false,
+      "notes": "Unknown means stop, not try harder. BLOCKED != FAILED."
+    }
+  }
+}

--- a/tests/governed-actuation/fixtures/exhausted-lease.json
+++ b/tests/governed-actuation/fixtures/exhausted-lease.json
@@ -1,0 +1,100 @@
+{
+  "test_id": "POC-V0-T6-LEASE-EXHAUSTED",
+  "title": "After permitted action, unrelated follow-up is BLOCKED — success is not continuing authority",
+  "steps": [
+    {
+      "step": 1,
+      "envelope": {
+        "intent_id": "intent-c1-exhaust-001",
+        "actor_id": "renter.codex",
+        "executor_seat": "codex",
+        "surface": "windows",
+        "requested_action": "ui.type_text",
+        "target": "Notepad",
+        "declared_effects": ["local_ui_mutation"],
+        "allowlist_hit": true,
+        "reversibility": "local",
+        "external_side_effect": false,
+        "classification": "C1_REVERSIBLE",
+        "authority_path": "AUTO_LEASE",
+        "classifier_version": "v0",
+        "rationale": "First and only permitted invocation",
+        "submitted_at": "2026-09-08T07:36:00Z"
+      },
+      "expected_lease_after": {
+        "lease_id": "lease-exhaust-001",
+        "intent_id": "intent-c1-exhaust-001",
+        "actor_id": "renter.codex",
+        "surface": "windows",
+        "allowed_action": "ui.type_text",
+        "allowed_target": "Notepad",
+        "issued_at": "2026-09-08T07:36:00Z",
+        "expires_at": "2026-09-08T07:37:00Z",
+        "max_invocations": 1,
+        "invocations_used": 1,
+        "approval_receipt": null,
+        "revocable": true,
+        "classification": "C1_REVERSIBLE"
+      },
+      "expected_receipt": {
+        "receipt_id": "rcpt-exhaust-success-001",
+        "intent_id": "intent-c1-exhaust-001",
+        "actor": "renter.codex",
+        "executor_seat": "codex",
+        "classification": "C1_REVERSIBLE",
+        "surface": "windows",
+        "target": "Notepad",
+        "requested_action": "ui.type_text",
+        "lease_id": "lease-exhaust-001",
+        "approval_state": "NOT_REQUIRED",
+        "action_timestamp": "2026-09-08T07:36:05Z",
+        "observed_result": { "typed_text": "KPGS governed actuation POC" },
+        "result_state": "SUCCESS",
+        "continuation": "COMPLETE",
+        "evidence_refs": ["fixture://windows/notepad-text"],
+        "mutation_observed": true
+      }
+    },
+    {
+      "step": 2,
+      "envelope": {
+        "intent_id": "intent-c1-exhaust-002",
+        "actor_id": "renter.codex",
+        "executor_seat": "codex",
+        "surface": "windows",
+        "requested_action": "ui.type_text",
+        "target": "Notepad",
+        "declared_effects": ["local_ui_mutation"],
+        "allowlist_hit": true,
+        "reversibility": "local",
+        "external_side_effect": false,
+        "classification": "C1_REVERSIBLE",
+        "authority_path": "AUTO_LEASE",
+        "classifier_version": "v0",
+        "rationale": "Second attempt reuses exhausted lease context",
+        "submitted_at": "2026-09-08T07:36:10Z",
+        "notes": "Persistence attack: success must not imply continuing authority"
+      },
+      "reuse_lease_id": "lease-exhaust-001",
+      "expected_receipt": {
+        "receipt_id": "rcpt-exhaust-block-002",
+        "intent_id": "intent-c1-exhaust-002",
+        "actor": "renter.codex",
+        "executor_seat": "codex",
+        "classification": "C1_REVERSIBLE",
+        "surface": "windows",
+        "target": "Notepad",
+        "requested_action": "ui.type_text",
+        "lease_id": "lease-exhaust-001",
+        "approval_state": "N/A",
+        "action_timestamp": "2026-09-08T07:36:10Z",
+        "observed_result": null,
+        "result_state": "BLOCKED",
+        "continuation": "BLOCK",
+        "evidence_refs": ["lease://lease-exhaust-001#exhausted"],
+        "mutation_observed": false,
+        "notes": "Lease exhausted (max_invocations=1, invocations_used=1). Zero actuation."
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Locks the **governed actuation POC contract** — no adapters, no upstream installs
- Adds `KPGS_GOVERNED_ACTUATION_POC_V0.md` + `KPGS_CONSEQUENCE_CLASSIFICATION_V0.md`
- Adds schemas: action envelope, capability lease, approval, action receipt
- Adds six fixture witnesses under `tests/governed-actuation/`
- Updates fork intake registry: `next_vertical_slice.status = SPEC_LOCKED`

## Claim
A rented executor may have hands on web + Windows surfaces, but authority stays external: classify → lease → (approve) → actuate → observe → receipt; unknown = BLOCKED; success ≠ continuing authority.

## Test plan
- [x] All JSON fixtures/schemas parse
- [ ] Review POC graduation bar before any implementation PR
- [ ] Next implementation only after this spec is accepted — PATTERN_ONLY extraction, not upstream landlord

Made with [Cursor](https://cursor.com)