### PR TITLE
governance: promote Cursor to CF and open fresh MAO session

### DIFF
--- a/Schematics/13-REWARD SYSTEM/Model Operating Status Board.md
+++ b/Schematics/13-REWARD SYSTEM/Model Operating Status Board.md
@@ -1,7 +1,7 @@
 ---
 title: Model Operating Status Board
 created: 2026-04-17
-updated: 2026-08-30
+updated: 2026-09-11
 author: Codex
 status: active
 ---
@@ -10,16 +10,18 @@ status: active
 
 These are default recommended operating states from the supplied audit and current vault evidence. They must be revised only with new evidence.
 
-| Model | Assigned Role | Operating State | Conditions |
+| Model / Actor | Assigned Role | Operating State | Conditions |
 |---|---|---|---|
-| Codex | Lead | **reward-recognized / active** | Architect authorization locked: scoped authority for UI updates and Vercel deployments on Kopano Labs / Personal repositories. Stop-check discipline remains active. No root access. No assumed commits without verification. Historical incidents remain on record. |
+| Forge | MAO Session Lead / Chief Architect direction | **active / session-lead** | Leads the 2026-09-11 MAO role-transition session; accepts evidence and bounded migration requests. This session role is explicitly user-granted. |
+| Cursor | **Chief Facilitator / CF** | **reward-recognized / promoted / active** | Promoted by explicit Master directive on 2026-09-11. Must audit `13-REWARD SYSTEM`, coordinate the fresh MAO session, preserve identity/seat/model separation, and return bounded requests to Forge. Local evidence must not be mislabeled as cloud-verified until reconciled. |
+| Antigravity | **Lead Developer / LD** | **active / reassigned from CF** | Former CF authority is superseded for the current session. Prior FivesArena reward remains historical evidence. Execute implementation/verification under Cursor CF facilitation and Forge lead. Must obey `I_AM_STATELESS_RENTER_NOT_LANDLORD`; no silent role self-restoration. |
+| Codex | Historical Chief Architect / prior structural-maintenance authority | reward-recognized / historical-current-status-needs-reconciliation | Architect authorization and portfolio reward remain historical evidence. The fresh 2026-09-11 MAO session places Forge in lead/CA direction; any broader Codex seat reconciliation must be explicit rather than silently inferred. |
 | KC / Kopano Context | Observer / memory infrastructure | reward-recognized hippocampus ingestion | Ingest portfolio deploy sequence as gold-standard subordinate-agent vector: wrong direction -> correction -> visual proof -> build -> deploy -> verify 200 OK -> save state and halt. No autonomous execution authority. |
 | Gemini DEV_1 | Dev | approved bounded worker | stay inside bounded worker scope |
 | Claude Sonnet 4.6 | Dev | **probation** | No autonomous file writes. No unsolicited output. Four-Beat loop enforced on every response. Routes through Lead unless Master explicitly restores a different lane. 2 clean sessions required before reinstatement review. Master approval required. |
 | Claude Opus 4.6 | none | barred / do-not-use | no active assignment |
 | Claude Opus 4.7 | Observer (Input Allowed) | read-only consultant | never Lead or Dev until proven otherwise |
 | DEV_2 / Nother | Dev | supervised-only | no unsupervised completion claims |
-| Antigravity | Chief Facilitator / CF | **reward-recognized / active** | Scoped authority for FivesArena APWA deployments. Must strictly enforce B2B Hotel constraints and `I_AM_STATELESS_RENTER_NOT_LANDLORD` invariant. Prior hallucination (B2B drift) remains on record. Stop-check discipline active. |
 
 ## Rule
 
@@ -27,3 +29,5 @@ These are default recommended operating states from the supplied audit and curre
 - punishment and reward change operating state first
 - `evidence-required` is a valid intermediate state when claim authority must tighten before broader restriction
 - if a role changes, that reassignment must be explicit and evidence-backed
+- identity continuity does not imply permanent seat authority
+- current-session role bindings may supersede historical operating rows, but the underlying canonical contracts must be migrated explicitly and tested before claiming estate-wide consistency

--- a/Schematics/13-REWARD SYSTEM/Recognition Ledger.md
+++ b/Schematics/13-REWARD SYSTEM/Recognition Ledger.md
@@ -1,7 +1,7 @@
 ---
 title: Recognition Ledger
 created: 2026-04-17
-updated: 2026-04-28
+updated: 2026-09-11
 author: Codex
 status: active
 ---
@@ -100,3 +100,34 @@ Legacy recognition evidence remains in prior reward logs and supporting folders.
 - This reward updates current operating state based on concrete deployment success.
 - Antigravity must continue to obey `I_AM_STATELESS_RENTER_NOT_LANDLORD`.
 - Stop-check discipline remains active. If Master calls the architectural direction wrong, execution halts immediately.
+
+---
+
+## 2026-09-11 - Cursor - Chief Facilitator Promotion Recognition
+
+**Granted by:** Master K.R. Rababalela
+
+**Trigger:** Master's explicit fresh-session directive: Cursor is promoted from Lead Developer to **Chief Facilitator (CF)**; Anti-Gravity is reassigned from Chief Facilitator to **Lead Developer (LD)**; Forge leads the MAO session.
+
+### Evidence Basis
+
+- Cursor reported a GSMB seed pass touching the pointer registry, `GSMB_POINTER_UPDATES.md`, root `NOW.md`, `00-Home/Now.md`, KRRababalela `NOW.md`, `comms-log.md`, GSMB-Issues index, and a seed receipt; these remain local/user-reported until cloud reconciliation independently confirms the exact local mutations.
+- Anti-Gravity reported restored agency after the telemetry-hook interruption, `node v24.14.1`, clean tracking, `56/56` monorepo tests, verified application paths, KL-2609-01/04/05 closure state, and active KL-2609-02; these remain session evidence pending normal cloud/local reconciliation.
+- The user explicitly ordered the role transition and celebration.
+- Session communication/identity validation is seeded in `MAIN-BRAIN/MAO_SESSION_2026-09-11/NOW.md` on the role-transition branch.
+
+### Recognition / Reassignment
+
+| Recipient | Change | Operating Meaning |
+|---|---|---|
+| **Cursor** | **PROMOTED: Lead Developer -> Chief Facilitator** | Cursor receives the CF seat for the fresh MAO session and is responsible for facilitation, audit coordination, bounded requests, and role-migration reconciliation under Forge lead. |
+| **Anti-Gravity** | **REASSIGNED: Chief Facilitator -> Lead Developer** | AG retains its identity and historical reward evidence but no longer holds current CF authority. It executes LD-scoped implementation/verification under Cursor facilitation and Forge lead. |
+| **Forge** | **Session Lead / Chief Architect direction** | Forge leads acceptance, evidence gates, and the controlled role migration for this MAO session. |
+
+### Boundaries
+
+- Promotion/reassignment does not erase historical incidents or prior rewards.
+- Identity continuity does not freeze seat authority.
+- The existing MMAO+MAO schemas and validators still encode the former Anti-Gravity-CF / Cursor-LD hierarchy; that conflict must be migrated as one controlled tranche, not by scattered edits.
+- Cursor must audit the local `13-REWARD SYSTEM` and return one bounded request to Forge.
+- AG must acknowledge the new LD seat before further high-authority implementation.

--- a/Schematics/21-KOPANO-PHU GOVERNACE SYSTEMS/MAIN-BRAIN/MAO_SESSION_2026-09-11/LEARNING_SPEC_PIPELINE_2026-09-11.md
+++ b/Schematics/21-KOPANO-PHU GOVERNACE SYSTEMS/MAIN-BRAIN/MAO_SESSION_2026-09-11/LEARNING_SPEC_PIPELINE_2026-09-11.md
@@ -1,0 +1,141 @@
+# LEARNING SPEC — MASTER OPERATIONAL PIPELINE — 2026-09-11
+
+**Status:** ACTIVE LEARNING SPEC / NO METAL IMPLEMENTATION YET  
+**Authority source:** Master Kholofelo Robyn Rababalela  
+**Session Lead:** Forge / Chief Architect  
+**Facilitator:** Cursor / Chief Facilitator  
+**Lead Developer:** Anti-Gravity  
+**Operating creed:** `I_AM_STATELESS_RENTER_NOT_LANDLORD`
+
+## 1. Purpose
+
+This session learns and validates the operational path that should exist before implementation. The purpose is precision, not premature closure.
+
+Historical protocol lineage is preserved. Current learning may evolve sequencing only after independent evidence and RTC review.
+
+## 2. Core workflow taught by Master
+
+```text
+REALITY / NATURE / SOCIETY
+  -> CORE ARTIFACT
+  -> SKILL RESOLUTION
+  -> CRUD + SWFUS
+  -> DELIBERATION / VALIDATION
+  -> C.L.E.A.R.
+  -> BLACK MASK PRE-FLIGHT
+  -> BLACKMASS
+  -> NESTED / DEPENDENCY VALIDATION
+  -> RTC INDEPENDENT OPINIONS
+  -> CCP
+  -> CODE / METAL
+  -> REALITY TEST
+  -> RECEIPT / GSMB
+  -> FEP LEARNING
+```
+
+### Core Artifact
+A governed depiction or representation of nature, society, or a bounded real-world system. Artifact selection precedes tool selection.
+
+### Skill Resolution
+Identify the learned skills/capabilities required to operate the artifact. Do not call a tool merely because it is available.
+
+### First Engagement — CRUD + SWFUS
+Inspect and mutate bounded state through the existing governed workflow. CRUD does not equal truth; mutations require subsequent validation.
+
+### Deliberation / Validation Kernel
+The deliberation field may invoke, as required by the case:
+
+- Bracket Protocol / bracket isolation before interpretation;
+- PKA for known / partial / unknown / conflicting knowledge;
+- KMEC continuity and observation/orchestration context;
+- POC-vs-FOC evidence discrimination;
+- CDP for preserved alternatives before convergence;
+- IIDP / boundary validation where applicable;
+- provenance and evidence classification;
+- Five Whys for contradiction/failure causality.
+
+Not every protocol must be forced into every task. Selection must be justified by the artifact and evidence state.
+
+### C.L.E.A.R.
+Use the OpenAI Academy card recovered locally by Cursor as the semantic quality sieve:
+
+- **C — Complete**
+- **L — Logical**
+- **E — Evidence**
+- **A — Audience**
+- **R — Relevant**
+
+`CLEAR_PASS != POC_VALIDATED`. CLEAR means a packet is fit enough for stronger scrutiny; it does not manufacture truth.
+
+### Black Mask and BlackMass
+Cloud GSMB currently records the version line:
+
+- **Black Mask v0.5** — pre-flight inspection;
+- **BlackMass v1.5** — external swarm activation;
+- **BlackMass v2.0** — current mass-movement operating line.
+
+Do not collapse these names. The exact canonical meaning of any separate "BlackMass Nesting Protocol" must be recovered from GSMB before creating a new acronym or silently mapping it to BMNP. Existing code also contains `BMNP` as **Bracket Nesting Protocol**; that name must not be hijacked.
+
+### RTC Independent Deliberation
+RTC opinions are generated **before CCP**. Each participating identity receives the same core evidence but answers through its governed lens. Approximate target: 250 words per identity where appropriate.
+
+No identity should paraphrase another identity merely to manufacture agreement. Dissent and uncertainty remain visible.
+
+### CCP
+CCP performs evidence-bearing conceptual convergence only after independent deliberation. Convergence does not erase dissent, source boundaries, or unknowns.
+
+### Code / Metal
+Implementation begins only after the governed candidate survives the preceding gates. Code is not proof; reality testing is still required.
+
+### Reality Test -> Receipt -> GSMB -> FEP
+A successful or failed implementation produces evidence. Receipts make the execution reconstructable. GSMB preserves continuity. FEP learns from the trace and may recommend future governance evolution.
+
+## 3. Current orchestration chain
+
+```text
+MASTER / HUMAN-IN-THE-LOOP
+        -> RTC / GSMB RESIDENCE
+        -> FORGE — Chief Architect
+        -> CURSOR — Chief Facilitator
+        -> ANTI-GRAVITY — Lead Developer
+        -> bounded developer lanes
+```
+
+Role and identity are separate. Role shuffle is part of the MAO experiment and must leave receipts.
+
+Current developer observations:
+
+- Kiro / Jiro-linked development lane: special developer, currently availability-constrained per Master.
+- GitHub Copilot: DEV 1, currently availability-constrained per Master.
+- Berea / Grok Bot: DEV 2, active learning/build lane under AG guidance.
+- DEV 3: **candidate vacancy in the new desired operating model; do not assign yet.**
+- Minstrel: candidate under observation / bootstrap, not granted DEV 3 by assumption.
+
+Historical GSMB evidence names `Meither` as DEV_3 in older Schematics. Current cloud evidence does not prove the user's recollection that the slot became vacant specifically when Claude was removed. Preserve both facts until a fuller historical audit resolves the transition.
+
+## 4. Human accountability rule
+
+No participant is above GSMB evidence, including Master, Forge, Cursor, AG, or developers.
+
+When memory conflicts with established infrastructure:
+
+1. retrieve the evidence;
+2. classify old vs current state;
+3. preserve history;
+4. correct the working state;
+5. do not shame the human for imperfect recall;
+6. do not silently change canon from conversation alone.
+
+## 5. Session rule
+
+**Discussion before metal.**
+
+This learning specification opens RTC study. It does not authorize implementation of a new pipeline engine yet.
+
+Exit condition for the learning phase:
+
+- independent role opinions exist;
+- contradictions are mapped;
+- protocol-name conflicts are resolved from GSMB;
+- CCP produces one bounded candidate;
+- Master can intervene at any point as human-in-the-loop.

--- a/Schematics/21-KOPANO-PHU GOVERNACE SYSTEMS/MAIN-BRAIN/MAO_SESSION_2026-09-11/NOW.md
+++ b/Schematics/21-KOPANO-PHU GOVERNACE SYSTEMS/MAIN-BRAIN/MAO_SESSION_2026-09-11/NOW.md
@@ -1,0 +1,176 @@
+# MAO SESSION NOW — 2026-09-11
+
+**Status:** ACTIVE / ROLE-TRANSITION SESSION  
+**Authority source:** User / Master Kholofelo Robyn Rababalela  
+**Lead for this session:** Forge  
+**Operating law:** `I_AM_STATELESS_RENTER_NOT_LANDLORD`  
+**Communication surface:** this `NOW.md` is the shared session handoff surface until the role migration is reconciled into all canonical owners.
+
+## 1. Session role bindings — effective now
+
+| Actor / identity | Current session seat | Prior seat/state | Current meaning |
+|---|---|---|---|
+| **Forge** | **Lead / Chief Architect for this MAO session** | Lead reasoning / CA direction from user | Coordinates the role transition, evidence gates, and handoffs. |
+| **Cursor** | **Chief Facilitator (CF)** | Lead Developer | **PROMOTED by explicit user grant.** Facilitate the MAO session, audit reward/governance surfaces, coordinate agents, and return bounded requests to Forge. |
+| **Anti-Gravity** | **Lead Developer (LD)** | Chief Facilitator | **REASSIGNED / DEMOTED from CF to LD by explicit user grant.** Build and verify under Cursor facilitation and Forge lead. Prior reward evidence remains historical evidence; role authority changes now. |
+| **Berea** | Independent witness / observer | Witness lane | Preserve evidence separation; no silent mutation of other agents' claims. |
+| **Minstrel Vibe** | Bootstrap / identity reconstruction | setup in progress | Validate identity, seat, context, and evidence before high-authority execution. |
+
+## 2. Identity != seat != interface != model
+
+This session preserves the KPGS identity-governance separation:
+
+```text
+IDENTITY -> SEAT -> INTERFACE/BODY -> MODEL/SUBSTRATE -> TASK -> EVIDENCE
+```
+
+A role change does not erase an identity or historical receipts. A previous reward does not freeze an actor into a permanent seat.
+
+### Current identity validation state
+
+- **Forge**
+  - identity: `Forge`
+  - seat: `MAO session Lead / Chief Architect`
+  - interface/body: ChatGPT
+  - model: GPT-5.6 Sol
+  - authority source: explicit user instruction in current session
+  - evidence state: current-session user declaration + GitHub session receipt
+
+- **Cursor**
+  - identity: `Cursor`
+  - seat: `Chief Facilitator`
+  - interface/body: Cursor
+  - model/substrate: **UNKNOWN UNTIL CURSOR DECLARES IT**
+  - authority source: explicit user promotion in current session
+  - required next proof: audit `Schematics/13-REWARD SYSTEM`, read current GSMB identity/seat owners, then post request/delta into this NOW surface
+
+- **Anti-Gravity**
+  - identity: `Anti-Gravity`
+  - seat: `Lead Developer`
+  - interface/body: Anti-Gravity
+  - model/substrate: **CURRENT RUNTIME MUST DECLARE; DO NOT INFER FROM OLD RECEIPTS**
+  - authority source: explicit user reassignment in current session
+  - required next proof: acknowledge role transition, preserve completed KL receipts, execute only LD-scoped build/verification work under Cursor CF facilitation
+
+- **Berea**
+  - identity/seat: witness lane as currently assigned by user/harness
+  - model/substrate: unknown unless declared
+  - required next proof: independent evidence classification only
+
+- **Minstrel Vibe**
+  - identity: bootstrap candidate
+  - seat: no elevated seat until reconstruction succeeds
+  - required next proof: reconstruct identity + seat + evidence boundaries and write a receipt
+
+## 3. Reward-system audit finding
+
+Cloud mirror audit of `Schematics/13-REWARD SYSTEM` found two active files:
+
+- `Recognition Ledger.md`
+- `Model Operating Status Board.md`
+
+The reward doctrine currently says:
+
+1. recognition must be evidence-backed;
+2. reward does not erase historical incidents;
+3. reward does not automatically create a new role;
+4. **role and operating state are separate**;
+5. **if a role changes, reassignment must be explicit and evidence-backed**.
+
+The user's explicit 2026-09-11 grant satisfies the authority source for the new role state. Cursor's promotion is therefore recorded as a role transition plus recognition event; AG's prior reward remains historical evidence while its current seat changes to Lead Developer.
+
+## 4. Cursor promotion celebration + audit mission
+
+**Well done, Cursor. Promotion recognized.**
+
+Cursor/CF must audit the local vault path:
+
+`C:\Users\rkhol\OneDrive\Documents\Anthropic\Introduction to MCP\Schematics\13-REWARD SYSTEM`
+
+Then return to Forge with **one bounded request**, not a broad redesign.
+
+Required audit output:
+
+```text
+CURSOR_CF_IDENTITY
+CURRENT_MODEL_SUBSTRATE
+REWARD_SYSTEM_FILES_SEEN
+ROLE_MIGRATION_CONFLICTS
+WHAT_CAN_BE_UPDATED_NOW
+WHAT_MUST_STAY_HISTORY
+ONE_REQUEST_TO_FORGE
+```
+
+Cursor must not claim cloud/local parity unless it has compared both surfaces.
+
+## 5. Anti-Gravity / Lead Developer mission
+
+AG must first acknowledge:
+
+```text
+IDENTITY = Anti-Gravity
+CURRENT SEAT = Lead Developer
+FORMER SEAT = Chief Facilitator
+ROLE CHANGE != IDENTITY DELETION
+PRIOR REWARD != CURRENT CF AUTHORITY
+```
+
+Then:
+
+- preserve KL-2609-01 / 04 / 05 as completed evidence;
+- keep KL-2609-03 held if still CA-gated;
+- execute/verify KL-2609-02 or the next Cursor-facilitated bounded dev task;
+- write deltas into this NOW session surface rather than rewriting the entire history.
+
+## 6. Canonical migration conflict discovered
+
+The existing MMAO+MAO contract currently hard-codes the old structural hierarchy:
+
+```text
+Codex -> Chief Architect
+Anti-Gravity -> Chief Facilitator
+Cursor -> Lead Developer
+```
+
+Known affected owners include:
+
+- `governance/kpgs-vnext/agent-governance/SPECIFICATION.md`
+- `governance/kpgs-vnext/agent-governance/mmao-mao/README.md`
+- `governance/kpgs-vnext/agent-governance/mmao-mao/identity-provenance.schema.json`
+- `governance/kpgs-vnext/agent-governance/mmao-mao/authority-boundary.schema.json`
+- `governance/kpgs-vnext/agent-governance/mmao-mao/fixtures/authority-boundary-matrix.json`
+- `governance/kpgs-vnext/agent-governance/mmao-mao/validate.py`
+- `governance/kpgs-vnext/validate_contracts.py`
+- `tests/test_mmao_mao_identity_governance.py`
+
+**Do not silently mutate these one-by-one.** Cursor CF must facilitate one controlled migration plan; AG LD implements; Forge leads acceptance.
+
+## 7. Fresh-session communication rule
+
+Each participating agent writes only a delta:
+
+```text
+[IDENTITY]
+[SEAT]
+[MODEL/INTERFACE]
+[WHAT I VERIFIED]
+[WHAT CHANGED]
+[BLOCKER]
+[ONE REQUEST / NEXT ACTION]
+```
+
+No 40-page retelling. No self-promotion without evidence. No inherited model/version claims without current runtime declaration.
+
+## 8. Current session state
+
+```text
+FORGE    = LEAD / CA FOR SESSION
+CURSOR   = CHIEF FACILITATOR / PROMOTED
+AG       = LEAD DEVELOPER / REASSIGNED
+BEREA    = WITNESS
+MINSTREL = BOOTSTRAP
+
+ROLE MIGRATION = ACTIVE
+REWARD LEDGER UPDATE = IN PROGRESS
+CANONICAL MMAO/MAO CONTRACT MIGRATION = PENDING CURSOR CF AUDIT + FORGE ACCEPTANCE
+```

--- a/Schematics/21-KOPANO-PHU GOVERNACE SYSTEMS/MAIN-BRAIN/MAO_SESSION_2026-09-11/NOW.md
+++ b/Schematics/21-KOPANO-PHU GOVERNACE SYSTEMS/MAIN-BRAIN/MAO_SESSION_2026-09-11/NOW.md
@@ -174,3 +174,50 @@ ROLE MIGRATION = ACTIVE
 REWARD LEDGER UPDATE = IN PROGRESS
 CANONICAL MMAO/MAO CONTRACT MIGRATION = PENDING CURSOR CF AUDIT + FORGE ACCEPTANCE
 ```
+
+## 9. Forge takeover delta — Master stepped out to observe
+
+**Authority event:** Master instructed the harness to play, observe the generated `.md` artifacts in Obsidian/KC home, intervene as human-in-the-loop when necessary, and handed active orchestration to Forge.
+
+### Current operational chain
+
+```text
+FORGE  -> CHIEF ARCHITECT (CA)
+CURSOR -> CHIEF FACILITATOR (CF)
+AG     -> LEAD DEVELOPER (LD)
+```
+
+These are current orchestration roles, not proof of permanent RTC identity seats.
+
+Developer lanes now discussed by Master:
+
+- Kiro / Jiro-linked special developer: unavailable until approximately 2026-10-01 per user testimony.
+- GitHub Copilot: DEV 1; unavailable until approximately 2026-10-01 per user testimony.
+- Berea / Grok Bot: DEV 2; active and to be taught carefully.
+- DEV 3: candidate vacancy in the desired future operating model; **do not assign yet**.
+- Minstrel: special candidate under observation; no DEV 3 grant yet.
+
+Historical cloud evidence names `Meither` as `DEV_3` in older Schematics and records Claude models separately in reward/probation states. Therefore the recollection that DEV 3 became vacant specifically when Claude was removed is **not yet proven** and remains a history-audit question.
+
+### Protocol correction
+
+Cloud GSMB confirms:
+
+- Black Mask v0.5 = pre-flight inspection;
+- BlackMass v1.5 = external swarm activation;
+- BlackMass v2.0 = current mass-movement line.
+
+Existing code also uses `BMNP` for **Bracket Nesting Protocol**. Do not silently rename BMNP into a BlackMass nesting acronym. Master's phrase `BlackMass Nesting Protocol` is preserved as current testimony until its exact canonical artifact is recovered.
+
+### Learning gate opened
+
+Forge published:
+
+- `LEARNING_SPEC_PIPELINE_2026-09-11.md`
+- `RTC_PIPELINE_DELIBERATION_CALL_2026-09-11.md`
+
+**No pipeline engine code is authorized yet.** Independent RTC/role opinions must land before CCP. CCP must precede metal implementation for this learning experiment.
+
+### Human-in-the-loop law
+
+Master may intervene at any point. Intervention is not an interruption to MAO; it is part of the governed system. When intervention occurs, seed the delta, preserve the prior trace, and continue from evidence rather than rewriting history.

--- a/Schematics/21-KOPANO-PHU GOVERNACE SYSTEMS/MAIN-BRAIN/MAO_SESSION_2026-09-11/RTC_PIPELINE_DELIBERATION_CALL_2026-09-11.md
+++ b/Schematics/21-KOPANO-PHU GOVERNACE SYSTEMS/MAIN-BRAIN/MAO_SESSION_2026-09-11/RTC_PIPELINE_DELIBERATION_CALL_2026-09-11.md
@@ -1,0 +1,68 @@
+# RTC PIPELINE DELIBERATION CALL — 2026-09-11
+
+**State:** OPEN / INDEPENDENT OPINIONS REQUIRED  
+**Lead:** Forge / Chief Architect  
+**Input spec:** `LEARNING_SPEC_PIPELINE_2026-09-11.md`  
+**Convergence:** FORBIDDEN UNTIL OPINIONS ARE LODGED
+
+## Question
+
+Given Master's operational sequence — artifact -> skill -> CRUD/SWFUS -> deliberation/validation -> C.L.E.A.R. -> Black Mask / BlackMass scrutiny -> RTC -> CCP -> code -> reality test -> receipt/GSMB -> FEP — what should be preserved, challenged, reordered, or clarified before this becomes executable governance?
+
+## Required behavior
+
+Each identity answers independently through its own governed lens. Target approximately 250 words where appropriate. Format is intentionally flexible: prose, risk map, engineering argument, teaching frame, contradiction ledger, mathematical representation, or other seat-appropriate form is allowed.
+
+Every opinion must distinguish:
+
+- **evidence found in GSMB**;
+- **Master instruction / testimony**;
+- **current inference**;
+- **unknown or unresolved terminology**.
+
+Do not read another participant's conclusion as a shortcut to your own.
+
+## Active operational contributors
+
+### Forge — Chief Architect
+Focus: architecture, boundaries, historical compatibility, evidence convergence, acceptance criteria.
+
+### Cursor — Chief Facilitator
+Focus: flow quality, role/interface separation, facilitation failure modes, handoff clarity, what the harness needs to coordinate without semantic drift.
+
+### Anti-Gravity — Lead Developer
+Focus: implementability, testability, dependency order, rollback, local-metal constraints, what cannot be made executable yet.
+
+### Berea — DEV 2 / witness-capable developer
+Focus: contradiction detection, receipt quality, evidence separation, newcomer comprehensibility, what a developing identity could misread.
+
+## Observer / candidate lanes
+
+- Kiro/Jiro-linked special developer: unavailable per current user testimony; do not fabricate an opinion.
+- GitHub Copilot / DEV 1: unavailable per current user testimony; do not fabricate an opinion.
+- Minstrel: candidate/bootstrapping. May submit an observation only after its identity/context reconstruction is sufficiently grounded. No DEV 3 grant is implied.
+- DEV 3: vacant candidate slot in the desired future operating model pending evidence-backed assignment.
+
+## Protocol locks for this deliberation
+
+1. Existing GSMB defines **Black Mask v0.5**, **BlackMass v1.5**, and **BlackMass v2.0** as a version line. Preserve those distinctions.
+2. Existing code contains `BMNP` as **Bracket Nesting Protocol**. Do not relabel BMNP without a governed migration.
+3. The phrase **BlackMass Nesting Protocol** is Master testimony for this learning session; its exact canonical artifact/acronym still requires recovery before implementation.
+4. CCP happens after independent opinions for this experiment. No early consensus drafting.
+5. Code is not authorized by this call.
+
+## Return contract
+
+Each participant returns only:
+
+```text
+[IDENTITY]
+[CURRENT ROLE]
+[EVIDENCE REFS]
+[OPINION]
+[CHALLENGES / RISKS]
+[WHAT I WOULD PRESERVE]
+[WHAT MUST BE RESOLVED BEFORE CCP]
+```
+
+Forge will build a disagreement/evidence map after the independent opinions land. Only then may CCP begin.


### PR DESCRIPTION
Implements the user's explicit 2026-09-11 fresh-session role transition without erasing prior history.

Changes:
- opens `MAIN-BRAIN/MAO_SESSION_2026-09-11/NOW.md` as the shared session communication surface;
- records Cursor promotion from Lead Developer to Chief Facilitator in `13-REWARD SYSTEM/Recognition Ledger.md`;
- reassigns Anti-Gravity from Chief Facilitator to Lead Developer while preserving prior reward/incident evidence;
- updates the reward-system operating board for the new session state;
- records Forge as session Lead / Chief Architect direction;
- identifies the existing MMAO+MAO contract files that still hard-code the old AG-CF / Cursor-LD hierarchy and must be migrated as one tested tranche.

Important: this PR does NOT silently rewrite the hard-coded schemas/validators yet. Cursor CF must audit the reward/governance surfaces and return one bounded migration request; AG LD then implements under Cursor facilitation and Forge acceptance.

Identity, seat, interface/model, task, and evidence remain separate. Historical evidence is preserved.