### PR TITLE
fix(kpgs): bound FEP runtime proof and Vercel build

### DIFF
--- a/governance/kpgs-artifacts/fep/depiction-of-nature-and-society/agent.py
+++ b/governance/kpgs-artifacts/fep/depiction-of-nature-and-society/agent.py
@@ -10,10 +10,12 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import yaml
-from google.adk.agents import Agent
+
+if TYPE_CHECKING:
+    from google.adk.agents import Agent
 
 
 ARTIFACT_PATH = Path(__file__).with_name("artifact.yml")
@@ -184,6 +186,8 @@ seat, source, model provenance field, causal mechanism, or missing evidence.
 
 def create_root_agent() -> Agent:
     """Create the ADK Agent after KPGS has resolved the runtime model and identity envelope."""
+    from google.adk.agents import Agent
+
     contract = load_artifact()
     runtime = resolve_runtime(contract)
     return Agent(

--- a/governance/kpgs-artifacts/receipts/FEP_ARTIFACT_001_BUILD_RECEIPT.yml
+++ b/governance/kpgs-artifacts/receipts/FEP_ARTIFACT_001_BUILD_RECEIPT.yml
@@ -64,11 +64,26 @@ receipt:
   validation:
     source_review: COMPLETE
     dedicated_tests_authored: true
-    local_test_execution: NOT_RUN
-    local_test_blocker: shell environment could not resolve github.com to clone the connected branch
+    local_test_execution: TARGETED_PASS
+    initial_local_test_blocker: shell environment could not resolve github.com to clone the connected branch
+    local_test_blocker: NONE_FOR_TARGETED_PROBE
     ci_test_execution: PENDING_PR_GATE
     runtime_adk_execution: NOT_RUN
-    smart_ledger_runtime_append: NOT_RUN
+    smart_ledger_runtime_append: LOCAL_SQLITE_PASS_NOT_AUTHORITY
+    bounded_runtime_probe:
+      date: 2026-09-10
+      callable_entry_point: PASS
+      concrete_model_envelope: PASS
+      literal_auto_fail_closed: PASS
+      missing_model_fail_closed: PASS
+      smart_ledger_append: PASS
+      smart_ledger_idempotent_replay: PASS
+      smart_ledger_conflicting_replay: REJECTED
+      smart_ledger_chain_integrity: PASS
+      scope: local_python_and_sqlite_only
+      adk_provider_execution: NOT_ESTABLISHED
+      external_authority: NOT_ESTABLISHED
+      durable_receipt_id: NOT_RETAINED_EPHEMERAL_PROBE
 
   proof_state:
     implementation: CODED

--- a/tools/kpgs-browser-mcp/vercel.json
+++ b/tools/kpgs-browser-mcp/vercel.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "node",
+  "buildCommand": "npm run build"
+}


### PR DESCRIPTION
PR #160 is already merged. This bounded follow-up gates the optional Google ADK import so the callable artifact can be probed without manufacturing provider proof, records the concrete-model and Smart Ledger local probe while preserving CODED_UNVALIDATED, and replaces the stale kpgs-browser-mcp Vercel build configuration. Validation: callable concrete model PASS; literal auto fail-closed PASS; missing model fail-closed PASS; Smart Ledger append/idempotent replay/conflicting replay/chain integrity PASS; npm run check 16/16; Vercel preview READY from commit 6664cb3. External ADK/provider execution remains NOT_ESTABLISHED by design.